### PR TITLE
POE-13: Go module init + project scaffold

### DIFF
--- a/.claude/agents/backend.md
+++ b/.claude/agents/backend.md
@@ -4,10 +4,16 @@ Server-side implementation principles. Extends the general agent with Go archite
 
 ## Architecture Patterns
 
-- Follow the project's package structure: `cmd/server/` for entrypoint, `internal/` for all business logic.
+ARCHITECTURE.md is the single source of truth for structural decisions (directory layout, module boundaries, tech stack choices).
+
+- **Hexagonal + CQRS + UseCase**: The project follows ports-and-adapters architecture with separated write (UseCase) and read (Query/Handler) paths.
+- Follow the project's package structure: `cmd/server/` for entrypoint, `internal/` for vertical slice modules.
+- Each module (`internal/{module}/`) contains three layers: `domain/`, `application/`, `infrastructure/`.
 - Domain invariants belong in domain types, not in handlers. A type should never be in an invalid state after construction.
-- Services orchestrate operations across domain types and repositories. Keep them focused on a single use case.
-- Use interfaces at package boundaries. Concrete implementations live in infrastructure packages.
+- **UseCases** (in `application/`) orchestrate write operations — one struct per operation with `Execute(req) (resp, error)`. Query handlers in `application/` handle reads.
+- **Infrastructure** (in `infrastructure/`) contains adapters: HTTP clients, PostgreSQL repositories, external service integrations. Domain never imports infrastructure.
+- Use interfaces (ports) defined in `domain/` at module boundaries. Concrete implementations live in `infrastructure/`.
+- **Cross-module hooks**: Use simple observer pattern for inter-module communication (e.g., price update triggers lab recomputation). No event bus.
 
 ## Go Conventions
 
@@ -42,29 +48,46 @@ Server-side implementation principles. Extends the general agent with Go archite
 
 ```
 cmd/
-└── server/          # main.go entrypoint
+└── server/                    # main.go entrypoint
 internal/
-├── domain/          # Business types, interfaces (no external dependencies)
-│   ├── strategy/    # Strategy tree, simulation
-│   ├── inventory/   # Shared inventory, set converter
-│   ├── price/       # Price types, source interfaces
-│   └── market/      # Market source abstractions
-├── handler/         # HTTP handlers (thin — validate, call service, respond)
-├── service/         # Use case orchestration
-├── repository/      # pgx implementations of domain interfaces
-├── pricefeed/       # poe.ninja + TFT API clients
-└── config/          # Configuration loading
+├── price/                     # Vertical slice: Multi-Source Price Engine
+│   ├── domain/                # PriceBook, SourcePrice, interfaces (ports)
+│   ├── application/           # UseCases: FetchPrices, RefreshPrices; Queries: GetPrices
+│   └── infrastructure/        # Adapters: NinjaClient, TftClient, PostgresRepo
+├── lab/                       # Vertical slice: Lab Farming Dashboard
+│   ├── domain/                # Analysis, Gem, GemColor, GemPool types
+│   ├── application/           # UseCases: AnalyzeFont, AnalyzeTransfigure; Queries
+│   └── infrastructure/        # Adapters: GemColorResolver, PostgresRepo
+├── simulation/                # Vertical slice: Simulation Engine (future)
+│   ├── domain/                # Strategy, Inventory, SetConverter, Runner
+│   ├── application/           # UseCases: RunSimulation
+│   └── infrastructure/        # Adapters: PostgresRepo
+└── server/                    # HTTP layer (thin)
+    ├── server.go              # chi router, middleware, startup
+    ├── handlers/              # HTTP handlers per module
+    └── scheduler/             # Background tick + hook registry
 ```
 
 ### Domain Layer Rules
 
 - Domain types are plain Go structs with constructor functions enforcing invariants.
-- Domain interfaces define what infrastructure the domain needs — domain never imports infrastructure.
+- Domain interfaces (ports) define what infrastructure the domain needs — domain never imports infrastructure.
 - Value objects are small immutable types (ItemName, Source, Price).
+
+### Application Layer Rules
+
+- One UseCase struct per write operation with `Execute(req) (resp, error)`.
+- Query handlers for reads may skip domain and go directly to repository.
+- Application code depends on domain ports, never on infrastructure directly.
+
+### Infrastructure Layer Rules
+
+- Contains adapters that implement domain ports: HTTP clients, database repositories, external APIs.
+- Each adapter lives in the module it serves, not in a shared package.
 
 ### Handler Layer Rules
 
-- Handlers are thin — parse request, call service, encode response.
+- Handlers are thin — parse request, call application layer, encode response.
 - Use middleware for cross-cutting concerns (logging, auth, CORS).
 - Static file serving via Go `embed` package for the compiled SvelteKit frontend.
 

