### PR TITLE
POE-12: Add Mercure to shared infra stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql://profitofexile:profitofexile@postgres:5432/profitofexile}
       - PORT=8080
+      - MERCURE_URL=${MERCURE_URL:-http://mercure/.well-known/mercure}
+      - MERCURE_JWT_SECRET=${MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
     networks:
       - infra
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add Mercure SSE hub service to shared infra docker-compose with Traefik routing (mercure.localhost, TLS)
- Add MERCURE_URL and MERCURE_JWT_SECRET env vars to ProfitOfExile app container

## Tracker
https://softsolution.youtrack.cloud/issue/POE-12

## Test Plan
- [ ] All tests pass (`make qa`)
- [ ] Mercure hub accessible at mercure.localhost
- [ ] SSE subscriptions work from browser (anonymous mode)
- [ ] ProfitOfExile app container has Mercure env vars

Generated with [Claude Code](https://claude.com/claude-code)