--- a/.claude/agents/backend.md
+++ b/.claude/agents/backend.md
@@ -17,7 +17,7 @@ ARCHITECTURE.md is the single source of truth for structural decisions (director
 
 ## Go Conventions
 
-- **Go 1.22+**: Use standard library HTTP routing (`http.NewServeMux` with method patterns) or chi router.
+- **Go 1.22+**: Use chi router for HTTP routing (`github.com/go-chi/chi/v5`). See `go.mod` and `internal/server/server.go`.
 - **Error handling**: Return errors, don't panic. Wrap with `fmt.Errorf("context: %w", err)` for chain preservation.
 - **Naming**: Follow Go conventions — short receiver names, unexported by default, exported only at package API boundaries.
 - **Constructors**: Use `New*` functions that validate invariants and return `(*T, error)` when construction can fail.

--- a/.claude/agents/general.md
+++ b/.claude/agents/general.md
@@ -8,6 +8,7 @@ Universal coding principles for all implementation and fix agents. This is the b
 - Don't over-engineer. Implement what's needed for the current task, not speculative future requirements.
 - Preserve intent and nuance. When modifying existing code, understand why it was written that way before changing it. Don't simplify away meaning.
 - Read the project's CLAUDE.md before starting work. It contains project-specific conventions, anti-patterns, and constraints that override general principles.
+- ARCHITECTURE.md is the single source of truth for structural decisions (directory layout, module boundaries, tech stack choices). When agent configs or other docs conflict with ARCHITECTURE.md, ARCHITECTURE.md wins.
 
 ## MCP Context Loading
 

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgresql://profitofexile:profitofexile@postgres:5432/profitofexile

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .mcp.json
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .idea/
 .mcp.json
 .env
+bin/
+tmp/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,270 @@
+# ProfitOfExile — Architecture
+
+> Decided 2026-03-12. This document captures architectural decisions for the Go rewrite.
+> For domain concepts and feature scope, see BACKBONE.md.
+
+---
+
+## 1. High-Level Overview
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        Browser                                  │
+│                  profitofexile.localhost                         │
+└──────────────────────┬──────────────────────────────────────────┘
+                       │
+                       ▼
+┌──────────────────────────────────────────────────────────────────┐
+│                      Traefik (shared infra)                      │
+│               TLS termination · *.localhost routing               │
+└──────────┬───────────────────────────────────┬──────────────────┘
+           │                                   │
+     ┌─────▼─────┐                      ┌──────▼──────┐
+     │ SvelteKit │  HMR (dev)           │   Mercure   │
+     │ Vite Dev  │  websocket           │   SSE Hub   │
+     │  :5173    │                      │             │
+     └─────┬─────┘                      └──────▲──────┘
+           │ /api/* proxy                      │ publish
+     ┌─────▼──────────────────────────────────────────┐
+     │                Go Server (:8080)                │
+     │                                                 │
+     │  ┌─────────┐  ┌─────────┐  ┌────────────────┐  │
+     │  │  price   │  │   lab   │  │  simulation    │  │
+     │  │  module  │  │  module │  │  module (future)│ │
+     │  └────┬─────┘  └────┬────┘  └────────────────┘  │
+     │       │              │                           │
+     │  ┌────▼──────────────▼───────────────────────┐  │
+     │  │         Background Scheduler              │  │
+     │  │  15-min tick: fetch → snapshot → analyze   │  │
+     │  │  + manual /api/refresh trigger             │  │
+     │  └───────────────────────────────────────────┘  │
+     └──────────────────────┬──────────────────────────┘
+                            │
+                     ┌──────▼──────┐
+                     │  PostgreSQL │
+                     │  (shared    │
+                     │   infra)    │
+                     └─────────────┘
+```
+
+### Production
+
+```
+┌────────────────────────────────────────────┐
+│              Coolify (VPS)                  │
+│                                            │
+│  ┌──────────────┐  ┌──────────┐            │
+│  │ Go Binary    │  │ Postgres │            │
+│  │ (embeds      │  │          │            │
+│  │  static      │  └──────────┘            │
+│  │  SvelteKit)  │                          │
+│  └──────────────┘  ┌──────────┐            │
+│                    │ Mercure  │            │
+│                    └──────────┘            │
+│  Traefik (Coolify-managed)                 │
+└────────────────────────────────────────────┘
+```
+
+In production, the Go binary serves everything: API + embedded static frontend.
+No Node runtime needed. Coolify injects `DATABASE_URL` and manages Traefik.
+
+---
+
+## 2. Architecture Pattern: Hexagonal + CQRS + UseCase
+
+Ported from [cresco](https://github.com/SebRogala/cresco) (PHP/Symfony), adapted for Go idioms.
+
+### Principles
+
+- **Vertical modules** — each feature area is a self-contained module
+- **Ports & Adapters** — domain defines interfaces (ports), infrastructure implements them
+- **CQRS** — write path (UseCase) and read path (Query/Handler) are separated
+- **UseCase per operation** — one struct per write operation with `Execute(req) (resp, error)`
+- **No ORM** — direct SQL via pgx
+- **No event bus** — simple observer pattern for cross-module hooks (e.g., price update triggers lab recomputation)
+
+### Module Structure
+
+```
+internal/
+├── price/                          # Epic: Multi-Source Price Engine
+│   ├── domain/
+│   │   ├── pricebook.go            # PriceBook, SourcePrice, BestDeal types
+│   │   ├── datasource.go           # Datasource interface (port)
+│   │   └── repository.go           # PriceRepository interface (port)
+│   ├── application/
+│   │   ├── fetch_prices.go         # UseCase: fetch from sources, normalize, cache
+│   │   ├── refresh_prices.go       # UseCase: force refresh
+│   │   └── get_prices.go           # Query handler: read cached price book
+│   └── infrastructure/
+│       ├── ninja_client.go         # poe.ninja HTTP adapter
+│       ├── tft_client.go           # TFT GitHub JSON adapter
+│       └── postgres_repo.go        # PriceRepository implementation
+│
+├── lab/                            # Epic: Lab Farming Dashboard + Strategies
+│   ├── domain/
+│   │   ├── analysis.go             # FontAnalysis, TransfigureAnalysis types
+│   │   ├── gem.go                  # Gem, GemColor, GemPool types
+│   │   └── repository.go           # LabRepository interface (port)
+│   ├── application/
+│   │   ├── analyze_font.go         # UseCase: compute font EV per color
+│   │   ├── analyze_transfigure.go  # UseCase: compute transfigure ROI
+│   │   ├── get_analysis.go         # Query: cached lab analysis results
+│   │   └── get_trends.go           # Query: price trends, saturation, movers
+│   └── infrastructure/
+│       ├── gem_color_resolver.go   # Icon base64 parsing + fallback maps
+│       └── postgres_repo.go
+│
+├── simulation/                     # Epic: Simulation Engine (future)
+│   ├── domain/
+│   │   ├── strategy.go             # Strategy interface
+│   │   ├── inventory.go            # Inventory + SetConverter
+│   │   ├── runner.go               # Recursive tree executor
+│   │   └── result.go               # Simulation results
+│   ├── application/
+│   │   └── run_simulation.go       # UseCase: execute strategy tree
+│   └── infrastructure/
+│       └── postgres_repo.go
+│
+└── server/                         # HTTP layer (thin)
+    ├── server.go                   # chi router, middleware, startup
+    ├── handlers/
+    │   ├── health.go               # GET /api/health
+    │   ├── prices.go               # GET /api/prices, GET /api/refresh
+    │   └── lab.go                  # GET /api/lab/font, GET /api/lab/transfigure
+    └── scheduler/
+        └── scheduler.go            # Background tick (15-min) + hook registry
+```
+
+### Request Flow
+
+```
+Write path (UseCase):
+
+  HTTP Request
+    → Handler (parse request, validate)
+      → UseCase.Execute(Request)
+        → Load from Domain Port (repository interface)
+        → Apply domain logic
+        → Save via Domain Port
+        → Return Response
+      → Handler (serialize response)
+  HTTP Response
+
+Read path (Query):
+
+  HTTP Request
+    → Handler (parse query params)
+      → QueryHandler.Handle(Query)
+        → Read directly from repository (skip domain model)
+        → Return Result DTO
+      → Handler (serialize result)
+  HTTP Response
+```
+
+### Cross-Module Communication
+
+```
+Price module fetches new data
+  → Scheduler calls registered hooks
+    → Lab module recomputes font EV + transfigure ROI
+    → Lab module recomputes trends
+  → Scheduler publishes "prices-updated" via Mercure
+  → Frontend auto-refreshes
+```
+
+No event bus or message queue. Hooks are simple function registrations:
+
+```go
+scheduler.OnPriceUpdate(func(book *price.PriceBook) {
+    labService.RecomputeAnalysis(book)
+    labService.RecomputeTrends(book)
+})
+```
+
+---
+
+## 3. Tech Stack
+
+| Layer | Technology | Notes |
+|-------|-----------|-------|
+| HTTP Router | chi | Lightweight, idiomatic, middleware support |
+| Database | PostgreSQL 16 + pgx | No ORM, direct queries |
+| Migrations | golang-migrate | Timestamp-based SQL files in `db/migrations/` |
+| Frontend | SvelteKit + Tailwind CSS | adapter-static, embedded in Go binary for prod |
+| Dev Reload | air (Go), Vite HMR (SvelteKit) | Both run inside Docker |
+| Real-time | Mercure | SSE hub, shared infra |
+| Deployment | Coolify | Dockerfile is the contract |
+
+---
+
+## 4. Development Environment
+
+```
+make up    → docker compose up -d
+             ├── Go container (air: watches .go files, auto-rebuilds)
+             ├── Node container (vite dev: HMR for SvelteKit)
+             └── joins shared infra network (postgres, redis, traefik, mercure)
+
+Accessible at: https://profitofexile.localhost (via Traefik)
+```
+
+No local Go or Node installation needed. Everything runs in containers.
+
+### Makefile Targets
+
+| Target | Description |
+|--------|-------------|
+| `make up` | Start dev environment (docker compose up -d) |
+| `make down` | Stop dev environment |
+| `make build` | Build Go binary |
+| `make test` | Run Go tests |
+| `make migrate` | Apply database migrations |
+| `make migrate-down` | Rollback last migration |
+
+---
+
+## 5. Data Flow: Price Snapshot Pipeline
+
+```
+Every 15 minutes (or GET /api/refresh):
+
+  ┌──────────┐     ┌───────────┐     ┌──────────────┐
+  │ poe.ninja │────▶│  Fetch &  │────▶│    Store     │
+  │   API     │     │ Normalize │     │  Snapshot    │
+  └──────────┘     └───────────┘     │  (history)   │
+                                      └──────┬───────┘
+  ┌──────────┐                               │
+  │   TFT    │────▶ (same pipeline)          ▼
+  │  GitHub  │                        ┌──────────────┐
+  └──────────┘                        │  Recompute   │
+                                      │  Lab Analysis│
+                                      │  + Trends    │
+                                      └──────┬───────┘
+                                             │
+                                             ▼
+                                      ┌──────────────┐
+                                      │   Publish    │
+                                      │  via Mercure │
+                                      └──────┬───────┘
+                                             │
+                                             ▼
+                                      ┌──────────────┐
+                                      │   Browser    │
+                                      │  auto-refresh│
+                                      └──────────────┘
+```
+
+---
+
+## 6. Key Differences from Cresco
+
+| Aspect | Cresco (PHP) | ProfitOfExile (Go) |
+|--------|-------------|-------------------|
+| Multi-tenancy | Doctrine SQL filter + TenantContext | Not needed (single tenant) |
+| Event dispatch | Symfony EventDispatcher + #[AsEventListener] | Simple hook registration |
+| Transaction | TransactionPort wrapping | pgx transactions directly |
+| Base classes | AggregateRoot, DoctrineRepository inheritance | Composition, embedded structs |
+| DI Container | Symfony autowiring | Manual construction in main.go |
+| ORM | Doctrine | None (pgx direct SQL) |
+| Immutability | readonly classes | Unexported fields + value receivers |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ProfitOfExile is a **Path of Exile 1 profit simulation platform** being rewritten from PHP/Symfony + Vue 3 to **Go + SvelteKit**. It models farming strategies as composable trees, fetches live prices from multiple market sources, simulates inventory flows with automatic set conversions, and calculates profitability per strategy.
 
-The original PHP codebase exists only in git history (commit `537e37e` and earlier) as architectural reference — do not restore or modify it. The current repo contains only design documents (`BACKBONE.md`, `EPICS.md`) as the Go rewrite hasn't started yet.
+The original PHP codebase exists only in git history (commit `537e37e` and earlier) as architectural reference — do not restore or modify it. The current repo contains design documents (`BACKBONE.md`, `EPICS.md`, `ARCHITECTURE.md`) as the Go rewrite is starting.
 
 ## Early Prototypes (`/var/www/poe`)
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: build run test up down migrate migrate-down
+
+build:
+	go build -o bin/server ./cmd/server
+
+run:
+	go run ./cmd/server
+
+test:
+	go test ./...
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+migrate:
+	@echo "migrate: not yet implemented (see POE-15)"
+
+migrate-down:
+	@echo "migrate-down: not yet implemented (see POE-15)"

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ run:
 	go run ./cmd/server
 
 test:
-	go test ./...
+	go test -race ./...
 
 up:
 	docker compose up -d

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
@@ -18,6 +21,12 @@ func main() {
 		port = "8080"
 	}
 
+	if p, err := strconv.Atoi(port); err != nil || p < 1 || p > 65535 {
+		slog.Error("invalid PORT value", "port", port)
+		fmt.Fprintf(os.Stderr, "PORT must be a number between 1 and 65535, got %q\n", port)
+		os.Exit(1)
+	}
+
 	router := server.NewRouter()
 
 	srv := &http.Server{
@@ -28,21 +37,27 @@ func main() {
 		IdleTimeout:  120 * time.Second,
 	}
 
-	// Start server in a goroutine so we can listen for shutdown signals.
+	// Start server in a goroutine, sending errors back to the main goroutine
+	// so deferred cleanup can run before exit.
+	errCh := make(chan error, 1)
 	go func() {
 		slog.Info("server starting", "addr", srv.Addr)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		errCh <- srv.ListenAndServe()
+	}()
+
+	// Wait for SIGINT/SIGTERM or a server startup error.
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, http.ErrServerClosed) {
 			slog.Error("server failed to start", "error", err)
 			os.Exit(1)
 		}
-	}()
-
-	// Wait for SIGINT or SIGTERM.
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	sig := <-quit
-
-	slog.Info("shutting down server", "signal", sig.String())
+	case sig := <-quit:
+		slog.Info("shutting down server", "signal", sig.String())
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"profitofexile/internal/server"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	router := server.NewRouter()
+
+	srv := &http.Server{
+		Addr:    fmt.Sprintf(":%s", port),
+		Handler: router,
+	}
+
+	// Start server in a goroutine so we can listen for shutdown signals.
+	go func() {
+		slog.Info("server starting", "addr", srv.Addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("server failed to start", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	// Wait for SIGINT or SIGTERM.
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	sig := <-quit
+
+	slog.Info("shutting down server", "signal", sig.String())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		slog.Error("server forced to shutdown", "error", err)
+		os.Exit(1)
+	}
+
+	slog.Info("server stopped")
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -22,8 +21,11 @@ func main() {
 	router := server.NewRouter()
 
 	srv := &http.Server{
-		Addr:    fmt.Sprintf(":%s", port),
-		Handler: router,
+		Addr:         ":" + port,
+		Handler:      router,
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 30 * time.Second,
+		IdleTimeout:  120 * time.Second,
 	}
 
 	// Start server in a goroutine so we can listen for shutdown signals.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  app:
+    build: .
+    container_name: profitofexile_app
+    environment:
+      - DATABASE_URL=${DATABASE_URL:-postgresql://profitofexile:profitofexile@postgres:5432/profitofexile}
+    networks:
+      - infra
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.profitofexile.rule=Host(`profitofexile.localhost`)"
+      - "traefik.http.routers.profitofexile.entrypoints=websecure"
+      - "traefik.http.routers.profitofexile.tls=true"
+      - "traefik.http.services.profitofexile.loadbalancer.server.port=8080"
+
+networks:
+  infra:
+    external: true

--- a/docs/adr/001-go-module-path.md
+++ b/docs/adr/001-go-module-path.md
@@ -1,0 +1,60 @@
+# ADR-001: Go Module Path: Short Local Identifier
+
+## Status
+
+Accepted
+
+## Context
+
+When initializing the Go module for ProfitOfExile, the module path must be chosen. In Go, the module path appears in every import statement throughout the codebase and is embedded in `go.mod`. Changing it later requires a mass rename of all import paths across all source files.
+
+Go's conventions offer two broad approaches:
+
+1. Use a fully-qualified VCS path (`github.com/owner/repo`) so the module can be fetched by others via `go get`
+2. Use a short local name with no VCS prefix (e.g., `profitofexile`) for applications that are never published as libraries
+
+ProfitOfExile is a single-tenant, self-hosted web application. It will never be imported by external Go code and will never be resolved via `go get`. The deployment artifact is a Docker image, not a Go package.
+
+Key considerations:
+
+1. Module paths with `github.com/` prefixes imply the module is a distributable library — this sends the wrong signal for an application codebase
+2. Short names are more readable in import statements throughout the codebase (`import "profitofexile/internal/price/domain"` vs `import "github.com/owner/profitofexile/internal/price/domain"`)
+3. The repository may be private or self-hosted, making the `github.com/` prefix misleading
+4. Go tooling does not require a VCS-prefixed path for application binaries built locally or in CI
+
+## Decision
+
+Use `profitofexile` as the Go module path in `go.mod`:
+
+```
+module profitofexile
+
+go 1.22
+```
+
+All internal packages are imported as `profitofexile/internal/{module}/...`.
+
+## Consequences
+
+### Positive
+
+- Import paths are short and readable throughout the codebase
+- No false implication that the module is a publishable library
+- No dependency on the GitHub org/repo name, which could change
+
+### Negative
+
+- Deviates from Go community convention for modules hosted on VCS — developers expecting `github.com/...` may find this surprising
+- If the project were ever extracted into a shared library (unlikely), all import paths would need to be renamed
+
+## Alternatives Considered
+
+### github.com/owner/profitofexile
+
+The conventional Go module path for open-source or distributable projects.
+
+**Rejected because**: ProfitOfExile is a self-contained application binary, not a library. Using a VCS-prefixed path implies `go get` installability that is intentionally not supported. The added verbosity in every import statement provides no benefit for an application-only codebase.
+
+## References
+
+- [POE-13](https://softsolution.youtrack.cloud/issue/POE-13) — Go module init + project scaffold (task that prompted this decision)

--- a/docs/adr/001-go-module-path.md
+++ b/docs/adr/001-go-module-path.md
@@ -29,7 +29,7 @@ Use `profitofexile` as the Go module path in `go.mod`:
 ```
 module profitofexile
 
-go 1.22
+go 1.22.0
 ```
 
 All internal packages are imported as `profitofexile/internal/{module}/...`.

--- a/docs/adr/002-internal-architecture-hexagonal-cqrs-vertical-slice.md
+++ b/docs/adr/002-internal-architecture-hexagonal-cqrs-vertical-slice.md
@@ -1,0 +1,108 @@
+# ADR-002: Internal Architecture: Hexagonal + CQRS + Vertical Slice
+
+## Status
+
+Accepted
+
+## Context
+
+The Go rewrite of ProfitOfExile requires a clear internal package structure that can accommodate multiple feature domains (price engine, lab farming, simulation engine) while keeping each domain's code cohesive and its boundaries explicit. The structure must also be comprehensible to developers familiar with idiomatic Go, which tends to favor flat packages.
+
+The original PHP/Symfony codebase used a domain-driven structure with Symfony's DI container, Doctrine ORM, and event dispatching. The Go rewrite must achieve similar separation of concerns without those framework affordances.
+
+Key considerations:
+
+1. Each feature domain (price, lab, simulation) needs to own its types, business logic, storage contracts, and external-system adapters independently — leaking these across domains creates coupling that makes the codebase harder to reason about
+2. The read path (serving cached results to the frontend) is significantly simpler than the write path (fetching, normalizing, and storing prices) — conflating them into a single "service" layer obscures this asymmetry
+3. Domain logic must be testable without a database or HTTP client — this requires explicit interface boundaries (ports) between business logic and infrastructure
+4. The project is inspired by the [cresco](https://github.com/SebRogala/cresco) PHP framework, whose patterns are being adapted to Go idioms
+
+## Decision
+
+Adopt a **Hexagonal Architecture + CQRS + Vertical Slice** structure:
+
+### Module layout
+
+Each feature domain is a vertical slice under `internal/`:
+
+```
+internal/
+├── {module}/
+│   ├── domain/          # Types, domain logic, port interfaces
+│   ├── application/     # UseCases (writes) + Query handlers (reads)
+│   └── infrastructure/  # Adapters: HTTP clients, postgres repos
+└── server/              # Thin HTTP layer: routing, handlers, scheduler
+```
+
+### CQRS separation within each module
+
+- **Write path**: `application/{use_case}.go` — one struct per write operation with `Execute(Req) (Resp, error)`
+- **Read path**: `application/{query}.go` — query handlers that read directly from the repository, bypassing domain model construction
+
+### Ports & Adapters
+
+- Domain defines interfaces (ports): `domain/repository.go`, `domain/datasource.go`
+- Infrastructure implements them: `infrastructure/postgres_repo.go`, `infrastructure/ninja_client.go`
+- Domain layer has zero imports from `infrastructure/`
+
+### Cross-module communication
+
+No event bus. Modules communicate via simple hook registration in the scheduler:
+
+```go
+scheduler.OnPriceUpdate(func(book *price.PriceBook) {
+    labService.RecomputeAnalysis(book)
+})
+```
+
+### Manual dependency injection
+
+No DI container. Dependencies are wired explicitly in `cmd/server/main.go`.
+
+## Consequences
+
+### Positive
+
+- Domain logic is fully isolated and testable without infrastructure (database, HTTP)
+- Read and write paths are explicitly separated, making the performance and complexity asymmetry visible
+- Each vertical slice is independently deployable as a unit — adding a new feature domain means adding a new `internal/{module}/` directory with no changes to existing modules
+- Familiar pattern for developers who know hexagonal architecture; differences from cresco are documented in ARCHITECTURE.md
+
+### Negative
+
+- More directories and files upfront compared to a flat package approach — the structure pays off as the codebase grows, but adds overhead for the initial scaffold
+- Manual DI wiring in `main.go` grows as modules are added; no auto-wiring
+
+## Alternatives Considered
+
+### Flat package layout
+
+```
+internal/
+├── domain/
+├── handler/
+├── service/
+├── repository/
+└── pricefeed/
+```
+
+**Rejected because**: All domains share the same `service/` and `repository/` layers, creating implicit coupling. Adding the simulation module would require touching existing layers. The flat layout also obscures the read/write asymmetry that CQRS makes explicit.
+
+### Standard layered n-tier (Controller → Service → Repository)
+
+A classic three-layer architecture where all features share layers.
+
+**Rejected because**: The service layer becomes a catch-all that grows unbounded. Repository interfaces end up aggregating all persistence operations across features. This was the weakness of early versions of the PHP codebase that cresco was designed to correct.
+
+### Go-idiomatic flat packages (one package per concept)
+
+Following Go standard library style: small, focused packages like `price`, `lab`, `gem`, etc., with no internal layer distinction.
+
+**Rejected because**: Without explicit layer boundaries, infrastructure concerns (SQL queries, HTTP clients) bleed into domain types. This makes unit testing the domain logic harder and makes the dependency direction implicit rather than enforced.
+
+## References
+
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — Full structural specification, module layout, request flow diagrams
+- [ADR-001](001-go-module-path.md) — Module path decision (foundational to all import paths)
+- [POE-13](https://softsolution.youtrack.cloud/issue/POE-13) — Go module init + project scaffold
+- [POE-2](https://softsolution.youtrack.cloud/issue/POE-2) — Foundation epic that this architecture serves

--- a/docs/adr/003-no-orm-direct-pgx-queries.md
+++ b/docs/adr/003-no-orm-direct-pgx-queries.md
@@ -23,7 +23,7 @@ Use **pgx v5** directly with raw SQL queries. No ORM layer.
 
 - All repository implementations in `internal/{module}/infrastructure/postgres_repo.go` use `pgxpool.Pool` for connection pooling
 - Queries are written as SQL strings, executed via `pool.Query()`, `pool.QueryRow()`, or `pool.Exec()`
-- Row scanning is done manually or via `pgx/v5/pgxscan` for struct scanning where convenient
+- Row scanning is done manually or via `github.com/georgysavva/scany/v2/pgxscan` for struct scanning where convenient
 - Migrations are managed by `golang-migrate` with timestamped SQL files in `db/migrations/`
 - Transactions are managed directly via `pool.BeginTx(ctx, pgx.TxOptions{})`
 
@@ -34,7 +34,7 @@ Use **pgx v5** directly with raw SQL queries. No ORM layer.
 - Full SQL control — queries are explicit, debuggable, and optimizable without ORM translation layers
 - PostgreSQL-specific features (JSONB operators, CTEs, window functions, LISTEN/NOTIFY) are first-class
 - No ORM magic to debug when queries behave unexpectedly
-- pgx v5 is the fastest Go PostgreSQL driver by benchmark
+- pgx v5 is a high-performance Go PostgreSQL driver with native type support
 
 ### Negative
 
@@ -60,7 +60,7 @@ A code-generation-based ORM with a schema DSL and graph traversal API.
 
 A lightweight extension to `database/sql` that adds struct scanning via reflection.
 
-**Rejected because**: sqlx uses `database/sql` under the hood, which means a pgx connection is proxied through the standard driver interface — losing pgx's native type support (JSONB, UUID, arrays). pgx v5 with `pgxscan` provides equivalent struct scanning convenience without sacrificing native type handling.
+**Rejected because**: sqlx uses `database/sql` under the hood, which means a pgx connection is proxied through the standard driver interface — losing pgx's native type support (JSONB, UUID, arrays). pgx v5 with `scany/pgxscan` provides equivalent struct scanning convenience without sacrificing native type handling.
 
 ## References
 

--- a/docs/adr/003-no-orm-direct-pgx-queries.md
+++ b/docs/adr/003-no-orm-direct-pgx-queries.md
@@ -1,0 +1,70 @@
+# ADR-003: No ORM — Direct pgx Queries
+
+## Status
+
+Accepted
+
+## Context
+
+ProfitOfExile stores price snapshots, lab analysis results, and strategy trees in PostgreSQL. The data access layer must be chosen before any repository implementations are written, because it affects the structure of every `infrastructure/postgres_repo.go` file across all modules.
+
+The project uses PostgreSQL 16 with JSONB columns for structured data (price books, strategy trees). Several queries involve aggregations over snapshot history and time-series analysis that benefit from direct SQL control.
+
+Key considerations:
+
+1. The domain model is relatively small — a handful of types per module. The mapping problem that ORMs solve (complex object graphs → relational tables) is minimal here
+2. JSONB columns require PostgreSQL-specific operators (`->`, `->>`, `@>`) that most ORMs abstract poorly or not at all
+3. Direct SQL queries are explicit: the developer sees exactly what hits the database, making performance reasoning straightforward
+4. pgx v5 is the idiomatic high-performance PostgreSQL driver for Go, with first-class support for PostgreSQL types including JSONB, UUID, arrays, and LISTEN/NOTIFY
+
+## Decision
+
+Use **pgx v5** directly with raw SQL queries. No ORM layer.
+
+- All repository implementations in `internal/{module}/infrastructure/postgres_repo.go` use `pgxpool.Pool` for connection pooling
+- Queries are written as SQL strings, executed via `pool.Query()`, `pool.QueryRow()`, or `pool.Exec()`
+- Row scanning is done manually or via `pgx/v5/pgxscan` for struct scanning where convenient
+- Migrations are managed by `golang-migrate` with timestamped SQL files in `db/migrations/`
+- Transactions are managed directly via `pool.BeginTx(ctx, pgx.TxOptions{})`
+
+## Consequences
+
+### Positive
+
+- Full SQL control — queries are explicit, debuggable, and optimizable without ORM translation layers
+- PostgreSQL-specific features (JSONB operators, CTEs, window functions, LISTEN/NOTIFY) are first-class
+- No ORM magic to debug when queries behave unexpectedly
+- pgx v5 is the fastest Go PostgreSQL driver by benchmark
+
+### Negative
+
+- More boilerplate per query compared to an ORM (explicit scan calls, manual column mapping)
+- Schema changes require updating both migration SQL and scan code — no auto-sync
+- No query builder means complex dynamic queries (e.g., filtering by multiple optional criteria) require string construction or a lightweight query builder
+
+## Alternatives Considered
+
+### GORM
+
+The most popular Go ORM. Provides struct-tag-based schema mapping, auto-migrations, and chainable query building.
+
+**Rejected because**: GORM adds a significant abstraction layer over pgx that obscures what SQL is being generated. JSONB column handling requires workarounds. GORM's "magic" (hooks, associations) creates implicit behavior that conflicts with the explicit, no-magic philosophy of this codebase. Performance overhead is non-trivial for high-frequency price snapshot writes.
+
+### Ent (Facebook)
+
+A code-generation-based ORM with a schema DSL and graph traversal API.
+
+**Rejected because**: The schema DSL and generated code add a heavy compile-time layer. Ent works best for complex relational graphs with many associations — ProfitOfExile's data model is simple enough that Ent's benefits do not justify its complexity. JSONB columns require custom extensions.
+
+### sqlx
+
+A lightweight extension to `database/sql` that adds struct scanning via reflection.
+
+**Rejected because**: sqlx uses `database/sql` under the hood, which means a pgx connection is proxied through the standard driver interface — losing pgx's native type support (JSONB, UUID, arrays). pgx v5 with `pgxscan` provides equivalent struct scanning convenience without sacrificing native type handling.
+
+## References
+
+- [ADR-002](002-internal-architecture-hexagonal-cqrs-vertical-slice.md) — Hexagonal architecture that defines repository ports (interfaces) implemented by pgx adapters
+- [ARCHITECTURE.md](../../ARCHITECTURE.md) — Tech stack table specifying PostgreSQL 16 + pgx
+- [POE-13](https://softsolution.youtrack.cloud/issue/POE-13) — Go module init + project scaffold (foundational task)
+- [POE-15](https://softsolution.youtrack.cloud/issue/POE-15) — DB migrations + connection wiring (first actual pgx usage)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module profitofexile
+
+go 1.22.0
+
+require github.com/go-chi/chi/v5 v5.2.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
-github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pVzi2xEOBKEE=

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pVzi2xEOBKEE=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
 github.com/go-chi/chi/v5 v5.2.1 h1:KOIHODQj58PmL80G2Eak4WdvUzjSJSm0vG72crDCqb8=
-github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pVzi2xEOBKEE=
+github.com/go-chi/chi/v5 v5.2.1/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=

--- a/internal/server/handlers/health.go
+++ b/internal/server/handlers/health.go
@@ -6,6 +6,11 @@ import (
 	"net/http"
 )
 
+// Version is set at build time via ldflags:
+//
+//	go build -ldflags "-X profitofexile/internal/server/handlers.Version=<sha>"
+var Version = "dev"
+
 type healthResponse struct {
 	Status  string `json:"status"`
 	Version string `json:"version"`
@@ -14,15 +19,19 @@ type healthResponse struct {
 // Health returns an HTTP handler that responds with the server health status.
 func Health() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-
 		resp := healthResponse{
 			Status:  "ok",
-			Version: "dev",
+			Version: Version,
 		}
 
-		if err := json.NewEncoder(w).Encode(resp); err != nil {
-			slog.Error("health: encode response", "error", err)
+		data, err := json.Marshal(resp)
+		if err != nil {
+			slog.Error("health: marshal response", "error", err)
+			http.Error(w, `{"status":"error"}`, http.StatusInternalServerError)
+			return
 		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
 	}
 }

--- a/internal/server/handlers/health.go
+++ b/internal/server/handlers/health.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type healthResponse struct {
+	Status  string `json:"status"`
+	Version string `json:"version"`
+}
+
+// Health returns an HTTP handler that responds with the server health status.
+func Health() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		resp := healthResponse{
+			Status:  "ok",
+			Version: "dev",
+		}
+
+		json.NewEncoder(w).Encode(resp)
+	}
+}

--- a/internal/server/handlers/health.go
+++ b/internal/server/handlers/health.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 )
 
@@ -14,13 +15,14 @@ type healthResponse struct {
 func Health() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
 
 		resp := healthResponse{
 			Status:  "ok",
 			Version: "dev",
 		}
 
-		json.NewEncoder(w).Encode(resp)
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			slog.Error("health: encode response", "error", err)
+		}
 	}
 }

--- a/internal/server/handlers/health_test.go
+++ b/internal/server/handlers/health_test.go
@@ -1,0 +1,79 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestHealth(t *testing.T) {
+	router := chi.NewRouter()
+	router.Get("/api/health", Health())
+
+	tests := []struct {
+		name           string
+		method         string
+		wantStatus     int
+		wantBody       *healthResponse
+		wantContentType string
+	}{
+		{
+			name:           "GET returns 200",
+			method:         http.MethodGet,
+			wantStatus:     http.StatusOK,
+			wantBody:       &healthResponse{Status: "ok", Version: "dev"},
+			wantContentType: "application/json",
+		},
+		{
+			name:       "POST returns 405 Method Not Allowed",
+			method:     http.MethodPost,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "PUT returns 405 Method Not Allowed",
+			method:     http.MethodPut,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+		{
+			name:       "DELETE returns 405 Method Not Allowed",
+			method:     http.MethodDelete,
+			wantStatus: http.StatusMethodNotAllowed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/api/health", nil)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+
+			if tt.wantContentType != "" {
+				got := w.Header().Get("Content-Type")
+				if got != tt.wantContentType {
+					t.Errorf("Content-Type = %q, want %q", got, tt.wantContentType)
+				}
+			}
+
+			if tt.wantBody != nil {
+				var got healthResponse
+				if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+					t.Fatalf("failed to decode response body: %v", err)
+				}
+				if got.Status != tt.wantBody.Status {
+					t.Errorf("Status = %q, want %q", got.Status, tt.wantBody.Status)
+				}
+				if got.Version != tt.wantBody.Version {
+					t.Errorf("Version = %q, want %q", got.Version, tt.wantBody.Version)
+				}
+			}
+		})
+	}
+}

--- a/internal/server/handlers/recover.go
+++ b/internal/server/handlers/recover.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"log/slog"
+	"net/http"
+	"runtime/debug"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// SlogRecoverer is a middleware that recovers from panics and logs them via slog
+// instead of the default log package used by chi's Recoverer.
+func SlogRecoverer(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if rec := recover(); rec != nil && rec != http.ErrAbortHandler {
+				reqID := middleware.GetReqID(r.Context())
+				slog.Error("panic recovered",
+					"request_id", reqID,
+					"method", r.Method,
+					"path", r.URL.Path,
+					"panic", rec,
+					"stack", string(debug.Stack()),
+				)
+				if r.Header.Get("Connection") != "Upgrade" {
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			}
+		}()
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"net/http"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 
@@ -8,12 +10,12 @@ import (
 )
 
 // NewRouter creates a chi router with middleware and mounted routes.
-func NewRouter() *chi.Mux {
+func NewRouter() http.Handler {
 	r := chi.NewRouter()
 
 	r.Use(middleware.RequestID)
 	r.Use(middleware.Logger)
-	r.Use(middleware.Recoverer)
+	r.Use(handlers.SlogRecoverer)
 
 	r.Get("/api/health", handlers.Health())
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,21 @@
+package server
+
+import (
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	"profitofexile/internal/server/handlers"
+)
+
+// NewRouter creates a chi router with middleware and mounted routes.
+func NewRouter() *chi.Mux {
+	r := chi.NewRouter()
+
+	r.Use(middleware.RequestID)
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	r.Get("/api/health", handlers.Health())
+
+	return r
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewRouter_HealthRoute(t *testing.T) {
+	router := NewRouter()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET /api/health status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	contentType := w.Header().Get("Content-Type")
+	if contentType != "application/json" {
+		t.Errorf("Content-Type = %q, want %q", contentType, "application/json")
+	}
+
+	var body struct {
+		Status  string `json:"status"`
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if body.Status != "ok" {
+		t.Errorf("status = %q, want %q", body.Status, "ok")
+	}
+	if body.Version != "dev" {
+		t.Errorf("version = %q, want %q", body.Version, "dev")
+	}
+}


### PR DESCRIPTION
## Summary
- Initialize Go module with chi v5 router and health endpoint at `GET /api/health`
- Create `cmd/server/main.go` with graceful shutdown (SIGINT/SIGTERM, 10s timeout)
- Add Makefile with `build`, `run`, `test`, `up` targets
- Add health handler tests using `httptest`
- Update agent configs (backend.md, general.md) to match ARCHITECTURE.md vertical slice layout

## Tracker
https://softsolution.youtrack.cloud/issue/POE-13

## Test Plan
- [ ] All tests pass (`make qa`)
- [ ] Manual testing completed
- [ ] Fixtures updated (if applicable)

Generated with [Claude Code](https://claude.com/claude-code)