### PR TITLE
POE-22: Smart polling with cache-aware scheduling

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -42,16 +42,30 @@ func main() {
 		league = "Mirage"
 	}
 
+	// Build endpoint configuration from defaults + env var overrides.
+	ninjaDefaults := collector.DefaultNinjaConfig()
+	ninjaOverrides := collector.ParseEndpointOverrides("NINJA")
+	ninjaCfg := collector.MergeEndpointConfig(ninjaDefaults, ninjaOverrides)
+
+	// NINJA_INTERVAL is a legacy alias for NINJA_FALLBACK_INTERVAL.
+	// If NINJA_FALLBACK_INTERVAL was not set via overrides but NINJA_INTERVAL
+	// exists, use it and log a deprecation warning.
 	ninjaIntervalStr := os.Getenv("NINJA_INTERVAL")
-	if ninjaIntervalStr == "" {
-		ninjaIntervalStr = "15m"
+	if ninjaOverrides.FallbackInterval == 0 && ninjaIntervalStr != "" {
+		slog.Warn("NINJA_INTERVAL is deprecated, use NINJA_FALLBACK_INTERVAL instead",
+			"value", ninjaIntervalStr,
+		)
+		parsed, err := time.ParseDuration(ninjaIntervalStr)
+		if err != nil {
+			slog.Error("invalid NINJA_INTERVAL", "value", ninjaIntervalStr, "error", err)
+			fmt.Fprintf(os.Stderr, "NINJA_INTERVAL must be a valid duration (e.g. 15m), got %q\n", ninjaIntervalStr)
+			os.Exit(1)
+		}
+		ninjaCfg.FallbackInterval = parsed
 	}
-	ninjaInterval, err := time.ParseDuration(ninjaIntervalStr)
-	if err != nil {
-		slog.Error("invalid NINJA_INTERVAL", "value", ninjaIntervalStr, "error", err)
-		fmt.Fprintf(os.Stderr, "NINJA_INTERVAL must be a valid duration (e.g. 15m), got %q\n", ninjaIntervalStr)
-		os.Exit(1)
-	}
+
+	// Use FallbackInterval as the scheduler interval for the legacy scheduler.
+	ninjaInterval := ninjaCfg.FallbackInterval
 
 	mercureURL := os.Getenv("MERCURE_URL")
 	if mercureURL == "" {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -111,7 +111,7 @@ func main() {
 	gemEndpoint.FetchFunc = fetcher.FetchGemsEndpoint
 	gemEndpoint.StoreFunc = func(ctx context.Context, snapTime time.Time, result *collector.FetchResult) (int, error) {
 		if len(result.GemData) == 0 {
-			return 0, fmt.Errorf("gem endpoint returned 200 with empty data — possible transient API issue")
+			return 0, fmt.Errorf("gem endpoint returned 200 with empty data for league %q — check LEAGUE env var or possible transient API issue", league)
 		}
 		return repo.InsertGemSnapshots(ctx, snapTime, result.GemData)
 	}
@@ -124,7 +124,7 @@ func main() {
 	currencyEndpoint.FetchFunc = fetcher.FetchCurrencyEndpoint
 	currencyEndpoint.StoreFunc = func(ctx context.Context, snapTime time.Time, result *collector.FetchResult) (int, error) {
 		if len(result.CurrencyData) == 0 {
-			return 0, fmt.Errorf("currency endpoint returned 200 with empty data — possible transient API issue")
+			return 0, fmt.Errorf("currency endpoint returned 200 with empty data for league %q — check LEAGUE env var or possible transient API issue", league)
 		}
 		return repo.InsertCurrencySnapshots(ctx, snapTime, result.CurrencyData)
 	}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -111,8 +111,7 @@ func main() {
 	gemEndpoint.FetchFunc = fetcher.FetchGemsEndpoint
 	gemEndpoint.StoreFunc = func(ctx context.Context, snapTime time.Time, result *collector.FetchResult) (int, error) {
 		if len(result.GemData) == 0 {
-			slog.Warn("gem endpoint returned 200 with empty data", "endpoint", collector.EndpointNinjaGems)
-			return 0, nil
+			return 0, fmt.Errorf("gem endpoint returned 200 with empty data — possible transient API issue")
 		}
 		return repo.InsertGemSnapshots(ctx, snapTime, result.GemData)
 	}
@@ -125,8 +124,7 @@ func main() {
 	currencyEndpoint.FetchFunc = fetcher.FetchCurrencyEndpoint
 	currencyEndpoint.StoreFunc = func(ctx context.Context, snapTime time.Time, result *collector.FetchResult) (int, error) {
 		if len(result.CurrencyData) == 0 {
-			slog.Warn("currency endpoint returned 200 with empty data", "endpoint", collector.EndpointNinjaCurrency)
-			return 0, nil
+			return 0, fmt.Errorf("currency endpoint returned 200 with empty data — possible transient API issue")
 		}
 		return repo.InsertCurrencySnapshots(ctx, snapTime, result.CurrencyData)
 	}

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -111,6 +111,7 @@ func main() {
 	gemEndpoint.FetchFunc = fetcher.FetchGemsEndpoint
 	gemEndpoint.StoreFunc = func(ctx context.Context, snapTime time.Time, result *collector.FetchResult) (int, error) {
 		if len(result.GemData) == 0 {
+			slog.Warn("gem endpoint returned 200 with empty data", "endpoint", collector.EndpointNinjaGems)
 			return 0, nil
 		}
 		return repo.InsertGemSnapshots(ctx, snapTime, result.GemData)
@@ -124,6 +125,7 @@ func main() {
 	currencyEndpoint.FetchFunc = fetcher.FetchCurrencyEndpoint
 	currencyEndpoint.StoreFunc = func(ctx context.Context, snapTime time.Time, result *collector.FetchResult) (int, error) {
 		if len(result.CurrencyData) == 0 {
+			slog.Warn("currency endpoint returned 200 with empty data", "endpoint", collector.EndpointNinjaCurrency)
 			return 0, nil
 		}
 		return repo.InsertCurrencySnapshots(ctx, snapTime, result.CurrencyData)

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -64,9 +64,6 @@ func main() {
 		ninjaCfg.FallbackInterval = parsed
 	}
 
-	// Use FallbackInterval as the scheduler interval for the legacy scheduler.
-	ninjaInterval := ninjaCfg.FallbackInterval
-
 	mercureURL := os.Getenv("MERCURE_URL")
 	if mercureURL == "" {
 		mercureURL = "http://mercure/.well-known/mercure"
@@ -108,11 +105,36 @@ func main() {
 		slog.Warn("MERCURE_JWT_SECRET not set, Mercure publishing disabled")
 	}
 
+	// Build per-endpoint configs for the goroutine-per-endpoint scheduler.
+	gemEndpoint := ninjaCfg
+	gemEndpoint.Name = collector.EndpointNinjaGems
+	gemEndpoint.FetchFunc = fetcher.FetchGemsEndpoint
+	gemEndpoint.StoreFunc = func(ctx context.Context, snapTime time.Time, result *collector.FetchResult) (int, error) {
+		if len(result.GemData) == 0 {
+			return 0, nil
+		}
+		return repo.InsertGemSnapshots(ctx, snapTime, result.GemData)
+	}
+	gemEndpoint.StalenessFunc = func(ctx context.Context) (time.Time, error) {
+		return repo.LastGemSnapshotTime(ctx)
+	}
+
+	currencyEndpoint := ninjaCfg
+	currencyEndpoint.Name = collector.EndpointNinjaCurrency
+	currencyEndpoint.FetchFunc = fetcher.FetchCurrencyEndpoint
+	currencyEndpoint.StoreFunc = func(ctx context.Context, snapTime time.Time, result *collector.FetchResult) (int, error) {
+		if len(result.CurrencyData) == 0 {
+			return 0, nil
+		}
+		return repo.InsertCurrencySnapshots(ctx, snapTime, result.CurrencyData)
+	}
+	currencyEndpoint.StalenessFunc = func(ctx context.Context) (time.Time, error) {
+		return repo.LastCurrencySnapshotTime(ctx)
+	}
+
 	scheduler, err := collector.NewScheduler(
-		repo,
-		[]collector.Fetcher{fetcher},
+		[]collector.EndpointConfig{gemEndpoint, currencyEndpoint},
 		resolver,
-		ninjaInterval,
 		league,
 		mercureURL,
 		mercureJWTSecret,
@@ -126,7 +148,7 @@ func main() {
 
 	slog.Info("collector starting",
 		"league", league,
-		"interval", ninjaInterval.String(),
+		"fallbackInterval", ninjaCfg.FallbackInterval.String(),
 		"port", port,
 	)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - DATABASE_URL=${DATABASE_URL:-postgresql://profitofexile:profitofexile@postgres:5432/profitofexile}
       - PORT=8090
       - LEAGUE=${LEAGUE:-Mirage}
-      # - NINJA_INTERVAL=15m       # deprecated (POE-22), use NINJA_FALLBACK_INTERVAL. Remove after next release.
+      # - NINJA_INTERVAL=15m       # deprecated (POE-22), use NINJA_FALLBACK_INTERVAL. Remove after v1.1.
       # - NINJA_FALLBACK_INTERVAL=30m
       # - NINJA_MAX_AGE=30m
       # - NINJA_MAX_RETRIES=5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,11 +53,11 @@ services:
       - DATABASE_URL=${DATABASE_URL:-postgresql://profitofexile:profitofexile@postgres:5432/profitofexile}
       - PORT=8090
       - LEAGUE=${LEAGUE:-Mirage}
-      # NINJA_INTERVAL=15m  # deprecated, use NINJA_FALLBACK_INTERVAL
-      # NINJA_FALLBACK_INTERVAL=30m
-      # NINJA_MAX_AGE=30m
-      # NINJA_MAX_RETRIES=5
-      # NINJA_MIN_SLEEP=30s
+      # - NINJA_INTERVAL=15m  # deprecated, use NINJA_FALLBACK_INTERVAL
+      # - NINJA_FALLBACK_INTERVAL=30m
+      # - NINJA_MAX_AGE=30m
+      # - NINJA_MAX_RETRIES=5
+      # - NINJA_MIN_SLEEP=30s
       - MERCURE_URL=${MERCURE_URL:-http://mercure/.well-known/mercure}
       - MERCURE_JWT_SECRET=${MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - DATABASE_URL=${DATABASE_URL:-postgresql://profitofexile:profitofexile@postgres:5432/profitofexile}
       - PORT=8090
       - LEAGUE=${LEAGUE:-Mirage}
-      # - NINJA_INTERVAL=15m  # deprecated, use NINJA_FALLBACK_INTERVAL
+      # - NINJA_INTERVAL=15m       # deprecated, use NINJA_FALLBACK_INTERVAL
       # - NINJA_FALLBACK_INTERVAL=30m
       # - NINJA_MAX_AGE=30m
       # - NINJA_MAX_RETRIES=5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,11 @@ services:
       - DATABASE_URL=${DATABASE_URL:-postgresql://profitofexile:profitofexile@postgres:5432/profitofexile}
       - PORT=8090
       - LEAGUE=${LEAGUE:-Mirage}
-      - NINJA_INTERVAL=${NINJA_INTERVAL:-15m}
+      # NINJA_INTERVAL=15m  # deprecated, use NINJA_FALLBACK_INTERVAL
+      # NINJA_FALLBACK_INTERVAL=30m
+      # NINJA_MAX_AGE=30m
+      # NINJA_MAX_RETRIES=5
+      # NINJA_MIN_SLEEP=30s
       - MERCURE_URL=${MERCURE_URL:-http://mercure/.well-known/mercure}
       - MERCURE_JWT_SECRET=${MERCURE_JWT_SECRET:-!ChangeThisMercureHubJWTSecretKey!}
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - DATABASE_URL=${DATABASE_URL:-postgresql://profitofexile:profitofexile@postgres:5432/profitofexile}
       - PORT=8090
       - LEAGUE=${LEAGUE:-Mirage}
-      # - NINJA_INTERVAL=15m       # deprecated, use NINJA_FALLBACK_INTERVAL
+      # - NINJA_INTERVAL=15m       # deprecated (POE-22), use NINJA_FALLBACK_INTERVAL. Remove after next release.
       # - NINJA_FALLBACK_INTERVAL=30m
       # - NINJA_MAX_AGE=30m
       # - NINJA_MAX_RETRIES=5

--- a/internal/collector/endpoint.go
+++ b/internal/collector/endpoint.go
@@ -17,9 +17,11 @@ const (
 	EndpointNinjaCurrency = "ninja-currency"
 )
 
-// FetchResult holds the outcome of a single endpoint fetch. Concrete typed
-// fields (GemData, CurrencyData) avoid the need for type assertions; the
-// StoreFunc closure on EndpointConfig reads the appropriate field.
+// FetchResult holds the outcome of a single endpoint fetch as a tagged union.
+// Exactly one of three states is valid: NotModified=true (no data), GemData
+// populated, or CurrencyData populated. Validate() enforces mutual exclusivity
+// at runtime and is called at every construction site. If the number of data
+// types grows beyond two, refactor to a discriminated interface pattern.
 type FetchResult struct {
 	GemData      []GemSnapshot
 	CurrencyData []CurrencySnapshot
@@ -70,7 +72,8 @@ type EndpointConfig struct {
 	// FetchFunc fetches data from the external source.
 	FetchFunc FetchFunc
 
-	// StoreFunc persists the fetched data.
+	// StoreFunc persists the fetched data. Nil is valid — fetch results will
+	// be discarded with a warning log (useful for dry-run or testing).
 	StoreFunc StoreFunc
 
 	// StalenessFunc returns the last snapshot time for startup check.
@@ -87,8 +90,9 @@ type EndpointConfig struct {
 	FallbackInterval time.Duration
 
 	// MaxRetries is the number of consecutive 304 Not Modified responses
-	// allowed before falling back to FallbackInterval sleep. The
-	// (MaxRetries+1)th consecutive 304 triggers the fallback.
+	// allowed before falling back to FallbackInterval sleep. After MaxRetries
+	// consecutive 304s, the next 304 triggers a FallbackInterval sleep and
+	// resets the counter.
 	MaxRetries int
 
 	// MinSleep is the minimum time between fetches, even when cache math
@@ -104,8 +108,10 @@ type EndpointConfig struct {
 }
 
 // Validate checks EndpointConfig invariants: Name must be non-empty, FetchFunc
-// must be non-nil, FallbackInterval must be positive, and Source should be
-// non-empty (logged as warning if empty since rate limiting will be skipped).
+// must be non-nil, FallbackInterval must be positive, and MinSleep must not
+// exceed FallbackInterval. Returns a list of warnings (e.g., empty Source) that
+// the caller should log. StoreFunc is intentionally not required — nil means
+// fetch results are discarded (see scheduler.go).
 func (c EndpointConfig) Validate() error {
 	if c.Name == "" {
 		return fmt.Errorf("empty Name")
@@ -115,11 +121,6 @@ func (c EndpointConfig) Validate() error {
 	}
 	if c.FallbackInterval <= 0 {
 		return fmt.Errorf("endpoint %q: non-positive FallbackInterval", c.Name)
-	}
-	if c.Source == "" {
-		slog.Warn("endpoint has empty Source, rate limiting will be skipped",
-			"endpoint", c.Name,
-		)
 	}
 	if c.MinSleep > 0 && c.FallbackInterval > 0 && c.MinSleep > c.FallbackInterval {
 		return fmt.Errorf("endpoint %q: MinSleep (%s) exceeds FallbackInterval (%s)", c.Name, c.MinSleep, c.FallbackInterval)
@@ -147,7 +148,15 @@ func DefaultNinjaConfig() EndpointConfig {
 // invalid values, or have zero/non-positive values are left at their zero
 // value — the caller should merge with defaults via MergeEndpointConfig.
 // Zero-valued fields in the returned config mean "not overridden", so it is
-// not possible to intentionally override a field to zero.
+// not possible to intentionally override a field to zero. If a future field
+// legitimately needs zero as a valid override, switch to pointer fields.
+//
+// Jitter fields (JitterMin, JitterMax) are intentionally not exposed as env
+// vars; they are only configurable programmatically via MergeEndpointConfig.
+//
+// Invalid env var values are logged at Warn level and silently ignored,
+// falling back to defaults. The log message includes the rejected value and
+// the parse error to aid debugging.
 //
 // Supported env vars (for prefix "NINJA"):
 //

--- a/internal/collector/endpoint.go
+++ b/internal/collector/endpoint.go
@@ -9,20 +9,17 @@ import (
 	"time"
 )
 
-// Canonical endpoint name constants. Used by main.go to configure endpoints
-// and by postCollect to conditionally run endpoint-specific logic (e.g., gem
-// color upsert).
+// Canonical endpoint name constants. Used to configure endpoints and to
+// conditionally run endpoint-specific post-collect logic (e.g., gem color
+// upsert).
 const (
 	EndpointNinjaGems     = "ninja-gems"
 	EndpointNinjaCurrency = "ninja-currency"
 )
 
-// FetchResult holds the outcome of a single endpoint fetch. We use concrete
-// typed fields instead of generics because Go generics cannot be used with
-// function-typed struct fields in EndpointConfig.FetchFunc without making
-// EndpointConfig itself generic, which would prevent mixing different endpoint
-// types in a single []EndpointConfig slice. The StoreFunc closure on
-// EndpointConfig reads the appropriate field — no type assertions needed.
+// FetchResult holds the outcome of a single endpoint fetch. Concrete typed
+// fields (GemData, CurrencyData) avoid the need for type assertions; the
+// StoreFunc closure on EndpointConfig reads the appropriate field.
 type FetchResult struct {
 	GemData      []GemSnapshot
 	CurrencyData []CurrencySnapshot
@@ -80,8 +77,8 @@ type EndpointConfig struct {
 	// Nil means always fetch on startup.
 	StalenessFunc StalenessFunc
 
-	// MaxAge is the assumed cache duration of the source data. The default for
-	// poe.ninja endpoints is 1800s (30 minutes). Used with Age to calculate
+	// MaxAge is the assumed cache duration of the source data. See
+	// DefaultNinjaConfig for poe.ninja defaults. Used with Age to calculate
 	// optimal sleep time.
 	MaxAge time.Duration
 
@@ -89,8 +86,9 @@ type EndpointConfig struct {
 	// available. Also used as the maximum sleep cap.
 	FallbackInterval time.Duration
 
-	// MaxRetries is the maximum number of consecutive 304 Not Modified
-	// responses before falling back to FallbackInterval sleep.
+	// MaxRetries is the number of consecutive 304 Not Modified responses
+	// allowed before falling back to FallbackInterval sleep. The
+	// (MaxRetries+1)th consecutive 304 triggers the fallback.
 	MaxRetries int
 
 	// MinSleep is the minimum time between fetches, even when cache math
@@ -103,6 +101,30 @@ type EndpointConfig struct {
 
 	// JitterMax is the maximum random startup delay before the first fetch.
 	JitterMax time.Duration
+}
+
+// Validate checks EndpointConfig invariants: Name must be non-empty, FetchFunc
+// must be non-nil, FallbackInterval must be positive, and Source should be
+// non-empty (logged as warning if empty since rate limiting will be skipped).
+func (c EndpointConfig) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("empty Name")
+	}
+	if c.FetchFunc == nil {
+		return fmt.Errorf("endpoint %q: nil FetchFunc", c.Name)
+	}
+	if c.FallbackInterval <= 0 {
+		return fmt.Errorf("endpoint %q: non-positive FallbackInterval", c.Name)
+	}
+	if c.Source == "" {
+		slog.Warn("endpoint has empty Source, rate limiting will be skipped",
+			"endpoint", c.Name,
+		)
+	}
+	if c.MinSleep > 0 && c.FallbackInterval > 0 && c.MinSleep > c.FallbackInterval {
+		return fmt.Errorf("endpoint %q: MinSleep (%s) exceeds FallbackInterval (%s)", c.Name, c.MinSleep, c.FallbackInterval)
+	}
+	return nil
 }
 
 // DefaultNinjaConfig returns an EndpointConfig with sensible defaults for
@@ -121,9 +143,11 @@ func DefaultNinjaConfig() EndpointConfig {
 }
 
 // ParseEndpointOverrides reads environment variables by prefix and returns an
-// EndpointConfig with any overrides applied. Fields that are not set or have
-// invalid values are left at their zero value (caller should merge with
-// defaults). Invalid values log a warning and are skipped.
+// EndpointConfig with any overrides applied. Fields that are not set, have
+// invalid values, or have zero/non-positive values are left at their zero
+// value — the caller should merge with defaults via MergeEndpointConfig.
+// Zero-valued fields in the returned config mean "not overridden", so it is
+// not possible to intentionally override a field to zero.
 //
 // Supported env vars (for prefix "NINJA"):
 //

--- a/internal/collector/endpoint.go
+++ b/internal/collector/endpoint.go
@@ -1,0 +1,216 @@
+package collector
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+)
+
+// Canonical endpoint name constants. Used by main.go config and scheduler's
+// postCollect gate to identify which endpoints have completed.
+const (
+	EndpointNinjaGems     = "ninja-gems"
+	EndpointNinjaCurrency = "ninja-currency"
+)
+
+// FetchResult holds the outcome of a single endpoint fetch. We use concrete
+// typed fields instead of generics because Go generics cannot be used with
+// function-typed struct fields in EndpointConfig.FetchFunc without making
+// EndpointConfig itself generic, which would prevent mixing different endpoint
+// types in a single []EndpointConfig slice. The StoreFunc closure on
+// EndpointConfig reads the appropriate field — no type assertions needed.
+type FetchResult struct {
+	GemData      []GemSnapshot
+	CurrencyData []CurrencySnapshot
+	ETag         string
+	Age          int  // seconds since origin server generated the response
+	NotModified  bool // true when source returned 304 Not Modified
+}
+
+// FetchFunc fetches data from an external source. The etag parameter is the
+// ETag from the previous successful fetch (empty on first call). Returning
+// a FetchResult with NotModified=true signals that the source data hasn't
+// changed since the last fetch.
+type FetchFunc func(ctx context.Context, league string, etag string) (*FetchResult, error)
+
+// StoreFunc persists snapshot data from a FetchResult. It receives the full
+// result and the snapshot timestamp; the closure reads the appropriate typed
+// field (GemData or CurrencyData). Returns the number of rows inserted.
+type StoreFunc func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error)
+
+// StalenessFunc returns the time of the last stored snapshot for an endpoint.
+// Used at startup to decide whether to fetch immediately or wait. A nil
+// StalenessFunc means the endpoint always fetches on startup.
+type StalenessFunc func(ctx context.Context) (time.Time, error)
+
+// EndpointConfig defines the configuration and behavior for a single data
+// collection endpoint. Each endpoint runs in its own goroutine with
+// independent cache-aware sleep calculation.
+type EndpointConfig struct {
+	// Name is a human-readable identifier for logging and metrics.
+	Name string
+
+	// Source is the semaphore key (e.g. "ninja"). Endpoints sharing a source
+	// share the same rate-limit semaphore to avoid hammering the API.
+	Source string
+
+	// FetchFunc fetches data from the external source.
+	FetchFunc FetchFunc
+
+	// StoreFunc persists the fetched data.
+	StoreFunc StoreFunc
+
+	// StalenessFunc returns the last snapshot time for startup check.
+	// Nil means always fetch on startup.
+	StalenessFunc StalenessFunc
+
+	// MaxAge is the expected cache duration of the source data (e.g. 1800s
+	// for poe.ninja). Used with Age to calculate optimal sleep time.
+	MaxAge time.Duration
+
+	// FallbackInterval is the polling interval when no cache headers are
+	// available. Also used as the maximum sleep cap.
+	FallbackInterval time.Duration
+
+	// MaxRetries is the maximum number of consecutive 304 Not Modified
+	// responses before falling back to FallbackInterval sleep.
+	MaxRetries int
+
+	// MinSleep is the minimum time between fetches, even when cache math
+	// suggests a shorter interval. Prevents tight polling loops when Age
+	// exceeds MaxAge (stale-while-revalidate).
+	MinSleep time.Duration
+
+	// JitterMin is the minimum random jitter added to sleep duration.
+	JitterMin time.Duration
+
+	// JitterMax is the maximum random jitter added to sleep duration.
+	JitterMax time.Duration
+}
+
+// DefaultNinjaConfig returns an EndpointConfig with sensible defaults for
+// poe.ninja endpoints. Callers must still set Name, FetchFunc, StoreFunc,
+// and StalenessFunc for their specific endpoint type.
+func DefaultNinjaConfig() EndpointConfig {
+	return EndpointConfig{
+		Source:           "ninja",
+		MaxAge:           1800 * time.Second,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       5,
+		MinSleep:         30 * time.Second,
+		JitterMin:        2 * time.Second,
+		JitterMax:        7 * time.Second,
+	}
+}
+
+// ParseEndpointOverrides reads environment variables by prefix and returns an
+// EndpointConfig with any overrides applied. Fields that are not set or have
+// invalid values are left at their zero value (caller should merge with
+// defaults). Invalid values log a warning and are skipped.
+//
+// Supported env vars (for prefix "NINJA"):
+//
+//	NINJA_MAX_AGE           — e.g. "1800s", "30m"
+//	NINJA_FALLBACK_INTERVAL — e.g. "30m"
+//	NINJA_MAX_RETRIES       — e.g. "5"
+//	NINJA_MIN_SLEEP         — e.g. "30s"
+func ParseEndpointOverrides(prefix string) EndpointConfig {
+	var cfg EndpointConfig
+
+	if v := os.Getenv(prefix + "_MAX_AGE"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			slog.Warn("invalid env var, ignoring",
+				"var", prefix+"_MAX_AGE",
+				"value", v,
+				"error", err,
+			)
+		} else {
+			cfg.MaxAge = d
+		}
+	}
+
+	if v := os.Getenv(prefix + "_FALLBACK_INTERVAL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			slog.Warn("invalid env var, ignoring",
+				"var", prefix+"_FALLBACK_INTERVAL",
+				"value", v,
+				"error", err,
+			)
+		} else {
+			cfg.FallbackInterval = d
+		}
+	}
+
+	if v := os.Getenv(prefix + "_MAX_RETRIES"); v != "" {
+		var n int
+		_, err := parsePositiveInt(v)
+		if err != nil {
+			slog.Warn("invalid env var, ignoring",
+				"var", prefix+"_MAX_RETRIES",
+				"value", v,
+				"error", err,
+			)
+		} else {
+			n, _ = parsePositiveInt(v)
+			cfg.MaxRetries = n
+		}
+	}
+
+	if v := os.Getenv(prefix + "_MIN_SLEEP"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			slog.Warn("invalid env var, ignoring",
+				"var", prefix+"_MIN_SLEEP",
+				"value", v,
+				"error", err,
+			)
+		} else {
+			cfg.MinSleep = d
+		}
+	}
+
+	return cfg
+}
+
+// MergeEndpointConfig applies non-zero overrides on top of a base config.
+// Zero-valued fields in overrides are ignored, preserving the base defaults.
+func MergeEndpointConfig(base, overrides EndpointConfig) EndpointConfig {
+	if overrides.MaxAge > 0 {
+		base.MaxAge = overrides.MaxAge
+	}
+	if overrides.FallbackInterval > 0 {
+		base.FallbackInterval = overrides.FallbackInterval
+	}
+	if overrides.MaxRetries > 0 {
+		base.MaxRetries = overrides.MaxRetries
+	}
+	if overrides.MinSleep > 0 {
+		base.MinSleep = overrides.MinSleep
+	}
+	if overrides.JitterMin > 0 {
+		base.JitterMin = overrides.JitterMin
+	}
+	if overrides.JitterMax > 0 {
+		base.JitterMax = overrides.JitterMax
+	}
+	return base
+}
+
+// parsePositiveInt parses a string as a positive integer.
+func parsePositiveInt(s string) (int, error) {
+	var n int
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("not a positive integer: %q", s)
+		}
+		n = n*10 + int(c-'0')
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("not a positive integer: %q", s)
+	}
+	return n, nil
+}

--- a/internal/collector/endpoint.go
+++ b/internal/collector/endpoint.go
@@ -9,8 +9,9 @@ import (
 	"time"
 )
 
-// Canonical endpoint name constants. Used by main.go config and scheduler's
-// postCollect gate to identify which endpoints have completed.
+// Canonical endpoint name constants. Used by main.go to configure endpoints
+// and by postCollect to conditionally run endpoint-specific logic (e.g., gem
+// color upsert).
 const (
 	EndpointNinjaGems     = "ninja-gems"
 	EndpointNinjaCurrency = "ninja-currency"
@@ -28,6 +29,18 @@ type FetchResult struct {
 	ETag         string
 	Age          int  // seconds since origin server generated the response
 	NotModified  bool // true when source returned 304 Not Modified
+}
+
+// Validate checks FetchResult invariants: a NotModified result must have no
+// data, and at most one of GemData/CurrencyData may be populated.
+func (r *FetchResult) Validate() error {
+	if r.NotModified && (len(r.GemData) > 0 || len(r.CurrencyData) > 0) {
+		return fmt.Errorf("FetchResult: NotModified=true but data slices are populated")
+	}
+	if len(r.GemData) > 0 && len(r.CurrencyData) > 0 {
+		return fmt.Errorf("FetchResult: both GemData and CurrencyData are populated")
+	}
+	return nil
 }
 
 // FetchFunc fetches data from an external source. The etag parameter is the
@@ -67,8 +80,9 @@ type EndpointConfig struct {
 	// Nil means always fetch on startup.
 	StalenessFunc StalenessFunc
 
-	// MaxAge is the expected cache duration of the source data (e.g. 1800s
-	// for poe.ninja). Used with Age to calculate optimal sleep time.
+	// MaxAge is the assumed cache duration of the source data. The default for
+	// poe.ninja endpoints is 1800s (30 minutes). Used with Age to calculate
+	// optimal sleep time.
 	MaxAge time.Duration
 
 	// FallbackInterval is the polling interval when no cache headers are
@@ -84,10 +98,10 @@ type EndpointConfig struct {
 	// exceeds MaxAge (stale-while-revalidate).
 	MinSleep time.Duration
 
-	// JitterMin is the minimum random jitter added to sleep duration.
+	// JitterMin is the minimum random startup delay before the first fetch.
 	JitterMin time.Duration
 
-	// JitterMax is the maximum random jitter added to sleep duration.
+	// JitterMax is the maximum random startup delay before the first fetch.
 	JitterMax time.Duration
 }
 
@@ -121,27 +135,13 @@ func ParseEndpointOverrides(prefix string) EndpointConfig {
 	var cfg EndpointConfig
 
 	if v := os.Getenv(prefix + "_MAX_AGE"); v != "" {
-		d, err := time.ParseDuration(v)
-		if err != nil {
-			slog.Warn("invalid env var, ignoring",
-				"var", prefix+"_MAX_AGE",
-				"value", v,
-				"error", err,
-			)
-		} else {
+		if d, err := parsePositiveDuration(prefix+"_MAX_AGE", v); err == nil {
 			cfg.MaxAge = d
 		}
 	}
 
 	if v := os.Getenv(prefix + "_FALLBACK_INTERVAL"); v != "" {
-		d, err := time.ParseDuration(v)
-		if err != nil {
-			slog.Warn("invalid env var, ignoring",
-				"var", prefix+"_FALLBACK_INTERVAL",
-				"value", v,
-				"error", err,
-			)
-		} else {
+		if d, err := parsePositiveDuration(prefix+"_FALLBACK_INTERVAL", v); err == nil {
 			cfg.FallbackInterval = d
 		}
 	}
@@ -160,14 +160,7 @@ func ParseEndpointOverrides(prefix string) EndpointConfig {
 	}
 
 	if v := os.Getenv(prefix + "_MIN_SLEEP"); v != "" {
-		d, err := time.ParseDuration(v)
-		if err != nil {
-			slog.Warn("invalid env var, ignoring",
-				"var", prefix+"_MIN_SLEEP",
-				"value", v,
-				"error", err,
-			)
-		} else {
+		if d, err := parsePositiveDuration(prefix+"_MIN_SLEEP", v); err == nil {
 			cfg.MinSleep = d
 		}
 	}
@@ -176,6 +169,8 @@ func ParseEndpointOverrides(prefix string) EndpointConfig {
 }
 
 // MergeEndpointConfig applies non-zero overrides on top of a base config.
+// Only timing and numeric fields are merged; identity fields (Name, Source) and
+// function fields (FetchFunc, StoreFunc, StalenessFunc) are never overridden.
 // Zero-valued fields in overrides are ignored, preserving the base defaults.
 func MergeEndpointConfig(base, overrides EndpointConfig) EndpointConfig {
 	if overrides.MaxAge > 0 {
@@ -206,4 +201,26 @@ func parsePositiveInt(s string) (int, error) {
 		return 0, fmt.Errorf("not a positive integer: %q", s)
 	}
 	return n, nil
+}
+
+// parsePositiveDuration parses a duration string and rejects non-positive values.
+// Logs a warning and returns an error for invalid or non-positive durations.
+func parsePositiveDuration(varName, value string) (time.Duration, error) {
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		slog.Warn("invalid env var, ignoring",
+			"var", varName,
+			"value", value,
+			"error", err,
+		)
+		return 0, err
+	}
+	if d <= 0 {
+		slog.Warn("non-positive duration env var, ignoring",
+			"var", varName,
+			"value", value,
+		)
+		return 0, fmt.Errorf("non-positive duration: %q", value)
+	}
+	return d, nil
 }

--- a/internal/collector/endpoint.go
+++ b/internal/collector/endpoint.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -146,8 +147,7 @@ func ParseEndpointOverrides(prefix string) EndpointConfig {
 	}
 
 	if v := os.Getenv(prefix + "_MAX_RETRIES"); v != "" {
-		var n int
-		_, err := parsePositiveInt(v)
+		n, err := parsePositiveInt(v)
 		if err != nil {
 			slog.Warn("invalid env var, ignoring",
 				"var", prefix+"_MAX_RETRIES",
@@ -155,7 +155,6 @@ func ParseEndpointOverrides(prefix string) EndpointConfig {
 				"error", err,
 			)
 		} else {
-			n, _ = parsePositiveInt(v)
 			cfg.MaxRetries = n
 		}
 	}
@@ -200,16 +199,10 @@ func MergeEndpointConfig(base, overrides EndpointConfig) EndpointConfig {
 	return base
 }
 
-// parsePositiveInt parses a string as a positive integer.
+// parsePositiveInt parses a string as a positive integer (> 0).
 func parsePositiveInt(s string) (int, error) {
-	var n int
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return 0, fmt.Errorf("not a positive integer: %q", s)
-		}
-		n = n*10 + int(c-'0')
-	}
-	if n <= 0 {
+	n, err := strconv.Atoi(s)
+	if err != nil || n <= 0 {
 		return 0, fmt.Errorf("not a positive integer: %q", s)
 	}
 	return n, nil

--- a/internal/collector/endpoint_test.go
+++ b/internal/collector/endpoint_test.go
@@ -1,0 +1,182 @@
+package collector
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultNinjaConfig_sensibleDefaults(t *testing.T) {
+	cfg := DefaultNinjaConfig()
+
+	if cfg.Source != "ninja" {
+		t.Errorf("Source = %q, want %q", cfg.Source, "ninja")
+	}
+	if cfg.MaxAge != 1800*time.Second {
+		t.Errorf("MaxAge = %v, want %v", cfg.MaxAge, 1800*time.Second)
+	}
+	if cfg.FallbackInterval != 30*time.Minute {
+		t.Errorf("FallbackInterval = %v, want %v", cfg.FallbackInterval, 30*time.Minute)
+	}
+	if cfg.MaxRetries != 5 {
+		t.Errorf("MaxRetries = %d, want %d", cfg.MaxRetries, 5)
+	}
+	if cfg.MinSleep != 30*time.Second {
+		t.Errorf("MinSleep = %v, want %v", cfg.MinSleep, 30*time.Second)
+	}
+	if cfg.JitterMin != 2*time.Second {
+		t.Errorf("JitterMin = %v, want %v", cfg.JitterMin, 2*time.Second)
+	}
+	if cfg.JitterMax != 7*time.Second {
+		t.Errorf("JitterMax = %v, want %v", cfg.JitterMax, 7*time.Second)
+	}
+}
+
+func TestMergeEndpointConfig_overridesNonZeroFields(t *testing.T) {
+	base := DefaultNinjaConfig()
+	overrides := EndpointConfig{
+		MaxAge:     900 * time.Second,
+		MaxRetries: 10,
+	}
+
+	merged := MergeEndpointConfig(base, overrides)
+
+	if merged.MaxAge != 900*time.Second {
+		t.Errorf("MaxAge = %v, want %v (should be overridden)", merged.MaxAge, 900*time.Second)
+	}
+	if merged.MaxRetries != 10 {
+		t.Errorf("MaxRetries = %d, want %d (should be overridden)", merged.MaxRetries, 10)
+	}
+	// Non-overridden fields should retain base values.
+	if merged.FallbackInterval != 30*time.Minute {
+		t.Errorf("FallbackInterval = %v, want %v (should retain base)", merged.FallbackInterval, 30*time.Minute)
+	}
+	if merged.MinSleep != 30*time.Second {
+		t.Errorf("MinSleep = %v, want %v (should retain base)", merged.MinSleep, 30*time.Second)
+	}
+	if merged.Source != "ninja" {
+		t.Errorf("Source = %q, want %q (should retain base)", merged.Source, "ninja")
+	}
+}
+
+func TestMergeEndpointConfig_zeroOverridesPreserveBase(t *testing.T) {
+	base := DefaultNinjaConfig()
+	overrides := EndpointConfig{} // all zero values
+
+	merged := MergeEndpointConfig(base, overrides)
+
+	// Cannot compare structs with function fields directly; check each field.
+	if merged.MaxAge != base.MaxAge {
+		t.Errorf("MaxAge = %v, want %v", merged.MaxAge, base.MaxAge)
+	}
+	if merged.FallbackInterval != base.FallbackInterval {
+		t.Errorf("FallbackInterval = %v, want %v", merged.FallbackInterval, base.FallbackInterval)
+	}
+	if merged.MaxRetries != base.MaxRetries {
+		t.Errorf("MaxRetries = %d, want %d", merged.MaxRetries, base.MaxRetries)
+	}
+	if merged.MinSleep != base.MinSleep {
+		t.Errorf("MinSleep = %v, want %v", merged.MinSleep, base.MinSleep)
+	}
+	if merged.JitterMin != base.JitterMin {
+		t.Errorf("JitterMin = %v, want %v", merged.JitterMin, base.JitterMin)
+	}
+	if merged.JitterMax != base.JitterMax {
+		t.Errorf("JitterMax = %v, want %v", merged.JitterMax, base.JitterMax)
+	}
+}
+
+func TestParseEndpointOverrides_validEnvVars(t *testing.T) {
+	t.Setenv("TEST_MAX_AGE", "900s")
+	t.Setenv("TEST_FALLBACK_INTERVAL", "20m")
+	t.Setenv("TEST_MAX_RETRIES", "3")
+	t.Setenv("TEST_MIN_SLEEP", "15s")
+
+	cfg := ParseEndpointOverrides("TEST")
+
+	if cfg.MaxAge != 900*time.Second {
+		t.Errorf("MaxAge = %v, want %v", cfg.MaxAge, 900*time.Second)
+	}
+	if cfg.FallbackInterval != 20*time.Minute {
+		t.Errorf("FallbackInterval = %v, want %v", cfg.FallbackInterval, 20*time.Minute)
+	}
+	if cfg.MaxRetries != 3 {
+		t.Errorf("MaxRetries = %d, want %d", cfg.MaxRetries, 3)
+	}
+	if cfg.MinSleep != 15*time.Second {
+		t.Errorf("MinSleep = %v, want %v", cfg.MinSleep, 15*time.Second)
+	}
+}
+
+func TestParseEndpointOverrides_missingEnvVarsReturnZero(t *testing.T) {
+	// No env vars set — all fields should be zero.
+	cfg := ParseEndpointOverrides("NONEXISTENT_PREFIX")
+
+	if cfg.MaxAge != 0 {
+		t.Errorf("MaxAge = %v, want 0", cfg.MaxAge)
+	}
+	if cfg.FallbackInterval != 0 {
+		t.Errorf("FallbackInterval = %v, want 0", cfg.FallbackInterval)
+	}
+	if cfg.MaxRetries != 0 {
+		t.Errorf("MaxRetries = %d, want 0", cfg.MaxRetries)
+	}
+	if cfg.MinSleep != 0 {
+		t.Errorf("MinSleep = %v, want 0", cfg.MinSleep)
+	}
+}
+
+func TestParseEndpointOverrides_invalidValuesIgnored(t *testing.T) {
+	t.Setenv("BAD_MAX_AGE", "notaduration")
+	t.Setenv("BAD_MAX_RETRIES", "abc")
+	t.Setenv("BAD_MIN_SLEEP", "5x")
+
+	cfg := ParseEndpointOverrides("BAD")
+
+	if cfg.MaxAge != 0 {
+		t.Errorf("MaxAge = %v, want 0 (invalid value should be ignored)", cfg.MaxAge)
+	}
+	if cfg.MaxRetries != 0 {
+		t.Errorf("MaxRetries = %d, want 0 (invalid value should be ignored)", cfg.MaxRetries)
+	}
+	if cfg.MinSleep != 0 {
+		t.Errorf("MinSleep = %v, want 0 (invalid value should be ignored)", cfg.MinSleep)
+	}
+}
+
+func TestParseEndpointOverrides_partialEnvVars(t *testing.T) {
+	// Only some env vars set — only those fields should be non-zero.
+	t.Setenv("PARTIAL_MAX_AGE", "1200s")
+
+	cfg := ParseEndpointOverrides("PARTIAL")
+
+	if cfg.MaxAge != 1200*time.Second {
+		t.Errorf("MaxAge = %v, want %v", cfg.MaxAge, 1200*time.Second)
+	}
+	if cfg.FallbackInterval != 0 {
+		t.Errorf("FallbackInterval = %v, want 0 (not set)", cfg.FallbackInterval)
+	}
+}
+
+func TestEndpointNameConstants(t *testing.T) {
+	// Verify constants exist and have expected values.
+	if EndpointNinjaGems != "ninja-gems" {
+		t.Errorf("EndpointNinjaGems = %q, want %q", EndpointNinjaGems, "ninja-gems")
+	}
+	if EndpointNinjaCurrency != "ninja-currency" {
+		t.Errorf("EndpointNinjaCurrency = %q, want %q", EndpointNinjaCurrency, "ninja-currency")
+	}
+}
+
+func TestFetchResult_zeroValueIsNotModified(t *testing.T) {
+	// A zero-value FetchResult should have NotModified=false.
+	var r FetchResult
+	if r.NotModified {
+		t.Error("zero-value FetchResult should have NotModified=false")
+	}
+	if r.ETag != "" {
+		t.Error("zero-value FetchResult should have empty ETag")
+	}
+	if r.Age != 0 {
+		t.Error("zero-value FetchResult should have Age=0")
+	}
+}

--- a/internal/collector/endpoint_test.go
+++ b/internal/collector/endpoint_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -311,5 +312,100 @@ func TestFetchResult_zeroValueIsNotModified(t *testing.T) {
 	}
 	if r.Age != 0 {
 		t.Error("zero-value FetchResult should have Age=0")
+	}
+}
+
+func TestFetchResult_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		result  FetchResult
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid gem data only",
+			result:  FetchResult{GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}},
+			wantErr: false,
+		},
+		{
+			name:    "valid currency data only",
+			result:  FetchResult{CurrencyData: []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}}},
+			wantErr: false,
+		},
+		{
+			name:    "valid empty result (no data, not modified false)",
+			result:  FetchResult{},
+			wantErr: false,
+		},
+		{
+			name: "NotModified with GemData populated returns error",
+			result: FetchResult{
+				NotModified: true,
+				GemData:     []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}},
+			},
+			wantErr: true,
+			errMsg:  "NotModified=true but data slices are populated",
+		},
+		{
+			name: "NotModified with CurrencyData populated returns error",
+			result: FetchResult{
+				NotModified:  true,
+				CurrencyData: []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}},
+			},
+			wantErr: true,
+			errMsg:  "NotModified=true but data slices are populated",
+		},
+		{
+			name: "both GemData and CurrencyData populated returns error",
+			result: FetchResult{
+				GemData:      []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}},
+				CurrencyData: []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}},
+			},
+			wantErr: true,
+			errMsg:  "both GemData and CurrencyData are populated",
+		},
+		{
+			name:    "NotModified with no data is valid",
+			result:  FetchResult{NotModified: true},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.result.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error = %q, want it to contain %q", err.Error(), tt.errMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestParseEndpointOverrides_negativeDurationIgnored(t *testing.T) {
+	// parsePositiveDuration explicitly rejects d <= 0, so valid-but-negative
+	// durations like "-5s" should be ignored, leaving the field at zero.
+	t.Setenv("NEG_MAX_AGE", "-5s")
+	t.Setenv("NEG_FALLBACK_INTERVAL", "-30m")
+	t.Setenv("NEG_MIN_SLEEP", "-1s")
+
+	cfg := ParseEndpointOverrides("NEG")
+
+	if cfg.MaxAge != 0 {
+		t.Errorf("MaxAge = %v, want 0 (negative duration should be ignored)", cfg.MaxAge)
+	}
+	if cfg.FallbackInterval != 0 {
+		t.Errorf("FallbackInterval = %v, want 0 (negative duration should be ignored)", cfg.FallbackInterval)
+	}
+	if cfg.MinSleep != 0 {
+		t.Errorf("MinSleep = %v, want 0 (negative duration should be ignored)", cfg.MinSleep)
 	}
 }

--- a/internal/collector/endpoint_test.go
+++ b/internal/collector/endpoint_test.go
@@ -201,15 +201,14 @@ func TestParseEndpointOverrides_ninjaIntervalAliasNotHandled(t *testing.T) {
 	}
 }
 
-func TestNinjaIntervalAlias_mergePattern(t *testing.T) {
-	// Simulates the NINJA_INTERVAL deprecated alias pattern used in
-	// cmd/collector/main.go: when FALLBACK_INTERVAL is not set via overrides
-	// but NINJA_INTERVAL is set, the alias value is applied after merge.
-	t.Setenv("LEGACY_FALLBACK_INTERVAL", "")
+func TestNinjaIntervalAlias_mergePreservesBase(t *testing.T) {
+	// When no env var overrides are set, MergeEndpointConfig retains the base
+	// FallbackInterval. This verifies the starting condition that the alias
+	// pattern in main.go relies on: if overrides.FallbackInterval == 0, the
+	// base default (30m) is active after merge, and the alias is free to
+	// override it.
+	overrides := ParseEndpointOverrides("LEGACY_NOMATCH_XYZ")
 
-	overrides := ParseEndpointOverrides("LEGACY")
-
-	// FallbackInterval not set via overrides — zero value.
 	if overrides.FallbackInterval != 0 {
 		t.Fatalf("precondition: FallbackInterval = %v, want 0", overrides.FallbackInterval)
 	}
@@ -217,15 +216,9 @@ func TestNinjaIntervalAlias_mergePattern(t *testing.T) {
 	base := DefaultNinjaConfig()
 	merged := MergeEndpointConfig(base, overrides)
 
-	// Simulate the alias: if overrides.FallbackInterval == 0 and legacy alias
-	// is set, apply it to the merged config.
-	legacyInterval := 20 * time.Minute // simulates parsed NINJA_INTERVAL=20m
-	if overrides.FallbackInterval == 0 {
-		merged.FallbackInterval = legacyInterval
-	}
-
-	if merged.FallbackInterval != 20*time.Minute {
-		t.Errorf("FallbackInterval = %v, want %v (legacy alias should override base)", merged.FallbackInterval, 20*time.Minute)
+	// Base default is preserved when no override is set.
+	if merged.FallbackInterval != 30*time.Minute {
+		t.Errorf("FallbackInterval = %v, want %v (base default should be preserved when override is zero)", merged.FallbackInterval, 30*time.Minute)
 	}
 }
 

--- a/internal/collector/endpoint_test.go
+++ b/internal/collector/endpoint_test.go
@@ -167,6 +167,135 @@ func TestEndpointNameConstants(t *testing.T) {
 	}
 }
 
+func TestParseEndpointOverrides_numericWithoutUnitIgnored(t *testing.T) {
+	// time.ParseDuration requires a unit suffix — "1800" alone is invalid.
+	t.Setenv("NOUNIT_MAX_AGE", "1800")
+	t.Setenv("NOUNIT_FALLBACK_INTERVAL", "900")
+	t.Setenv("NOUNIT_MIN_SLEEP", "30")
+
+	cfg := ParseEndpointOverrides("NOUNIT")
+
+	if cfg.MaxAge != 0 {
+		t.Errorf("MaxAge = %v, want 0 (numeric without unit suffix should be ignored)", cfg.MaxAge)
+	}
+	if cfg.FallbackInterval != 0 {
+		t.Errorf("FallbackInterval = %v, want 0 (numeric without unit suffix should be ignored)", cfg.FallbackInterval)
+	}
+	if cfg.MinSleep != 0 {
+		t.Errorf("MinSleep = %v, want 0 (numeric without unit suffix should be ignored)", cfg.MinSleep)
+	}
+}
+
+func TestParseEndpointOverrides_ninjaIntervalAliasNotHandled(t *testing.T) {
+	// The NINJA_INTERVAL deprecated alias is handled in cmd/collector/main.go,
+	// not in ParseEndpointOverrides. Setting PREFIX_INTERVAL should have no
+	// effect on parsed config — the alias wiring is caller responsibility.
+	t.Setenv("ALIAS_INTERVAL", "20m")
+
+	cfg := ParseEndpointOverrides("ALIAS")
+
+	// FallbackInterval should be zero because _INTERVAL is not a recognized
+	// suffix — only _FALLBACK_INTERVAL is parsed.
+	if cfg.FallbackInterval != 0 {
+		t.Errorf("FallbackInterval = %v, want 0 (_INTERVAL is not parsed, only _FALLBACK_INTERVAL)", cfg.FallbackInterval)
+	}
+}
+
+func TestNinjaIntervalAlias_mergePattern(t *testing.T) {
+	// Simulates the NINJA_INTERVAL deprecated alias pattern used in
+	// cmd/collector/main.go: when FALLBACK_INTERVAL is not set via overrides
+	// but NINJA_INTERVAL is set, the alias value is applied after merge.
+	t.Setenv("LEGACY_FALLBACK_INTERVAL", "")
+
+	overrides := ParseEndpointOverrides("LEGACY")
+
+	// FallbackInterval not set via overrides — zero value.
+	if overrides.FallbackInterval != 0 {
+		t.Fatalf("precondition: FallbackInterval = %v, want 0", overrides.FallbackInterval)
+	}
+
+	base := DefaultNinjaConfig()
+	merged := MergeEndpointConfig(base, overrides)
+
+	// Simulate the alias: if overrides.FallbackInterval == 0 and legacy alias
+	// is set, apply it to the merged config.
+	legacyInterval := 20 * time.Minute // simulates parsed NINJA_INTERVAL=20m
+	if overrides.FallbackInterval == 0 {
+		merged.FallbackInterval = legacyInterval
+	}
+
+	if merged.FallbackInterval != 20*time.Minute {
+		t.Errorf("FallbackInterval = %v, want %v (legacy alias should override base)", merged.FallbackInterval, 20*time.Minute)
+	}
+}
+
+func TestNinjaIntervalAlias_fallbackIntervalTakesPrecedence(t *testing.T) {
+	// When FALLBACK_INTERVAL is explicitly set, the legacy INTERVAL alias
+	// should NOT override it. This mirrors the main.go guard:
+	// if ninjaOverrides.FallbackInterval == 0 && ninjaIntervalStr != "" { ... }
+	t.Setenv("PRIO_FALLBACK_INTERVAL", "25m")
+
+	overrides := ParseEndpointOverrides("PRIO")
+
+	if overrides.FallbackInterval != 25*time.Minute {
+		t.Fatalf("precondition: FallbackInterval = %v, want %v", overrides.FallbackInterval, 25*time.Minute)
+	}
+
+	base := DefaultNinjaConfig()
+	merged := MergeEndpointConfig(base, overrides)
+
+	// Simulate the alias guard: only apply if overrides.FallbackInterval == 0.
+	legacyInterval := 20 * time.Minute
+	if overrides.FallbackInterval == 0 {
+		merged.FallbackInterval = legacyInterval
+	}
+
+	// FALLBACK_INTERVAL wins over the legacy alias.
+	if merged.FallbackInterval != 25*time.Minute {
+		t.Errorf("FallbackInterval = %v, want %v (explicit FALLBACK_INTERVAL should take precedence over alias)", merged.FallbackInterval, 25*time.Minute)
+	}
+}
+
+func TestMergeEndpointConfig_jitterOverrides(t *testing.T) {
+	base := DefaultNinjaConfig()
+	overrides := EndpointConfig{
+		JitterMin: 5 * time.Second,
+		JitterMax: 15 * time.Second,
+	}
+
+	merged := MergeEndpointConfig(base, overrides)
+
+	if merged.JitterMin != 5*time.Second {
+		t.Errorf("JitterMin = %v, want %v (should be overridden)", merged.JitterMin, 5*time.Second)
+	}
+	if merged.JitterMax != 15*time.Second {
+		t.Errorf("JitterMax = %v, want %v (should be overridden)", merged.JitterMax, 15*time.Second)
+	}
+	// Other fields should retain base values.
+	if merged.MaxAge != 1800*time.Second {
+		t.Errorf("MaxAge = %v, want %v (should retain base)", merged.MaxAge, 1800*time.Second)
+	}
+}
+
+func TestDefaultNinjaConfig_functionalFieldsAreNil(t *testing.T) {
+	// DefaultNinjaConfig only sets scalar configuration. Callers must
+	// provide FetchFunc, StoreFunc, and StalenessFunc for their endpoint.
+	cfg := DefaultNinjaConfig()
+
+	if cfg.FetchFunc != nil {
+		t.Error("FetchFunc should be nil — caller must set it")
+	}
+	if cfg.StoreFunc != nil {
+		t.Error("StoreFunc should be nil — caller must set it")
+	}
+	if cfg.StalenessFunc != nil {
+		t.Error("StalenessFunc should be nil — caller must set it")
+	}
+	if cfg.Name != "" {
+		t.Errorf("Name = %q, want empty — caller must set it", cfg.Name)
+	}
+}
+
 func TestFetchResult_zeroValueIsNotModified(t *testing.T) {
 	// A zero-value FetchResult should have NotModified=false.
 	var r FetchResult

--- a/internal/collector/endpoint_test.go
+++ b/internal/collector/endpoint_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
@@ -387,6 +388,26 @@ func TestFetchResult_Validate(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestEndpointConfig_Validate_minSleepExceedsFallbackInterval(t *testing.T) {
+	ep := EndpointConfig{
+		Name:             "test",
+		FetchFunc:        func(ctx context.Context, league string, etag string) (*FetchResult, error) { return nil, nil },
+		FallbackInterval: 30 * time.Second,
+		MinSleep:         60 * time.Second,
+	}
+
+	err := ep.Validate()
+	if err == nil {
+		t.Fatal("expected error when MinSleep exceeds FallbackInterval, got nil")
+	}
+	if !strings.Contains(err.Error(), "MinSleep") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "MinSleep")
+	}
+	if !strings.Contains(err.Error(), "exceeds FallbackInterval") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "exceeds FallbackInterval")
 	}
 }
 

--- a/internal/collector/endpoint_test.go
+++ b/internal/collector/endpoint_test.go
@@ -289,6 +289,17 @@ func TestDefaultNinjaConfig_functionalFieldsAreNil(t *testing.T) {
 	}
 }
 
+func TestParseEndpointOverrides_zeroMaxRetriesIgnored(t *testing.T) {
+	// parsePositiveInt rejects n <= 0, so MAX_RETRIES=0 should be ignored.
+	t.Setenv("ZERO_MAX_RETRIES", "0")
+
+	cfg := ParseEndpointOverrides("ZERO")
+
+	if cfg.MaxRetries != 0 {
+		t.Errorf("MaxRetries = %d, want 0 (zero should be rejected by parsePositiveInt)", cfg.MaxRetries)
+	}
+}
+
 func TestFetchResult_zeroValueIsNotModified(t *testing.T) {
 	// A zero-value FetchResult should have NotModified=false.
 	var r FetchResult

--- a/internal/collector/fetcher.go
+++ b/internal/collector/fetcher.go
@@ -3,19 +3,8 @@
 package collector
 
 import (
-	"context"
 	"time"
 )
-
-// Fetcher abstracts an external price data source (poe.ninja, TFT, etc.).
-// Each implementation handles its own API format and returns normalised domain types.
-//
-// Deprecated: Superseded by EndpointConfig.FetchFunc. Will be removed when
-// the scheduler is rewritten to the goroutine-per-endpoint model.
-type Fetcher interface {
-	FetchGems(ctx context.Context, league string) ([]GemSnapshot, error)
-	FetchCurrency(ctx context.Context, league string) ([]CurrencySnapshot, error)
-}
 
 // GemSnapshot represents a single gem price observation matching the gem_snapshots
 // hypertable columns. The Time field is populated when reading from the database;

--- a/internal/collector/fetcher.go
+++ b/internal/collector/fetcher.go
@@ -9,6 +9,9 @@ import (
 
 // Fetcher abstracts an external price data source (poe.ninja, TFT, etc.).
 // Each implementation handles its own API format and returns normalised domain types.
+//
+// Deprecated: Superseded by EndpointConfig.FetchFunc. Will be removed when
+// the scheduler is rewritten to the goroutine-per-endpoint model.
 type Fetcher interface {
 	FetchGems(ctx context.Context, league string) ([]GemSnapshot, error)
 	FetchCurrency(ctx context.Context, league string) ([]CurrencySnapshot, error)

--- a/internal/collector/ninja.go
+++ b/internal/collector/ninja.go
@@ -238,10 +238,16 @@ func (f *NinjaFetcher) getWithCache(ctx context.Context, rawURL string, etag str
 	// Parse Age header (seconds since origin generated the response).
 	age := 0
 	if ageStr := resp.Header.Get("Age"); ageStr != "" {
-		if parsed, parseErr := strconv.Atoi(ageStr); parseErr == nil && parsed >= 0 {
+		parsed, parseErr := strconv.Atoi(ageStr)
+		if parseErr != nil {
+			slog.Warn("invalid Age header, defaulting to 0",
+				"raw", ageStr, "url", rawURL, "error", parseErr)
+		} else if parsed < 0 {
+			slog.Warn("negative Age header, defaulting to 0",
+				"raw", ageStr, "url", rawURL)
+		} else {
 			age = parsed
 		}
-		// Invalid Age header is silently ignored (defaults to 0).
 	}
 
 	// Parse ETag from response.

--- a/internal/collector/ninja.go
+++ b/internal/collector/ninja.go
@@ -272,18 +272,3 @@ func (f *NinjaFetcher) getWithCache(ctx context.Context, rawURL string, etag str
 	}, nil
 }
 
-// ClampAge checks if age exceeds maxAge and clamps it, logging a warning.
-// This handles the stale-while-revalidate edge case where poe.ninja's CDN
-// may serve responses with age > max-age. Returns the clamped age in seconds.
-func ClampAge(age int, maxAge time.Duration, endpoint string) int {
-	maxAgeSec := int(maxAge.Seconds())
-	if maxAgeSec > 0 && age > maxAgeSec {
-		slog.Warn("response age exceeds max-age, clamping",
-			"endpoint", endpoint,
-			"age", age,
-			"maxAge", maxAgeSec,
-		)
-		return maxAgeSec
-	}
-	return age
-}

--- a/internal/collector/ninja.go
+++ b/internal/collector/ninja.go
@@ -56,9 +56,8 @@ type ninjaGemLine struct {
 	} `json:"tradeFilter"`
 }
 
-// ninjaCurrencyLine represents a single currency entry from poe.ninja's unified
-// stash/item/overview endpoint (not the legacy /currencyoverview). Uses
-// chaosEquivalent and receiveSparkLine fields.
+// ninjaCurrencyLine represents a single currency entry from the poe.ninja
+// stash/item/overview endpoint.
 type ninjaCurrencyLine struct {
 	CurrencyTypeName string  `json:"currencyTypeName"`
 	ChaosEquivalent  float64 `json:"chaosEquivalent"`
@@ -94,7 +93,6 @@ func (f *NinjaFetcher) FetchGemsEndpoint(ctx context.Context, league string, eta
 	}
 
 	if hr.NotModified {
-		slog.Info("ninja: gems not modified (304)", "etag", etag)
 		return &FetchResult{
 			NotModified: true,
 			ETag:        hr.ETag,
@@ -111,11 +109,15 @@ func (f *NinjaFetcher) FetchGemsEndpoint(ctx context.Context, league string, eta
 	snapshots := f.convertGemLines(resp.Lines)
 
 	slog.Info("ninja: fetched gems", "total_api", len(resp.Lines), "after_filter", len(snapshots), "age", hr.Age, "etag", hr.ETag)
-	return &FetchResult{
+	result := &FetchResult{
 		GemData: snapshots,
 		ETag:    hr.ETag,
 		Age:     hr.Age,
-	}, nil
+	}
+	if err := result.Validate(); err != nil {
+		return nil, fmt.Errorf("ninja: gems result invalid: %w", err)
+	}
+	return result, nil
 }
 
 // FetchCurrencyEndpoint is a FetchFunc-compatible method that fetches Currency
@@ -129,7 +131,6 @@ func (f *NinjaFetcher) FetchCurrencyEndpoint(ctx context.Context, league string,
 	}
 
 	if hr.NotModified {
-		slog.Info("ninja: currency not modified (304)", "etag", etag)
 		return &FetchResult{
 			NotModified: true,
 			ETag:        hr.ETag,
@@ -146,11 +147,15 @@ func (f *NinjaFetcher) FetchCurrencyEndpoint(ctx context.Context, league string,
 	snapshots := convertCurrencyLines(resp.Lines)
 
 	slog.Info("ninja: fetched currency", "count", len(snapshots), "age", hr.Age, "etag", hr.ETag)
-	return &FetchResult{
+	result := &FetchResult{
 		CurrencyData: snapshots,
 		ETag:         hr.ETag,
 		Age:          hr.Age,
-	}, nil
+	}
+	if err := result.Validate(); err != nil {
+		return nil, fmt.Errorf("ninja: currency result invalid: %w", err)
+	}
+	return result, nil
 }
 
 // convertGemLines filters and transforms raw API gem lines into GemSnapshots.

--- a/internal/collector/ninja.go
+++ b/internal/collector/ninja.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,7 +21,7 @@ const (
 	ninjaUserAgent      = "ProfitOfExile/1.0 (price-collector)"
 )
 
-// NinjaFetcher implements Fetcher for the poe.ninja API.
+// NinjaFetcher fetches price data from the poe.ninja API.
 type NinjaFetcher struct {
 	client   *http.Client
 	baseURL  string
@@ -71,19 +72,92 @@ type ninjaResponse[T any] struct {
 	Lines []T `json:"lines"`
 }
 
-// FetchGems retrieves all SkillGem prices from poe.ninja, filters out corrupted
-// and Heist-exclusive gems, detects transfigured variants, and resolves gem colors.
-func (f *NinjaFetcher) FetchGems(ctx context.Context, league string) ([]GemSnapshot, error) {
+// httpResult holds the HTTP response metadata and body from a cache-aware
+// request. Callers must close Body when non-nil.
+type httpResult struct {
+	StatusCode  int
+	ETag        string
+	Age         int // seconds since origin server generated the response
+	Body        io.ReadCloser
+	NotModified bool
+}
+
+// FetchGemsEndpoint is a FetchFunc-compatible method that fetches SkillGem data
+// with conditional request support. When etag is non-empty, it sends an
+// If-None-Match header; a 304 response returns FetchResult{NotModified: true}.
+func (f *NinjaFetcher) FetchGemsEndpoint(ctx context.Context, league string, etag string) (*FetchResult, error) {
 	endpoint := fmt.Sprintf("%s/economy/stash/current/item/overview?league=%s&type=SkillGem", f.baseURL, url.QueryEscape(league))
 
-	var resp ninjaResponse[ninjaGemLine]
-	if err := f.get(ctx, endpoint, &resp); err != nil {
+	hr, err := f.getWithCache(ctx, endpoint, etag)
+	if err != nil {
 		return nil, fmt.Errorf("ninja: fetch gems: %w", err)
 	}
 
-	snapshots := make([]GemSnapshot, 0, len(resp.Lines))
-	for _, line := range resp.Lines {
-		// Skip corrupted gems — prices are unreliable.
+	if hr.NotModified {
+		slog.Info("ninja: gems not modified (304)", "etag", etag)
+		return &FetchResult{
+			NotModified: true,
+			ETag:        hr.ETag,
+			Age:         hr.Age,
+		}, nil
+	}
+	defer hr.Body.Close()
+
+	var resp ninjaResponse[ninjaGemLine]
+	if err := json.NewDecoder(hr.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("ninja: decode gems response: %w", err)
+	}
+
+	snapshots := f.convertGemLines(resp.Lines)
+
+	slog.Info("ninja: fetched gems", "total_api", len(resp.Lines), "after_filter", len(snapshots), "age", hr.Age, "etag", hr.ETag)
+	return &FetchResult{
+		GemData: snapshots,
+		ETag:    hr.ETag,
+		Age:     hr.Age,
+	}, nil
+}
+
+// FetchCurrencyEndpoint is a FetchFunc-compatible method that fetches Currency
+// data with conditional request support.
+func (f *NinjaFetcher) FetchCurrencyEndpoint(ctx context.Context, league string, etag string) (*FetchResult, error) {
+	endpoint := fmt.Sprintf("%s/economy/stash/current/item/overview?league=%s&type=Currency", f.baseURL, url.QueryEscape(league))
+
+	hr, err := f.getWithCache(ctx, endpoint, etag)
+	if err != nil {
+		return nil, fmt.Errorf("ninja: fetch currency: %w", err)
+	}
+
+	if hr.NotModified {
+		slog.Info("ninja: currency not modified (304)", "etag", etag)
+		return &FetchResult{
+			NotModified: true,
+			ETag:        hr.ETag,
+			Age:         hr.Age,
+		}, nil
+	}
+	defer hr.Body.Close()
+
+	var resp ninjaResponse[ninjaCurrencyLine]
+	if err := json.NewDecoder(hr.Body).Decode(&resp); err != nil {
+		return nil, fmt.Errorf("ninja: decode currency response: %w", err)
+	}
+
+	snapshots := convertCurrencyLines(resp.Lines)
+
+	slog.Info("ninja: fetched currency", "count", len(snapshots), "age", hr.Age, "etag", hr.ETag)
+	return &FetchResult{
+		CurrencyData: snapshots,
+		ETag:         hr.ETag,
+		Age:          hr.Age,
+	}, nil
+}
+
+// convertGemLines filters and transforms raw API gem lines into GemSnapshots.
+func (f *NinjaFetcher) convertGemLines(lines []ninjaGemLine) []GemSnapshot {
+	snapshots := make([]GemSnapshot, 0, len(lines))
+	for _, line := range lines {
+		// Skip corrupted gems -- prices are unreliable.
 		if line.Corrupted {
 			continue
 		}
@@ -124,54 +198,92 @@ func (f *NinjaFetcher) FetchGems(ctx context.Context, league string) ([]GemSnaps
 		}
 	}
 
-	slog.Info("ninja: fetched gems", "total_api", len(resp.Lines), "after_filter", len(snapshots))
-	return snapshots, nil
+	return snapshots
 }
 
-// FetchCurrency retrieves all Currency prices from poe.ninja.
-func (f *NinjaFetcher) FetchCurrency(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-	endpoint := fmt.Sprintf("%s/economy/stash/current/item/overview?league=%s&type=Currency", f.baseURL, url.QueryEscape(league))
-
-	var resp ninjaResponse[ninjaCurrencyLine]
-	if err := f.get(ctx, endpoint, &resp); err != nil {
-		return nil, fmt.Errorf("ninja: fetch currency: %w", err)
-	}
-
-	snapshots := make([]CurrencySnapshot, 0, len(resp.Lines))
-	for _, line := range resp.Lines {
+// convertCurrencyLines transforms raw API currency lines into CurrencySnapshots.
+func convertCurrencyLines(lines []ninjaCurrencyLine) []CurrencySnapshot {
+	snapshots := make([]CurrencySnapshot, 0, len(lines))
+	for _, line := range lines {
 		snapshots = append(snapshots, CurrencySnapshot{
 			CurrencyID:      line.CurrencyTypeName,
 			Chaos:           line.ChaosEquivalent,
 			SparklineChange: line.Sparkline.TotalChange,
 		})
 	}
-
-	slog.Info("ninja: fetched currency", "count", len(snapshots))
-	return snapshots, nil
+	return snapshots
 }
 
-// get performs an HTTP GET request and JSON-decodes the response body into dst.
-func (f *NinjaFetcher) get(ctx context.Context, url string, dst any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+// getWithCache performs an HTTP GET request with conditional request support.
+// When etag is non-empty, it sends an If-None-Match header. On a 304 response,
+// it returns an httpResult with NotModified=true and a nil Body. On a 200
+// response, it returns the response body (caller must close) along with parsed
+// ETag and Age headers.
+func (f *NinjaFetcher) getWithCache(ctx context.Context, rawURL string, etag string) (*httpResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
-		return fmt.Errorf("create request: %w", err)
+		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("User-Agent", ninjaUserAgent)
 
+	if etag != "" {
+		req.Header.Set("If-None-Match", etag)
+	}
+
 	resp, err := f.client.Do(req)
 	if err != nil {
-		return fmt.Errorf("http get %s: %w", url, err)
+		return nil, fmt.Errorf("http get %s: %w", rawURL, err)
 	}
-	defer resp.Body.Close()
+
+	// Parse Age header (seconds since origin generated the response).
+	age := 0
+	if ageStr := resp.Header.Get("Age"); ageStr != "" {
+		if parsed, parseErr := strconv.Atoi(ageStr); parseErr == nil && parsed >= 0 {
+			age = parsed
+		}
+		// Invalid Age header is silently ignored (defaults to 0).
+	}
+
+	// Parse ETag from response.
+	respETag := resp.Header.Get("ETag")
+
+	// Handle 304 Not Modified.
+	if resp.StatusCode == http.StatusNotModified {
+		resp.Body.Close()
+		return &httpResult{
+			StatusCode:  resp.StatusCode,
+			ETag:        respETag,
+			Age:         age,
+			NotModified: true,
+		}, nil
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
-		return fmt.Errorf("http get %s: status %d: %s", url, resp.StatusCode, string(body))
+		resp.Body.Close()
+		return nil, fmt.Errorf("http get %s: status %d: %s", rawURL, resp.StatusCode, string(body))
 	}
 
-	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
-		return fmt.Errorf("decode response from %s: %w", url, err)
-	}
+	return &httpResult{
+		StatusCode: resp.StatusCode,
+		ETag:       respETag,
+		Age:        age,
+		Body:       resp.Body,
+	}, nil
+}
 
-	return nil
+// ClampAge checks if age exceeds maxAge and clamps it, logging a warning.
+// This handles the stale-while-revalidate edge case where poe.ninja's CDN
+// may serve responses with age > max-age. Returns the clamped age in seconds.
+func ClampAge(age int, maxAge time.Duration, endpoint string) int {
+	maxAgeSec := int(maxAge.Seconds())
+	if maxAgeSec > 0 && age > maxAgeSec {
+		slog.Warn("response age exceeds max-age, clamping",
+			"endpoint", endpoint,
+			"age", age,
+			"maxAge", maxAgeSec,
+		)
+		return maxAgeSec
+	}
+	return age
 }

--- a/internal/collector/ninja.go
+++ b/internal/collector/ninja.go
@@ -57,7 +57,7 @@ type ninjaGemLine struct {
 }
 
 // ninjaCurrencyLine represents a single currency entry from the poe.ninja
-// stash/item/overview endpoint.
+// economy/stash/current/item/overview endpoint.
 type ninjaCurrencyLine struct {
 	CurrencyTypeName string  `json:"currencyTypeName"`
 	ChaosEquivalent  float64 `json:"chaosEquivalent"`

--- a/internal/collector/ninja_test.go
+++ b/internal/collector/ninja_test.go
@@ -32,7 +32,7 @@ func gemLine(name, variant string, chaos float64, listings int, discriminator st
 	return line
 }
 
-func TestFetchGems_validResponse(t *testing.T) {
+func TestFetchGemsEndpoint_validResponse(t *testing.T) {
 	payload := ninjaResponse[ninjaGemLine]{
 		Lines: []ninjaGemLine{
 			gemLine("Arc", "20/20", 15.5, 300, "gem"),
@@ -46,16 +46,16 @@ func TestFetchGems_validResponse(t *testing.T) {
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	gems, err := f.FetchGems(context.Background(), "Standard")
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	gems := result.GemData
 	if len(gems) != 2 {
 		t.Fatalf("got %d gems, want 2", len(gems))
 	}
 
-	// Verify field extraction for first gem.
 	g := gems[0]
 	if g.Name != "Arc" {
 		t.Errorf("Name = %q, want %q", g.Name, "Arc")
@@ -73,13 +73,12 @@ func TestFetchGems_validResponse(t *testing.T) {
 		t.Error("IsTransfigured = true, want false")
 	}
 
-	// Verify empty variant is normalised to "default".
 	if gems[1].Variant != "default" {
 		t.Errorf("empty variant = %q, want %q", gems[1].Variant, "default")
 	}
 }
 
-func TestFetchGems_corruptedFiltered(t *testing.T) {
+func TestFetchGemsEndpoint_corruptedFiltered(t *testing.T) {
 	payload := ninjaResponse[ninjaGemLine]{
 		Lines: []ninjaGemLine{
 			{Name: "Arc", ChaosValue: 10, ListingCount: 100},
@@ -93,11 +92,12 @@ func TestFetchGems_corruptedFiltered(t *testing.T) {
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	gems, err := f.FetchGems(context.Background(), "Standard")
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	gems := result.GemData
 	if len(gems) != 1 {
 		t.Fatalf("got %d gems, want 1 (corrupted should be filtered)", len(gems))
 	}
@@ -106,7 +106,7 @@ func TestFetchGems_corruptedFiltered(t *testing.T) {
 	}
 }
 
-func TestFetchGems_heistFiltered(t *testing.T) {
+func TestFetchGemsEndpoint_heistFiltered(t *testing.T) {
 	payload := ninjaResponse[ninjaGemLine]{
 		Lines: []ninjaGemLine{
 			{Name: "Arc", ChaosValue: 10, ListingCount: 100},
@@ -120,11 +120,12 @@ func TestFetchGems_heistFiltered(t *testing.T) {
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	gems, err := f.FetchGems(context.Background(), "Standard")
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	gems := result.GemData
 	if len(gems) != 1 {
 		t.Fatalf("got %d gems, want 1 (Heist gem should be filtered)", len(gems))
 	}
@@ -133,7 +134,7 @@ func TestFetchGems_heistFiltered(t *testing.T) {
 	}
 }
 
-func TestFetchGems_transfiguredDetection(t *testing.T) {
+func TestFetchGemsEndpoint_transfiguredDetection(t *testing.T) {
 	payload := ninjaResponse[ninjaGemLine]{
 		Lines: []ninjaGemLine{
 			gemLine("Arc of Surging", "", 200, 10, "alt_lightning"),
@@ -147,11 +148,12 @@ func TestFetchGems_transfiguredDetection(t *testing.T) {
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	gems, err := f.FetchGems(context.Background(), "Standard")
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	gems := result.GemData
 	if len(gems) != 2 {
 		t.Fatalf("got %d gems, want 2", len(gems))
 	}
@@ -164,7 +166,7 @@ func TestFetchGems_transfiguredDetection(t *testing.T) {
 	}
 }
 
-func TestFetchGems_emptyResponse(t *testing.T) {
+func TestFetchGemsEndpoint_emptyResponse(t *testing.T) {
 	payload := ninjaResponse[ninjaGemLine]{Lines: []ninjaGemLine{}}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -173,24 +175,24 @@ func TestFetchGems_emptyResponse(t *testing.T) {
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	gems, err := f.FetchGems(context.Background(), "Standard")
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(gems) != 0 {
-		t.Errorf("got %d gems, want 0", len(gems))
+	if len(result.GemData) != 0 {
+		t.Errorf("got %d gems, want 0", len(result.GemData))
 	}
 }
 
-func TestFetchGems_malformedJSON(t *testing.T) {
+func TestFetchGemsEndpoint_malformedJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("{not valid json"))
 	}))
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	_, err := f.FetchGems(context.Background(), "Standard")
+	_, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
 	if err == nil {
 		t.Fatal("expected error for malformed JSON, got nil")
 	}
@@ -199,14 +201,14 @@ func TestFetchGems_malformedJSON(t *testing.T) {
 	}
 }
 
-func TestFetchGems_httpError(t *testing.T) {
+func TestFetchGemsEndpoint_httpError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	_, err := f.FetchGems(context.Background(), "Standard")
+	_, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
 	if err == nil {
 		t.Fatal("expected error for 503 response, got nil")
 	}
@@ -215,7 +217,7 @@ func TestFetchGems_httpError(t *testing.T) {
 	}
 }
 
-func TestFetchCurrency_validResponse(t *testing.T) {
+func TestFetchCurrencyEndpoint_validResponse(t *testing.T) {
 	payload := ninjaResponse[ninjaCurrencyLine]{
 		Lines: []ninjaCurrencyLine{
 			{
@@ -241,16 +243,16 @@ func TestFetchCurrency_validResponse(t *testing.T) {
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	currencies, err := f.FetchCurrency(context.Background(), "Standard")
+	result, err := f.FetchCurrencyEndpoint(context.Background(), "Standard", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	currencies := result.CurrencyData
 	if len(currencies) != 2 {
 		t.Fatalf("got %d currencies, want 2", len(currencies))
 	}
 
-	// Verify field mapping for Divine.
 	c := currencies[0]
 	if c.CurrencyID != "divine" {
 		t.Errorf("CurrencyID = %q, want %q", c.CurrencyID, "divine")
@@ -262,13 +264,12 @@ func TestFetchCurrency_validResponse(t *testing.T) {
 		t.Errorf("SparklineChange = %v, want %v", c.SparklineChange, -2.3)
 	}
 
-	// Verify second currency.
 	if currencies[1].CurrencyID != "exalted" {
 		t.Errorf("second CurrencyID = %q, want %q", currencies[1].CurrencyID, "exalted")
 	}
 }
 
-func TestFetchCurrency_emptyResponse(t *testing.T) {
+func TestFetchCurrencyEndpoint_emptyResponse(t *testing.T) {
 	payload := ninjaResponse[ninjaCurrencyLine]{Lines: []ninjaCurrencyLine{}}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -277,24 +278,24 @@ func TestFetchCurrency_emptyResponse(t *testing.T) {
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	currencies, err := f.FetchCurrency(context.Background(), "Standard")
+	result, err := f.FetchCurrencyEndpoint(context.Background(), "Standard", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(currencies) != 0 {
-		t.Errorf("got %d currencies, want 0", len(currencies))
+	if len(result.CurrencyData) != 0 {
+		t.Errorf("got %d currencies, want 0", len(result.CurrencyData))
 	}
 }
 
-func TestFetchCurrency_malformedJSON(t *testing.T) {
+func TestFetchCurrencyEndpoint_malformedJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("{{bad"))
 	}))
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	_, err := f.FetchCurrency(context.Background(), "Standard")
+	_, err := f.FetchCurrencyEndpoint(context.Background(), "Standard", "")
 	if err == nil {
 		t.Fatal("expected error for malformed JSON, got nil")
 	}
@@ -303,7 +304,7 @@ func TestFetchCurrency_malformedJSON(t *testing.T) {
 	}
 }
 
-func TestFetchGems_requestIncludesLeague(t *testing.T) {
+func TestFetchGemsEndpoint_requestIncludesLeague(t *testing.T) {
 	var receivedPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedPath = r.URL.String()
@@ -312,7 +313,7 @@ func TestFetchGems_requestIncludesLeague(t *testing.T) {
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	_, _ = f.FetchGems(context.Background(), "Mirage")
+	_, _ = f.FetchGemsEndpoint(context.Background(), "Mirage", "")
 
 	if !strings.Contains(receivedPath, "league=Mirage") {
 		t.Errorf("request path = %q, want league=Mirage parameter", receivedPath)
@@ -322,7 +323,7 @@ func TestFetchGems_requestIncludesLeague(t *testing.T) {
 	}
 }
 
-func TestFetchGems_requestIncludesUserAgent(t *testing.T) {
+func TestFetchGemsEndpoint_requestIncludesUserAgent(t *testing.T) {
 	var receivedUserAgent string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedUserAgent = r.Header.Get("User-Agent")
@@ -331,14 +332,14 @@ func TestFetchGems_requestIncludesUserAgent(t *testing.T) {
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	_, _ = f.FetchGems(context.Background(), "Standard")
+	_, _ = f.FetchGemsEndpoint(context.Background(), "Standard", "")
 
 	if receivedUserAgent != ninjaUserAgent {
 		t.Errorf("User-Agent = %q, want %q", receivedUserAgent, ninjaUserAgent)
 	}
 }
 
-func TestFetchCurrency_requestIncludesUserAgent(t *testing.T) {
+func TestFetchCurrencyEndpoint_requestIncludesUserAgent(t *testing.T) {
 	var receivedUserAgent string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedUserAgent = r.Header.Get("User-Agent")
@@ -347,7 +348,7 @@ func TestFetchCurrency_requestIncludesUserAgent(t *testing.T) {
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	_, _ = f.FetchCurrency(context.Background(), "Standard")
+	_, _ = f.FetchCurrencyEndpoint(context.Background(), "Standard", "")
 
 	if receivedUserAgent != ninjaUserAgent {
 		t.Errorf("User-Agent = %q, want %q", receivedUserAgent, ninjaUserAgent)
@@ -364,8 +365,7 @@ func newTestResolver(colors map[string]string) *gemcolor.Resolver {
 	return gemcolor.NewResolverFromMap(m)
 }
 
-func TestFetchGems_resolverPopulatesGemColor(t *testing.T) {
-	// When a resolver is provided, FetchGems should populate GemColor from the resolver.
+func TestFetchGemsEndpoint_resolverPopulatesGemColor(t *testing.T) {
 	payload := ninjaResponse[ninjaGemLine]{
 		Lines: []ninjaGemLine{
 			gemLine("Arc", "20/20", 15.5, 300, "gem"),
@@ -385,11 +385,12 @@ func TestFetchGems_resolverPopulatesGemColor(t *testing.T) {
 
 	f := NewNinjaFetcher(resolver)
 	f.baseURL = server.URL
-	gems, err := f.FetchGems(context.Background(), "Standard")
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	gems := result.GemData
 	if len(gems) != 2 {
 		t.Fatalf("got %d gems, want 2", len(gems))
 	}
@@ -402,8 +403,7 @@ func TestFetchGems_resolverPopulatesGemColor(t *testing.T) {
 	}
 }
 
-func TestFetchGems_resolverUnresolvedGemColorEmpty(t *testing.T) {
-	// When the resolver cannot resolve a gem, GemColor should be empty.
+func TestFetchGemsEndpoint_resolverUnresolvedGemColorEmpty(t *testing.T) {
 	payload := ninjaResponse[ninjaGemLine]{
 		Lines: []ninjaGemLine{
 			gemLine("Unknown Gem", "", 10.0, 50, "gem"),
@@ -415,15 +415,16 @@ func TestFetchGems_resolverUnresolvedGemColorEmpty(t *testing.T) {
 	}))
 	defer server.Close()
 
-	resolver := newTestResolver(map[string]string{}) // no known gems
+	resolver := newTestResolver(map[string]string{})
 
 	f := NewNinjaFetcher(resolver)
 	f.baseURL = server.URL
-	gems, err := f.FetchGems(context.Background(), "Standard")
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	gems := result.GemData
 	if len(gems) != 1 {
 		t.Fatalf("got %d gems, want 1", len(gems))
 	}
@@ -432,25 +433,23 @@ func TestFetchGems_resolverUnresolvedGemColorEmpty(t *testing.T) {
 	}
 }
 
-func TestFetchGems_contextCancellation(t *testing.T) {
-	// A cancelled context should propagate through the HTTP call and return an error.
+func TestFetchGemsEndpoint_contextCancellation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Delay response so cancellation can take effect.
 		<-r.Context().Done()
 	}))
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
 	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // cancel immediately
+	cancel()
 
-	_, err := f.FetchGems(ctx, "Standard")
+	_, err := f.FetchGemsEndpoint(ctx, "Standard", "")
 	if err == nil {
 		t.Fatal("expected error for cancelled context, got nil")
 	}
 }
 
-func TestFetchCurrency_requestIncludesLeague(t *testing.T) {
+func TestFetchCurrencyEndpoint_requestIncludesLeague(t *testing.T) {
 	var receivedPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		receivedPath = r.URL.String()
@@ -459,12 +458,69 @@ func TestFetchCurrency_requestIncludesLeague(t *testing.T) {
 	defer server.Close()
 
 	f := testNinjaFetcher(t, server)
-	_, _ = f.FetchCurrency(context.Background(), "Mirage")
+	_, _ = f.FetchCurrencyEndpoint(context.Background(), "Mirage", "")
 
 	if !strings.Contains(receivedPath, "league=Mirage") {
 		t.Errorf("request path = %q, want league=Mirage parameter", receivedPath)
 	}
 	if !strings.Contains(receivedPath, "type=Currency") {
 		t.Errorf("request path = %q, want type=Currency parameter", receivedPath)
+	}
+}
+
+func TestFetchGemsEndpoint_304NotModified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") == `"abc123"` {
+			w.Header().Set("ETag", `"abc123"`)
+			w.Header().Set("Age", "500")
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		json.NewEncoder(w).Encode(ninjaResponse[ninjaGemLine]{})
+	}))
+	defer server.Close()
+
+	f := testNinjaFetcher(t, server)
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", `"abc123"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.NotModified {
+		t.Error("expected NotModified = true")
+	}
+	if result.ETag != `"abc123"` {
+		t.Errorf("ETag = %q, want %q", result.ETag, `"abc123"`)
+	}
+	if result.Age != 500 {
+		t.Errorf("Age = %d, want 500", result.Age)
+	}
+}
+
+func TestFetchGemsEndpoint_parsesETagAndAge(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"xyz789"`)
+		w.Header().Set("Age", "1200")
+		json.NewEncoder(w).Encode(ninjaResponse[ninjaGemLine]{
+			Lines: []ninjaGemLine{gemLine("Arc", "20/20", 10, 100, "gem")},
+		})
+	}))
+	defer server.Close()
+
+	f := testNinjaFetcher(t, server)
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.NotModified {
+		t.Error("expected NotModified = false for 200 response")
+	}
+	if result.ETag != `"xyz789"` {
+		t.Errorf("ETag = %q, want %q", result.ETag, `"xyz789"`)
+	}
+	if result.Age != 1200 {
+		t.Errorf("Age = %d, want 1200", result.Age)
+	}
+	if len(result.GemData) != 1 {
+		t.Errorf("got %d gems, want 1", len(result.GemData))
 	}
 }

--- a/internal/collector/ninja_test.go
+++ b/internal/collector/ninja_test.go
@@ -524,3 +524,186 @@ func TestFetchGemsEndpoint_parsesETagAndAge(t *testing.T) {
 		t.Errorf("got %d gems, want 1", len(result.GemData))
 	}
 }
+
+func TestFetchGemsEndpoint_noIfNoneMatchWhenEtagEmpty(t *testing.T) {
+	var receivedIfNoneMatch string
+	var headerPresent bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedIfNoneMatch = r.Header.Get("If-None-Match")
+		_, headerPresent = r.Header["If-None-Match"]
+		json.NewEncoder(w).Encode(ninjaResponse[ninjaGemLine]{
+			Lines: []ninjaGemLine{gemLine("Arc", "20/20", 10, 100, "gem")},
+		})
+	}))
+	defer server.Close()
+
+	f := testNinjaFetcher(t, server)
+	_, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if headerPresent {
+		t.Errorf("If-None-Match header should not be present when etag is empty, got %q", receivedIfNoneMatch)
+	}
+}
+
+func TestFetchGemsEndpoint_ifNoneMatchHeaderSentWithEtag(t *testing.T) {
+	var receivedIfNoneMatch string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedIfNoneMatch = r.Header.Get("If-None-Match")
+		w.Header().Set("ETag", `"test-etag"`)
+		w.WriteHeader(http.StatusNotModified)
+	}))
+	defer server.Close()
+
+	f := testNinjaFetcher(t, server)
+	_, err := f.FetchGemsEndpoint(context.Background(), "Standard", `"test-etag"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedIfNoneMatch != `"test-etag"` {
+		t.Errorf("If-None-Match = %q, want %q", receivedIfNoneMatch, `"test-etag"`)
+	}
+}
+
+func TestFetchGemsEndpoint_missingAgeHeaderReturnsZero(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No Age header set.
+		w.Header().Set("ETag", `"no-age"`)
+		json.NewEncoder(w).Encode(ninjaResponse[ninjaGemLine]{
+			Lines: []ninjaGemLine{gemLine("Arc", "20/20", 10, 100, "gem")},
+		})
+	}))
+	defer server.Close()
+
+	f := testNinjaFetcher(t, server)
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Age != 0 {
+		t.Errorf("Age = %d, want 0 when Age header is missing", result.Age)
+	}
+}
+
+func TestFetchGemsEndpoint_invalidAgeHeaderReturnsZero(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Age", "not-a-number")
+		w.Header().Set("ETag", `"invalid-age"`)
+		json.NewEncoder(w).Encode(ninjaResponse[ninjaGemLine]{
+			Lines: []ninjaGemLine{gemLine("Arc", "20/20", 10, 100, "gem")},
+		})
+	}))
+	defer server.Close()
+
+	f := testNinjaFetcher(t, server)
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Age != 0 {
+		t.Errorf("Age = %d, want 0 when Age header is invalid", result.Age)
+	}
+}
+
+func TestFetchGemsEndpoint_etagCapturedFromResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"captured-etag"`)
+		w.Header().Set("Age", "100")
+		json.NewEncoder(w).Encode(ninjaResponse[ninjaGemLine]{
+			Lines: []ninjaGemLine{gemLine("Arc", "20/20", 10, 100, "gem")},
+		})
+	}))
+	defer server.Close()
+
+	f := testNinjaFetcher(t, server)
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.ETag != `"captured-etag"` {
+		t.Errorf("ETag = %q, want %q", result.ETag, `"captured-etag"`)
+	}
+}
+
+func TestFetchCurrencyEndpoint_populatedWithETagAndAge(t *testing.T) {
+	payload := ninjaResponse[ninjaCurrencyLine]{
+		Lines: []ninjaCurrencyLine{
+			{
+				CurrencyTypeName: "divine",
+				ChaosEquivalent:  210.5,
+				Sparkline: struct {
+					TotalChange float64 `json:"totalChange"`
+				}{TotalChange: -2.3},
+			},
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("ETag", `"currency-etag"`)
+		w.Header().Set("Age", "900")
+		json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	f := testNinjaFetcher(t, server)
+	result, err := f.FetchCurrencyEndpoint(context.Background(), "Standard", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.NotModified {
+		t.Error("expected NotModified = false for 200 response")
+	}
+	if result.ETag != `"currency-etag"` {
+		t.Errorf("ETag = %q, want %q", result.ETag, `"currency-etag"`)
+	}
+	if result.Age != 900 {
+		t.Errorf("Age = %d, want 900", result.Age)
+	}
+	if len(result.CurrencyData) != 1 {
+		t.Fatalf("got %d currencies, want 1", len(result.CurrencyData))
+	}
+	if result.CurrencyData[0].CurrencyID != "divine" {
+		t.Errorf("CurrencyID = %q, want %q", result.CurrencyData[0].CurrencyID, "divine")
+	}
+	if result.CurrencyData[0].Chaos != 210.5 {
+		t.Errorf("Chaos = %v, want %v", result.CurrencyData[0].Chaos, 210.5)
+	}
+}
+
+func TestFetchCurrencyEndpoint_304NotModified(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("If-None-Match") == `"curr-etag"` {
+			w.Header().Set("ETag", `"curr-etag"`)
+			w.Header().Set("Age", "600")
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		json.NewEncoder(w).Encode(ninjaResponse[ninjaCurrencyLine]{})
+	}))
+	defer server.Close()
+
+	f := testNinjaFetcher(t, server)
+	result, err := f.FetchCurrencyEndpoint(context.Background(), "Standard", `"curr-etag"`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !result.NotModified {
+		t.Error("expected NotModified = true for 304 response")
+	}
+	if result.ETag != `"curr-etag"` {
+		t.Errorf("ETag = %q, want %q", result.ETag, `"curr-etag"`)
+	}
+	if result.Age != 600 {
+		t.Errorf("Age = %d, want 600", result.Age)
+	}
+}

--- a/internal/collector/ninja_test.go
+++ b/internal/collector/ninja_test.go
@@ -612,6 +612,27 @@ func TestFetchGemsEndpoint_invalidAgeHeaderReturnsZero(t *testing.T) {
 	}
 }
 
+func TestFetchGemsEndpoint_negativeAgeHeaderReturnsZero(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Age", "-5")
+		w.Header().Set("ETag", `"neg-age"`)
+		json.NewEncoder(w).Encode(ninjaResponse[ninjaGemLine]{
+			Lines: []ninjaGemLine{gemLine("Arc", "20/20", 10, 100, "gem")},
+		})
+	}))
+	defer server.Close()
+
+	f := testNinjaFetcher(t, server)
+	result, err := f.FetchGemsEndpoint(context.Background(), "Standard", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Age != 0 {
+		t.Errorf("Age = %d, want 0 when Age header is negative", result.Age)
+	}
+}
+
 func TestFetchGemsEndpoint_etagCapturedFromResponse(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("ETag", `"captured-etag"`)

--- a/internal/collector/repository.go
+++ b/internal/collector/repository.go
@@ -9,8 +9,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// SnapshotStore defines the interface that Repository implements.
-// Used by the Scheduler to decouple from the concrete pgxpool-backed Repository.
+// SnapshotStore defines the persistence interface for snapshot data. Used by
+// main.go to wire endpoint closures and by test mocks.
 type SnapshotStore interface {
 	LastGemSnapshotTime(ctx context.Context) (time.Time, error)
 	LastCurrencySnapshotTime(ctx context.Context) (time.Time, error)

--- a/internal/collector/repository.go
+++ b/internal/collector/repository.go
@@ -13,6 +13,7 @@ import (
 // Used by the Scheduler to decouple from the concrete pgxpool-backed Repository.
 type SnapshotStore interface {
 	LastGemSnapshotTime(ctx context.Context) (time.Time, error)
+	LastCurrencySnapshotTime(ctx context.Context) (time.Time, error)
 	InsertGemSnapshots(ctx context.Context, snapTime time.Time, snapshots []GemSnapshot) (int, error)
 	InsertCurrencySnapshots(ctx context.Context, snapTime time.Time, snapshots []CurrencySnapshot) (int, error)
 	LatestSnapshot(ctx context.Context) (*SnapshotSummary, error)
@@ -35,6 +36,20 @@ func (r *Repository) LastGemSnapshotTime(ctx context.Context) (time.Time, error)
 	err := r.pool.QueryRow(ctx, "SELECT MAX(time) FROM gem_snapshots").Scan(&t)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("repo: last gem snapshot time: %w", err)
+	}
+	if t == nil {
+		return time.Time{}, nil
+	}
+	return *t, nil
+}
+
+// LastCurrencySnapshotTime returns the most recent currency snapshot timestamp.
+// Returns the zero time if no snapshots exist.
+func (r *Repository) LastCurrencySnapshotTime(ctx context.Context) (time.Time, error) {
+	var t *time.Time
+	err := r.pool.QueryRow(ctx, "SELECT MAX(time) FROM currency_snapshots").Scan(&t)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("repo: last currency snapshot time: %w", err)
 	}
 	if t == nil {
 		return time.Time{}, nil

--- a/internal/collector/repository.go
+++ b/internal/collector/repository.go
@@ -9,8 +9,9 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// SnapshotStore defines the persistence interface for snapshot data. Used by
-// main.go to wire endpoint closures and by test mocks.
+// SnapshotStore defines the persistence interface for snapshot data. Used for
+// compile-time conformance checks on Repository and for future integration
+// test mocks. Main.go wires endpoint closures directly via Repository methods.
 type SnapshotStore interface {
 	LastGemSnapshotTime(ctx context.Context) (time.Time, error)
 	LastCurrencySnapshotTime(ctx context.Context) (time.Time, error)

--- a/internal/collector/repository_test.go
+++ b/internal/collector/repository_test.go
@@ -6,39 +6,6 @@ import (
 	"time"
 )
 
-// mockStore implements SnapshotStore with configurable function fields.
-// Used by scheduler tests to inject controlled behavior without a database.
-type mockStore struct {
-	LastGemSnapshotTimeFn      func(ctx context.Context) (time.Time, error)
-	LastCurrencySnapshotTimeFn func(ctx context.Context) (time.Time, error)
-	InsertGemSnapshotsFn       func(ctx context.Context, snapTime time.Time, snapshots []GemSnapshot) (int, error)
-	InsertCurrencySnapshotsFn  func(ctx context.Context, snapTime time.Time, snapshots []CurrencySnapshot) (int, error)
-	LatestSnapshotFn           func(ctx context.Context) (*SnapshotSummary, error)
-}
-
-func (m *mockStore) LastGemSnapshotTime(ctx context.Context) (time.Time, error) {
-	return m.LastGemSnapshotTimeFn(ctx)
-}
-
-func (m *mockStore) LastCurrencySnapshotTime(ctx context.Context) (time.Time, error) {
-	if m.LastCurrencySnapshotTimeFn != nil {
-		return m.LastCurrencySnapshotTimeFn(ctx)
-	}
-	return time.Time{}, nil
-}
-
-func (m *mockStore) InsertGemSnapshots(ctx context.Context, snapTime time.Time, snapshots []GemSnapshot) (int, error) {
-	return m.InsertGemSnapshotsFn(ctx, snapTime, snapshots)
-}
-
-func (m *mockStore) InsertCurrencySnapshots(ctx context.Context, snapTime time.Time, snapshots []CurrencySnapshot) (int, error) {
-	return m.InsertCurrencySnapshotsFn(ctx, snapTime, snapshots)
-}
-
-func (m *mockStore) LatestSnapshot(ctx context.Context) (*SnapshotSummary, error) {
-	return m.LatestSnapshotFn(ctx)
-}
-
 // Compile-time check that Repository satisfies SnapshotStore.
 var _ SnapshotStore = (*Repository)(nil)
 

--- a/internal/collector/repository_test.go
+++ b/internal/collector/repository_test.go
@@ -9,14 +9,22 @@ import (
 // mockStore implements SnapshotStore with configurable function fields.
 // Used by scheduler tests to inject controlled behavior without a database.
 type mockStore struct {
-	LastGemSnapshotTimeFn     func(ctx context.Context) (time.Time, error)
-	InsertGemSnapshotsFn      func(ctx context.Context, snapTime time.Time, snapshots []GemSnapshot) (int, error)
-	InsertCurrencySnapshotsFn func(ctx context.Context, snapTime time.Time, snapshots []CurrencySnapshot) (int, error)
-	LatestSnapshotFn          func(ctx context.Context) (*SnapshotSummary, error)
+	LastGemSnapshotTimeFn      func(ctx context.Context) (time.Time, error)
+	LastCurrencySnapshotTimeFn func(ctx context.Context) (time.Time, error)
+	InsertGemSnapshotsFn       func(ctx context.Context, snapTime time.Time, snapshots []GemSnapshot) (int, error)
+	InsertCurrencySnapshotsFn  func(ctx context.Context, snapTime time.Time, snapshots []CurrencySnapshot) (int, error)
+	LatestSnapshotFn           func(ctx context.Context) (*SnapshotSummary, error)
 }
 
 func (m *mockStore) LastGemSnapshotTime(ctx context.Context) (time.Time, error) {
 	return m.LastGemSnapshotTimeFn(ctx)
+}
+
+func (m *mockStore) LastCurrencySnapshotTime(ctx context.Context) (time.Time, error) {
+	if m.LastCurrencySnapshotTimeFn != nil {
+		return m.LastCurrencySnapshotTimeFn(ctx)
+	}
+	return time.Time{}, nil
 }
 
 func (m *mockStore) InsertGemSnapshots(ctx context.Context, snapTime time.Time, snapshots []GemSnapshot) (int, error) {

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -51,6 +51,11 @@ func NewScheduler(
 		if err := ep.Validate(); err != nil {
 			return nil, fmt.Errorf("scheduler: endpoint %d: %w", i, err)
 		}
+		if ep.Source == "" {
+			logger.Warn("endpoint has empty Source, rate limiting will be skipped",
+				"endpoint", ep.Name,
+			)
+		}
 	}
 
 	// Build per-source semaphores (limits concurrent requests to the same API
@@ -64,8 +69,12 @@ func NewScheduler(
 		}
 	}
 
+	// Defensive copy to prevent caller mutations from affecting the scheduler.
+	eps := make([]EndpointConfig, len(endpoints))
+	copy(eps, endpoints)
+
 	return &Scheduler{
-		endpoints:     endpoints,
+		endpoints:     eps,
 		resolver:      resolver,
 		league:        league,
 		mercureURL:    mercureURL,
@@ -130,11 +139,17 @@ func (s *Scheduler) startupJitter(ep EndpointConfig) time.Duration {
 	return ep.JitterMin + time.Duration(rand.Int64N(int64(spread)))
 }
 
+// endpointState holds per-goroutine mutable state for a running endpoint.
+// Encapsulates the ETag and retry counter that persist across fetch cycles.
+type endpointState struct {
+	lastETag   string
+	retryCount int
+}
+
 // runEndpoint is the core loop for a single endpoint. It handles startup
 // staleness checks, fetching, storing, and cache-aware sleep calculation.
 func (s *Scheduler) runEndpoint(ctx context.Context, ep EndpointConfig) {
-	var lastETag string
-	retryCount := 0
+	state := &endpointState{}
 
 	// Startup staleness check: if recent data exists, skip the first fetch.
 	if sleep := s.checkStaleness(ctx, ep); sleep > 0 {
@@ -154,7 +169,7 @@ func (s *Scheduler) runEndpoint(ctx context.Context, ep EndpointConfig) {
 			return
 		}
 
-		sleep := s.fetchAndStore(ctx, ep, &lastETag, &retryCount)
+		sleep := s.fetchAndStore(ctx, ep, state)
 
 		select {
 		case <-ctx.Done():
@@ -167,6 +182,11 @@ func (s *Scheduler) runEndpoint(ctx context.Context, ep EndpointConfig) {
 // checkStaleness checks whether a recent snapshot exists for the endpoint. If
 // the data is fresh enough (within MaxAge), it returns the calculated sleep
 // duration. Returns 0 to indicate an immediate fetch is needed.
+//
+// On StalenessFunc error, falls back to immediate fetch. This assumes errors
+// are transient (e.g., container startup order). Permanent DB errors (missing
+// table, wrong permissions) will cause repeated fetch-store-fail cycles at
+// MinSleep intervals until the DB issue is resolved.
 func (s *Scheduler) checkStaleness(ctx context.Context, ep EndpointConfig) time.Duration {
 	if ep.StalenessFunc == nil {
 		return 0
@@ -200,7 +220,7 @@ func (s *Scheduler) checkStaleness(ctx context.Context, ep EndpointConfig) time.
 
 // fetchAndStore executes one fetch-store cycle and returns the sleep duration
 // before the next cycle.
-func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastETag *string, retryCount *int) time.Duration {
+func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, state *endpointState) time.Duration {
 	// Acquire source semaphore; defer release to guard against panics.
 	sem := s.semaphores[ep.Source]
 	if sem != nil {
@@ -212,7 +232,7 @@ func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastET
 		}
 	}
 
-	result, err := ep.FetchFunc(ctx, s.league, *lastETag)
+	result, err := ep.FetchFunc(ctx, s.league, state.lastETag)
 
 	if err != nil {
 		s.logger.Error("fetch failed",
@@ -232,26 +252,26 @@ func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastET
 
 	// 304 Not Modified — data hasn't changed.
 	if result.NotModified {
-		*retryCount++
+		state.retryCount++
 		s.logger.Info("source returned 304 Not Modified",
 			"endpoint", ep.Name,
-			"retries", *retryCount,
+			"retries", state.retryCount,
 		)
-		if *retryCount > ep.MaxRetries {
+		if state.retryCount > ep.MaxRetries {
 			s.logger.Info("max 304 retries exceeded, falling back",
 				"endpoint", ep.Name,
 				"fallback", ep.FallbackInterval.String(),
 			)
-			*retryCount = 0
+			state.retryCount = 0
 			return ep.FallbackInterval
 		}
 		return ep.MinSleep
 	}
 
 	// 200 OK — new data available.
-	*retryCount = 0
+	state.retryCount = 0
 	if result.ETag != "" {
-		*lastETag = result.ETag
+		state.lastETag = result.ETag
 	}
 
 	snapTime := time.Now().UTC()
@@ -284,7 +304,7 @@ func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastET
 
 // calculateSleep computes the optimal sleep duration based on the endpoint's
 // MaxAge and the response's Age header. Clamps to [MinSleep, FallbackInterval].
-// Logs a warning when the CDN-reported age exceeds MaxAge (stale-while-revalidate).
+// Logs at debug level when the CDN-reported age exceeds MaxAge (stale-while-revalidate).
 func (s *Scheduler) calculateSleep(ep EndpointConfig, ageSeconds int) time.Duration {
 	maxAgeSec := int(ep.MaxAge.Seconds())
 	if maxAgeSec > 0 && ageSeconds > maxAgeSec {

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -6,11 +6,17 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand/v2"
+	"runtime/debug"
 	"sync"
 	"time"
 
 	"profitofexile/internal/price/gemcolor"
 )
+
+// perSourceSemaphoreCapacity is the number of concurrent requests allowed per
+// source (e.g., "ninja"). Limits concurrent requests to the same API to avoid
+// rate-limiting.
+const perSourceSemaphoreCapacity = 3
 
 // Scheduler orchestrates price data collection with independent goroutines per
 // endpoint. Each endpoint runs its own fetch-sleep loop with cache-aware sleep
@@ -39,27 +45,21 @@ func NewScheduler(
 		return nil, fmt.Errorf("scheduler: at least one endpoint is required")
 	}
 
-	// Validate required fields on each endpoint to catch misconfiguration at
-	// startup rather than as a runtime panic inside a goroutine.
+	// Validate each endpoint configuration at startup to surface
+	// misconfiguration early rather than as a runtime panic inside a goroutine.
 	for i, ep := range endpoints {
-		if ep.Name == "" {
-			return nil, fmt.Errorf("scheduler: endpoint %d has empty Name", i)
-		}
-		if ep.FetchFunc == nil {
-			return nil, fmt.Errorf("scheduler: endpoint %d (%s) has nil FetchFunc", i, ep.Name)
-		}
-		if ep.FallbackInterval <= 0 {
-			return nil, fmt.Errorf("scheduler: endpoint %d (%s) has non-positive FallbackInterval", i, ep.Name)
+		if err := ep.Validate(); err != nil {
+			return nil, fmt.Errorf("scheduler: endpoint %d: %w", i, err)
 		}
 	}
 
-	// Build per-source semaphores (capacity 3 per source — allows all current
-	// endpoints plus headroom for future ones without blocking).
+	// Build per-source semaphores (limits concurrent requests to the same API
+	// to avoid rate-limiting).
 	sems := make(map[string]chan struct{})
 	for _, ep := range endpoints {
 		if ep.Source != "" {
 			if _, ok := sems[ep.Source]; !ok {
-				sems[ep.Source] = make(chan struct{}, 3)
+				sems[ep.Source] = make(chan struct{}, perSourceSemaphoreCapacity)
 			}
 		}
 	}
@@ -87,9 +87,10 @@ func (s *Scheduler) Run(ctx context.Context) error {
 			defer wg.Done()
 			defer func() {
 				if r := recover(); r != nil {
-					s.logger.Error("endpoint goroutine panicked",
+					s.logger.Error("endpoint goroutine panicked — this endpoint will stop collecting permanently",
 						"endpoint", ep.Name,
 						"panic", r,
+						"stack", string(debug.Stack()),
 					)
 				}
 			}()
@@ -268,10 +269,14 @@ func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastET
 			"endpoint", ep.Name,
 			"inserted", inserted,
 		)
-	}
 
-	// Post-collect: conditional gem color upsert (gems only) + Mercure publish.
-	s.postCollect(ctx, ep.Name, snapTime)
+		// Post-collect: conditional gem color upsert (gems only) + Mercure publish.
+		s.postCollect(ctx, ep.Name, snapTime)
+	} else {
+		s.logger.Warn("no StoreFunc configured, fetch result discarded",
+			"endpoint", ep.Name,
+		)
+	}
 
 	// Calculate sleep from cache headers.
 	return s.calculateSleep(ep, result.Age)
@@ -283,7 +288,7 @@ func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastET
 func (s *Scheduler) calculateSleep(ep EndpointConfig, ageSeconds int) time.Duration {
 	maxAgeSec := int(ep.MaxAge.Seconds())
 	if maxAgeSec > 0 && ageSeconds > maxAgeSec {
-		s.logger.Warn("response age exceeds max-age (stale-while-revalidate)",
+		s.logger.Debug("response age exceeds max-age (stale-while-revalidate)",
 			"endpoint", ep.Name,
 			"age", ageSeconds,
 			"maxAge", maxAgeSec,

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -39,7 +39,22 @@ func NewScheduler(
 		return nil, fmt.Errorf("scheduler: at least one endpoint is required")
 	}
 
-	// Build per-source semaphores (capacity 3 per source).
+	// Validate required fields on each endpoint to catch misconfiguration at
+	// startup rather than as a runtime panic inside a goroutine.
+	for i, ep := range endpoints {
+		if ep.Name == "" {
+			return nil, fmt.Errorf("scheduler: endpoint %d has empty Name", i)
+		}
+		if ep.FetchFunc == nil {
+			return nil, fmt.Errorf("scheduler: endpoint %d (%s) has nil FetchFunc", i, ep.Name)
+		}
+		if ep.FallbackInterval <= 0 {
+			return nil, fmt.Errorf("scheduler: endpoint %d (%s) has non-positive FallbackInterval", i, ep.Name)
+		}
+	}
+
+	// Build per-source semaphores (capacity 3 per source — allows all current
+	// endpoints plus headroom for future ones without blocking).
 	sems := make(map[string]chan struct{})
 	for _, ep := range endpoints {
 		if ep.Source != "" {
@@ -70,6 +85,14 @@ func (s *Scheduler) Run(ctx context.Context) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					s.logger.Error("endpoint goroutine panicked",
+						"endpoint", ep.Name,
+						"panic", r,
+					)
+				}
+			}()
 
 			// Startup jitter: random delay between JitterMin and JitterMax.
 			jitter := s.startupJitter(ep)
@@ -103,7 +126,7 @@ func (s *Scheduler) startupJitter(ep EndpointConfig) time.Duration {
 		return 0
 	}
 	spread := ep.JitterMax - ep.JitterMin
-	return ep.JitterMin + time.Duration(rand.Int63n(int64(spread)))
+	return ep.JitterMin + time.Duration(rand.Int64N(int64(spread)))
 }
 
 // runEndpoint is the core loop for a single endpoint. It handles startup
@@ -177,11 +200,12 @@ func (s *Scheduler) checkStaleness(ctx context.Context, ep EndpointConfig) time.
 // fetchAndStore executes one fetch-store cycle and returns the sleep duration
 // before the next cycle.
 func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastETag *string, retryCount *int) time.Duration {
-	// Acquire source semaphore.
+	// Acquire source semaphore; defer release to guard against panics.
 	sem := s.semaphores[ep.Source]
 	if sem != nil {
 		select {
 		case sem <- struct{}{}:
+			defer func() { <-sem }()
 		case <-ctx.Done():
 			return 0
 		}
@@ -189,13 +213,16 @@ func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastET
 
 	result, err := ep.FetchFunc(ctx, s.league, *lastETag)
 
-	// Release source semaphore.
-	if sem != nil {
-		<-sem
-	}
-
 	if err != nil {
 		s.logger.Error("fetch failed",
+			"endpoint", ep.Name,
+			"error", err,
+		)
+		return ep.FallbackInterval
+	}
+
+	if err := result.Validate(); err != nil {
+		s.logger.Error("invalid fetch result",
 			"endpoint", ep.Name,
 			"error", err,
 		)
@@ -231,19 +258,19 @@ func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastET
 	if ep.StoreFunc != nil {
 		inserted, err := ep.StoreFunc(ctx, snapTime, result)
 		if err != nil {
-			s.logger.Error("store failed",
+			s.logger.Error("store failed, skipping post-collect and retrying sooner",
 				"endpoint", ep.Name,
 				"error", err,
 			)
-		} else {
-			s.logger.Info("snapshot stored",
-				"endpoint", ep.Name,
-				"inserted", inserted,
-			)
+			return ep.MinSleep
 		}
+		s.logger.Info("snapshot stored",
+			"endpoint", ep.Name,
+			"inserted", inserted,
+		)
 	}
 
-	// Post-collect: gem color upsert + Mercure publish.
+	// Post-collect: conditional gem color upsert (gems only) + Mercure publish.
 	s.postCollect(ctx, ep.Name, snapTime)
 
 	// Calculate sleep from cache headers.

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -5,162 +5,298 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math/rand"
+	"sync"
 	"time"
 
 	"profitofexile/internal/price/gemcolor"
 )
 
-// Scheduler orchestrates periodic price data collection from external sources.
+// Scheduler orchestrates price data collection with independent goroutines per
+// endpoint. Each endpoint runs its own fetch-sleep loop with cache-aware sleep
+// calculation. Endpoints sharing a Source field share a rate-limit semaphore.
 type Scheduler struct {
-	repo          SnapshotStore
-	fetchers      []Fetcher
+	endpoints     []EndpointConfig
 	resolver      *gemcolor.Resolver
-	interval      time.Duration
 	league        string
 	mercureURL    string
 	mercureSecret string
 	logger        *slog.Logger
+	semaphores    map[string]chan struct{}
 }
 
-// NewScheduler creates a scheduler that runs collection at the given interval.
-// interval must be positive and fetchers must not be empty.
+// NewScheduler creates a scheduler that runs each endpoint in its own goroutine.
+// At least one endpoint is required.
 func NewScheduler(
-	repo SnapshotStore,
-	fetchers []Fetcher,
+	endpoints []EndpointConfig,
 	resolver *gemcolor.Resolver,
-	interval time.Duration,
 	league string,
 	mercureURL string,
 	mercureSecret string,
 	logger *slog.Logger,
 ) (*Scheduler, error) {
-	if interval <= 0 {
-		return nil, fmt.Errorf("scheduler: interval must be positive, got %s", interval)
+	if len(endpoints) == 0 {
+		return nil, fmt.Errorf("scheduler: at least one endpoint is required")
 	}
-	if len(fetchers) == 0 {
-		return nil, fmt.Errorf("scheduler: at least one fetcher is required")
+
+	// Build per-source semaphores (capacity 3 per source).
+	sems := make(map[string]chan struct{})
+	for _, ep := range endpoints {
+		if ep.Source != "" {
+			if _, ok := sems[ep.Source]; !ok {
+				sems[ep.Source] = make(chan struct{}, 3)
+			}
+		}
 	}
 
 	return &Scheduler{
-		repo:          repo,
-		fetchers:      fetchers,
+		endpoints:     endpoints,
 		resolver:      resolver,
-		interval:      interval,
 		league:        league,
 		mercureURL:    mercureURL,
 		mercureSecret: mercureSecret,
 		logger:        logger,
+		semaphores:    sems,
 	}, nil
 }
 
-// Run starts the collection loop. It checks for recent snapshots on startup to
-// avoid redundant API calls on rapid redeploys, then ticks at the configured
-// interval. Run blocks until ctx is cancelled.
+// Run launches a goroutine per endpoint with startup jitter, then blocks until
+// ctx is cancelled. All goroutines are waited on for clean shutdown.
 func (s *Scheduler) Run(ctx context.Context) error {
-	// Startup: check if a recent snapshot already exists.
-	last, err := s.repo.LastGemSnapshotTime(ctx)
-	if err != nil {
-		// DB check failed — fall through to collect anyway. If the DB is truly
-		// unreachable, collect() will independently report its own errors.
-		s.logger.Error("startup: failed to check last snapshot time (degraded startup, attempting collect)", "error", err)
-		s.collect(ctx)
-	} else if !last.IsZero() && time.Since(last) < s.interval {
-		s.logger.Info("recent snapshot exists, waiting for next tick",
-			"last", last.Format(time.RFC3339),
-			"age", time.Since(last).Round(time.Second).String(),
-		)
-	} else {
-		s.collect(ctx)
+	var wg sync.WaitGroup
+
+	for i := range s.endpoints {
+		ep := s.endpoints[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			// Startup jitter: random delay between JitterMin and JitterMax.
+			jitter := s.startupJitter(ep)
+			if jitter > 0 {
+				s.logger.Info("endpoint startup jitter",
+					"endpoint", ep.Name,
+					"jitter", jitter.Round(time.Millisecond).String(),
+				)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(jitter):
+				}
+			}
+
+			s.runEndpoint(ctx, ep)
+		}()
 	}
 
-	ticker := time.NewTicker(s.interval)
-	defer ticker.Stop()
+	<-ctx.Done()
+	s.logger.Info("scheduler stopping, waiting for endpoints to finish")
+	wg.Wait()
+	s.logger.Info("scheduler stopped")
+	return nil
+}
 
-	for {
+// startupJitter returns a random duration between ep.JitterMin and ep.JitterMax.
+// Returns 0 if JitterMax <= JitterMin or JitterMax is 0.
+func (s *Scheduler) startupJitter(ep EndpointConfig) time.Duration {
+	if ep.JitterMax <= ep.JitterMin || ep.JitterMax == 0 {
+		return 0
+	}
+	spread := ep.JitterMax - ep.JitterMin
+	return ep.JitterMin + time.Duration(rand.Int63n(int64(spread)))
+}
+
+// runEndpoint is the core loop for a single endpoint. It handles startup
+// staleness checks, fetching, storing, and cache-aware sleep calculation.
+func (s *Scheduler) runEndpoint(ctx context.Context, ep EndpointConfig) {
+	var lastETag string
+	retryCount := 0
+
+	// Startup staleness check: if recent data exists, skip the first fetch.
+	if sleep := s.checkStaleness(ctx, ep); sleep > 0 {
+		s.logger.Info("recent snapshot exists, sleeping before first fetch",
+			"endpoint", ep.Name,
+			"sleep", sleep.Round(time.Second).String(),
+		)
 		select {
 		case <-ctx.Done():
-			s.logger.Info("scheduler stopping")
-			return nil
-		case <-ticker.C:
-			s.collect(ctx)
+			return
+		case <-time.After(sleep):
+		}
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		sleep := s.fetchAndStore(ctx, ep, &lastETag, &retryCount)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(sleep):
 		}
 	}
 }
 
-// collect runs a single collection cycle across all fetchers.
-func (s *Scheduler) collect(ctx context.Context) {
-	if ctx.Err() != nil {
-		return
+// checkStaleness checks whether a recent snapshot exists for the endpoint. If
+// the data is fresh enough (within MaxAge), it returns the calculated sleep
+// duration. Returns 0 to indicate an immediate fetch is needed.
+func (s *Scheduler) checkStaleness(ctx context.Context, ep EndpointConfig) time.Duration {
+	if ep.StalenessFunc == nil {
+		return 0
 	}
 
-	start := time.Now().UTC()
-	snapTime := start
+	last, err := ep.StalenessFunc(ctx)
+	if err != nil {
+		s.logger.Error("startup staleness check failed, fetching immediately",
+			"endpoint", ep.Name,
+			"error", err,
+		)
+		return 0
+	}
 
-	totalGems := 0
-	totalCurrencies := 0
-	errorCount := 0
+	if last.IsZero() {
+		return 0
+	}
 
-	for i, fetcher := range s.fetchers {
-		// Fetch gems.
-		gems, err := fetcher.FetchGems(ctx, s.league)
-		if err != nil {
-			s.logger.Error("fetch gems failed", "fetcher", i, "error", err)
-			errorCount++
-		} else if len(gems) > 0 {
-			inserted, err := s.repo.InsertGemSnapshots(ctx, snapTime, gems)
-			if err != nil {
-				s.logger.Error("insert gem snapshots failed", "fetcher", i, "error", err)
-				errorCount++
-			} else {
-				totalGems += inserted
-			}
-		}
+	age := time.Since(last)
+	if age >= ep.MaxAge {
+		return 0
+	}
 
-		// Fetch currency.
-		currencies, err := fetcher.FetchCurrency(ctx, s.league)
-		if err != nil {
-			s.logger.Error("fetch currency failed", "fetcher", i, "error", err)
-			errorCount++
-		} else if len(currencies) > 0 {
-			inserted, err := s.repo.InsertCurrencySnapshots(ctx, snapTime, currencies)
-			if err != nil {
-				s.logger.Error("insert currency snapshots failed", "fetcher", i, "error", err)
-				errorCount++
-			} else {
-				totalCurrencies += inserted
-			}
+	// Data is fresh — calculate how long to wait before the next fetch.
+	sleep := ep.MaxAge - age + 5*time.Second
+	if sleep < ep.MinSleep {
+		sleep = ep.MinSleep
+	}
+	return sleep
+}
+
+// fetchAndStore executes one fetch-store cycle and returns the sleep duration
+// before the next cycle.
+func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastETag *string, retryCount *int) time.Duration {
+	// Acquire source semaphore.
+	sem := s.semaphores[ep.Source]
+	if sem != nil {
+		select {
+		case sem <- struct{}{}:
+		case <-ctx.Done():
+			return 0
 		}
 	}
 
-	// Persist newly resolved gem colors.
-	if s.resolver != nil {
+	result, err := ep.FetchFunc(ctx, s.league, *lastETag)
+
+	// Release source semaphore.
+	if sem != nil {
+		<-sem
+	}
+
+	if err != nil {
+		s.logger.Error("fetch failed",
+			"endpoint", ep.Name,
+			"error", err,
+		)
+		return ep.FallbackInterval
+	}
+
+	// 304 Not Modified — data hasn't changed.
+	if result.NotModified {
+		*retryCount++
+		s.logger.Info("source returned 304 Not Modified",
+			"endpoint", ep.Name,
+			"retries", *retryCount,
+		)
+		if *retryCount > ep.MaxRetries {
+			s.logger.Info("max 304 retries exceeded, falling back",
+				"endpoint", ep.Name,
+				"fallback", ep.FallbackInterval.String(),
+			)
+			*retryCount = 0
+			return ep.FallbackInterval
+		}
+		return 30 * time.Second
+	}
+
+	// 200 OK — new data available.
+	*retryCount = 0
+	if result.ETag != "" {
+		*lastETag = result.ETag
+	}
+
+	snapTime := time.Now().UTC()
+
+	if ep.StoreFunc != nil {
+		inserted, err := ep.StoreFunc(ctx, snapTime, result)
+		if err != nil {
+			s.logger.Error("store failed",
+				"endpoint", ep.Name,
+				"error", err,
+			)
+		} else {
+			s.logger.Info("snapshot stored",
+				"endpoint", ep.Name,
+				"inserted", inserted,
+			)
+		}
+	}
+
+	// Post-collect: gem color upsert + Mercure publish.
+	s.postCollect(ctx, ep.Name, snapTime)
+
+	// Calculate sleep from cache headers.
+	return s.calculateSleep(ep, result.Age)
+}
+
+// calculateSleep computes the optimal sleep duration based on the endpoint's
+// MaxAge and the response's Age header. Clamps to [MinSleep, FallbackInterval].
+func (s *Scheduler) calculateSleep(ep EndpointConfig, ageSeconds int) time.Duration {
+	ageDur := time.Duration(ageSeconds) * time.Second
+	sleep := ep.MaxAge - ageDur + 5*time.Second
+
+	if sleep < ep.MinSleep {
+		sleep = ep.MinSleep
+	}
+	if sleep > ep.FallbackInterval {
+		sleep = ep.FallbackInterval
+	}
+
+	return sleep
+}
+
+// postCollect handles actions after a successful fetch: Mercure publish for all
+// endpoints, gem color upsert for the gems endpoint only.
+func (s *Scheduler) postCollect(ctx context.Context, endpointName string, snapTime time.Time) {
+	// Gem color resolver — only for the gems endpoint.
+	if endpointName == EndpointNinjaGems && s.resolver != nil {
 		if err := s.resolver.UpsertDiscoveries(ctx); err != nil {
-			s.logger.Error("upsert gem color discoveries failed", "error", err)
-			errorCount++
+			s.logger.Error("upsert gem color discoveries failed",
+				"endpoint", endpointName,
+				"error", err,
+			)
 		}
 	}
 
-	// Publish Mercure event (non-fatal on failure).
-	// Marshal failure = programming bug (Error); publish failure = transient infra issue (Warn).
+	// Mercure publish (non-fatal on failure).
 	payload, err := json.Marshal(map[string]string{
 		"league":    s.league,
+		"endpoint":  endpointName,
 		"timestamp": snapTime.Format(time.RFC3339),
 	})
 	if err != nil {
-		s.logger.Error("marshal mercure payload", "error", err)
-	} else if err := PublishMercureEvent(ctx, s.mercureURL, s.mercureSecret, "prices-updated", string(payload)); err != nil {
-		s.logger.Warn("mercure publish failed", "error", err)
+		s.logger.Error("marshal mercure payload",
+			"endpoint", endpointName,
+			"error", err,
+		)
+		return
 	}
 
-	elapsed := time.Since(start)
-	logLevel := slog.LevelInfo
-	if errorCount > 0 && totalGems == 0 && totalCurrencies == 0 {
-		logLevel = slog.LevelError
+	if err := PublishMercureEvent(ctx, s.mercureURL, s.mercureSecret, "prices-updated", string(payload)); err != nil {
+		s.logger.Warn("mercure publish failed",
+			"endpoint", endpointName,
+			"error", err,
+		)
 	}
-	s.logger.Log(ctx, logLevel, "snapshot complete",
-		"gems", totalGems,
-		"currencies", totalCurrencies,
-		"errors", errorCount,
-		"duration", elapsed.Round(time.Millisecond).String(),
-	)
 }

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -217,7 +217,7 @@ func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastET
 			*retryCount = 0
 			return ep.FallbackInterval
 		}
-		return 30 * time.Second
+		return ep.MinSleep
 	}
 
 	// 200 OK — new data available.
@@ -252,7 +252,17 @@ func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, lastET
 
 // calculateSleep computes the optimal sleep duration based on the endpoint's
 // MaxAge and the response's Age header. Clamps to [MinSleep, FallbackInterval].
+// Logs a warning when the CDN-reported age exceeds MaxAge (stale-while-revalidate).
 func (s *Scheduler) calculateSleep(ep EndpointConfig, ageSeconds int) time.Duration {
+	maxAgeSec := int(ep.MaxAge.Seconds())
+	if maxAgeSec > 0 && ageSeconds > maxAgeSec {
+		s.logger.Warn("response age exceeds max-age (stale-while-revalidate)",
+			"endpoint", ep.Name,
+			"age", ageSeconds,
+			"maxAge", maxAgeSec,
+		)
+	}
+
 	ageDur := time.Duration(ageSeconds) * time.Second
 	sleep := ep.MaxAge - ageDur + 5*time.Second
 

--- a/internal/collector/scheduler_test.go
+++ b/internal/collector/scheduler_test.go
@@ -2,11 +2,13 @@ package collector
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -535,5 +537,469 @@ func TestScheduler_storeErrorDoesNotCrash(t *testing.T) {
 
 	if atomic.LoadInt32(&fetchCount) == 0 {
 		t.Error("fetch should have been called even though store will fail")
+	}
+}
+
+func TestScheduler_recentCurrencySnapshotSkipsFirstFetch(t *testing.T) {
+	recentTime := time.Now().UTC().Add(-5 * time.Minute)
+	var fetchCalled int32
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaCurrency,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCalled, 1)
+			return &FetchResult{CurrencyData: []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return len(result.CurrencyData), nil
+		},
+		StalenessFunc: func(ctx context.Context) (time.Time, error) {
+			return recentTime, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&fetchCalled) != 0 {
+		t.Error("currency fetcher should not have been called when snapshot is recent")
+	}
+}
+
+func TestScheduler_304RetriesUpToMaxThenFallback(t *testing.T) {
+	var fetchCount int32
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           50 * time.Millisecond,
+		FallbackInterval: 50 * time.Millisecond,
+		MaxRetries:       3,
+		MinSleep:         1 * time.Millisecond,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCount, 1)
+			return &FetchResult{NotModified: true, ETag: `"abc"`, Age: 0}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	// The test uses MinSleep=1ms so the scheduler can iterate quickly.
+	// Verify at least one fetch happens and the scheduler does not crash on 304 responses.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	count := atomic.LoadInt32(&fetchCount)
+	if count == 0 {
+		t.Error("expected at least one fetch call for 304 retry logic")
+	}
+}
+
+func TestScheduler_200SleepFromAgeHeader(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+
+	ep := EndpointConfig{
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 35 * time.Minute,
+		MinSleep:         30 * time.Second,
+	}
+
+	// Age=600s (10 min), expected sleep = 30m - 10m + 5s = 20m5s
+	got := s.calculateSleep(ep, 600)
+	want := 20*time.Minute + 5*time.Second
+	if got != want {
+		t.Errorf("calculateSleep(age=600) = %v, want %v", got, want)
+	}
+}
+
+func TestScheduler_missingAgeHeaderFallsBackToMaxAge(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+
+	ep := EndpointConfig{
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 35 * time.Minute,
+		MinSleep:         30 * time.Second,
+	}
+
+	// Age=0 (missing age header), sleep = MaxAge - 0 + 5s = 30m5s
+	got := s.calculateSleep(ep, 0)
+	want := 30*time.Minute + 5*time.Second
+	if got != want {
+		t.Errorf("calculateSleep(age=0) = %v, want %v", got, want)
+	}
+}
+
+func TestScheduler_ageExceedsMaxAgeClampsToMinSleep(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+
+	ep := EndpointConfig{
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MinSleep:         30 * time.Second,
+	}
+
+	// Age=2100s (35 min) exceeds MaxAge 30 min.
+	// sleep = 30m - 35m + 5s = -4m55s -> clamped to MinSleep
+	got := s.calculateSleep(ep, 2100)
+	if got != 30*time.Second {
+		t.Errorf("calculateSleep(age=2100) = %v, want %v (MinSleep)", got, 30*time.Second)
+	}
+}
+
+func TestScheduler_negativeCalculatedSleepClampsToMinSleep(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+
+	ep := EndpointConfig{
+		MaxAge:           10 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MinSleep:         30 * time.Second,
+	}
+
+	// Age=3600s (60 min), sleep = 10m - 60m + 5s = -49m55s -> clamped to MinSleep
+	got := s.calculateSleep(ep, 3600)
+	if got != 30*time.Second {
+		t.Errorf("calculateSleep(age=3600) = %v, want %v (MinSleep)", got, 30*time.Second)
+	}
+}
+
+func TestScheduler_contextCancellationStopsAllGoroutines(t *testing.T) {
+	var gemStarted, currStarted int32
+
+	gemEp := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&gemStarted, 1)
+			return &FetchResult{}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
+		},
+	}
+
+	currEp := EndpointConfig{
+		Name:             EndpointNinjaCurrency,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&currStarted, 1)
+			return &FetchResult{}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{gemEp, currEp}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned error = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not stop within 2s after context cancellation — goroutine leak suspected")
+	}
+
+	// Verify both goroutines actually ran.
+	if atomic.LoadInt32(&gemStarted) == 0 {
+		t.Error("gem endpoint goroutine did not run before cancellation")
+	}
+	if atomic.LoadInt32(&currStarted) == 0 {
+		t.Error("currency endpoint goroutine did not run before cancellation")
+	}
+}
+
+func TestScheduler_perSourceSemaphoreShared(t *testing.T) {
+	// Both endpoints share source "ninja". Verify they share the same
+	// semaphore channel and both can execute.
+	var gemFetched, currFetched int32
+
+	gemEp := EndpointConfig{
+		Name:   EndpointNinjaGems,
+		Source: "ninja",
+		MaxAge: 30 * time.Minute, FallbackInterval: time.Hour,
+		MaxRetries: 3, MinSleep: 30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&gemFetched, 1)
+			return &FetchResult{}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
+		},
+	}
+
+	currEp := EndpointConfig{
+		Name:   EndpointNinjaCurrency,
+		Source: "ninja",
+		MaxAge: 30 * time.Minute, FallbackInterval: time.Hour,
+		MaxRetries: 3, MinSleep: 30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&currFetched, 1)
+			return &FetchResult{}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{gemEp, currEp}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&gemFetched) == 0 {
+		t.Error("gem endpoint should have fetched")
+	}
+	if atomic.LoadInt32(&currFetched) == 0 {
+		t.Error("currency endpoint should have fetched")
+	}
+
+	// Verify shared semaphore: one semaphore for both endpoints with source "ninja".
+	if _, ok := s.semaphores["ninja"]; !ok {
+		t.Error("expected a shared semaphore for source 'ninja'")
+	}
+	if len(s.semaphores) != 1 {
+		t.Errorf("expected 1 semaphore (shared source), got %d", len(s.semaphores))
+	}
+}
+
+func TestScheduler_oneEndpointFailureDoesNotAffectOther(t *testing.T) {
+	var currencyStored int32
+
+	failingEp := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			return nil, errors.New("network timeout")
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
+		},
+	}
+
+	workingEp := EndpointConfig{
+		Name:             EndpointNinjaCurrency,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			return &FetchResult{CurrencyData: []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			atomic.AddInt32(&currencyStored, 1)
+			return 1, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{failingEp, workingEp}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&currencyStored) == 0 {
+		t.Error("currency endpoint should have stored data despite gem endpoint failure")
+	}
+}
+
+func TestScheduler_upsertDiscoveriesCalledOnlyForGems(t *testing.T) {
+	// Use a map-based resolver; UpsertDiscoveries will return an error since
+	// there is no database, but the error is logged non-fatally. The test
+	// verifies the scheduler completes without crashing for both endpoints
+	// when a resolver is present.
+	resolver := newTestResolver(map[string]string{"Arc": "BLUE"})
+
+	var gemStoreCalled, currStoreCalled int32
+
+	gemEp := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			return &FetchResult{GemData: []GemSnapshot{{Name: "Arc", Variant: "20/20", Chaos: 10}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			atomic.AddInt32(&gemStoreCalled, 1)
+			return 1, nil
+		},
+	}
+
+	currEp := EndpointConfig{
+		Name:             EndpointNinjaCurrency,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			return &FetchResult{CurrencyData: []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			atomic.AddInt32(&currStoreCalled, 1)
+			return 1, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{gemEp, currEp}, resolver, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&gemStoreCalled) == 0 {
+		t.Error("gem endpoint store should have been called")
+	}
+	if atomic.LoadInt32(&currStoreCalled) == 0 {
+		t.Error("currency endpoint store should have been called")
+	}
+}
+
+func TestScheduler_mercurePublishFiresPerEndpoint(t *testing.T) {
+	var mu sync.Mutex
+	var publishedEndpoints []string
+
+	mercureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err == nil {
+			data := r.FormValue("data")
+			var payload map[string]string
+			if err := json.Unmarshal([]byte(data), &payload); err == nil {
+				mu.Lock()
+				publishedEndpoints = append(publishedEndpoints, payload["endpoint"])
+				mu.Unlock()
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mercureServer.Close()
+
+	gemEp := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			return &FetchResult{GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 1, nil
+		},
+	}
+
+	currEp := EndpointConfig{
+		Name:             EndpointNinjaCurrency,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			return &FetchResult{CurrencyData: []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 1, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{gemEp, currEp}, nil, "Standard", mercureServer.URL, "test-secret", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	hasGems := false
+	hasCurrency := false
+	for _, ep := range publishedEndpoints {
+		if ep == EndpointNinjaGems {
+			hasGems = true
+		}
+		if ep == EndpointNinjaCurrency {
+			hasCurrency = true
+		}
+	}
+	if !hasGems {
+		t.Error("expected Mercure publish for gems endpoint")
+	}
+	if !hasCurrency {
+		t.Error("expected Mercure publish for currency endpoint")
 	}
 }

--- a/internal/collector/scheduler_test.go
+++ b/internal/collector/scheduler_test.go
@@ -981,10 +981,11 @@ func TestScheduler_oneEndpointFailureDoesNotAffectOther(t *testing.T) {
 }
 
 func TestScheduler_upsertDiscoveriesCalledOnlyForGems(t *testing.T) {
-	// Use a map-based resolver; UpsertDiscoveries will return an error since
-	// there is no database, but the error is logged non-fatally. The test
-	// verifies the scheduler completes without crashing for both endpoints
-	// when a resolver is present.
+	// Verifies the scheduler completes without crashing when a resolver is
+	// present. UpsertDiscoveries will return an error (no database) but the
+	// error is logged non-fatally. Note: this test does not verify that
+	// UpsertDiscoveries is called exclusively for gems -- that would require a
+	// spy/mock on the resolver. It only asserts both endpoints store data.
 	resolver := newTestResolver(map[string]string{"Arc": "BLUE"})
 
 	var gemStoreCalled, currStoreCalled int32
@@ -1399,5 +1400,198 @@ func TestScheduler_emptySourceNoSemaphore(t *testing.T) {
 
 	if atomic.LoadInt32(&fetchCalled) == 0 {
 		t.Error("endpoint with empty Source should still execute fetches")
+	}
+}
+
+func TestScheduler_storeErrorReturnsMinSleepNotFallback(t *testing.T) {
+	// When StoreFunc returns an error, fetchAndStore must return ep.MinSleep
+	// (retry sooner), not ep.FallbackInterval. This ensures transient DB errors
+	// trigger a quick retry rather than a long wait.
+	s := &Scheduler{
+		logger:     slog.Default(),
+		semaphores: map[string]chan struct{}{},
+	}
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			return &FetchResult{GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, errors.New("connection refused")
+		},
+	}
+
+	state := &endpointState{}
+	got := s.fetchAndStore(context.Background(), ep, state)
+
+	if got != ep.MinSleep {
+		t.Errorf("fetchAndStore on store error = %v, want %v (MinSleep)", got, ep.MinSleep)
+	}
+	// Ensure it is NOT FallbackInterval.
+	if got == ep.FallbackInterval {
+		t.Errorf("fetchAndStore on store error should return MinSleep, not FallbackInterval (%v)", ep.FallbackInterval)
+	}
+}
+
+func TestScheduler_checkStalenessMinSleepFloor(t *testing.T) {
+	// When the remaining freshness window is very small (computed sleep <
+	// MinSleep), checkStaleness must clamp up to MinSleep.
+	s := &Scheduler{logger: slog.Default()}
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MinSleep:         30 * time.Second,
+		StalenessFunc: func(ctx context.Context) (time.Time, error) {
+			// Data is 29m55s old: remaining = 30m - 29m55s = 5s, plus 5s buffer = 10s.
+			// 10s < MinSleep 30s, so should clamp to 30s.
+			return time.Now().UTC().Add(-29*time.Minute - 55*time.Second), nil
+		},
+	}
+
+	got := s.checkStaleness(context.Background(), ep)
+	if got < ep.MinSleep {
+		t.Errorf("checkStaleness = %v, want >= %v (MinSleep floor)", got, ep.MinSleep)
+	}
+}
+
+func TestScheduler_304DoesNotOverwriteLastETag(t *testing.T) {
+	// Verifies that a 304 response with a different ETag value does NOT
+	// overwrite lastETag. Call 1 returns 200 with ETag "v1", call 2 returns
+	// 304 with ETag "v2", call 3 must still receive etag="v1".
+	var mu sync.Mutex
+	var receivedEtags []string
+	callCount := 0
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           50 * time.Millisecond,
+		FallbackInterval: 50 * time.Millisecond,
+		MaxRetries:       5,
+		MinSleep:         1 * time.Millisecond,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			mu.Lock()
+			receivedEtags = append(receivedEtags, etag)
+			callCount++
+			c := callCount
+			mu.Unlock()
+
+			switch c {
+			case 1:
+				// 200 with ETag "v1".
+				return &FetchResult{
+					GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}},
+					ETag:    `"v1"`,
+					Age:     0,
+				}, nil
+			case 2:
+				// 304 with a DIFFERENT ETag "v2" -- must NOT overwrite lastETag.
+				return &FetchResult{NotModified: true, ETag: `"v2"`, Age: 0}, nil
+			default:
+				// Subsequent: 304 to keep looping.
+				return &FetchResult{NotModified: true, Age: 0}, nil
+			}
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return len(result.GemData), nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(receivedEtags) < 3 {
+		t.Fatalf("expected at least 3 fetch calls, got %d", len(receivedEtags))
+	}
+	if receivedEtags[0] != "" {
+		t.Errorf("call 1 etag = %q, want empty", receivedEtags[0])
+	}
+	if receivedEtags[1] != `"v1"` {
+		t.Errorf("call 2 etag = %q, want %q", receivedEtags[1], `"v1"`)
+	}
+	// Call 3 must still have "v1", NOT "v2" from the 304 response.
+	if receivedEtags[2] != `"v1"` {
+		t.Errorf("call 3 etag = %q, want %q (304 must not overwrite lastETag)", receivedEtags[2], `"v1"`)
+	}
+}
+
+func TestScheduler_panicInFetchFuncDoesNotCrashOtherEndpoints(t *testing.T) {
+	// When one endpoint's FetchFunc panics, the recover handler should catch
+	// it so the other endpoint continues running and Run() returns nil.
+	var currencyStored int32
+
+	panickingEp := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			panic("simulated FetchFunc panic")
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
+		},
+	}
+
+	workingEp := EndpointConfig{
+		Name:             EndpointNinjaCurrency,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			return &FetchResult{CurrencyData: []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			atomic.AddInt32(&currencyStored, 1)
+			return 1, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{panickingEp, workingEp}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Run returned error = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not stop within 2s after context cancellation")
+	}
+
+	if atomic.LoadInt32(&currencyStored) == 0 {
+		t.Error("currency endpoint should have stored data despite gem endpoint panic")
 	}
 }

--- a/internal/collector/scheduler_test.go
+++ b/internal/collector/scheduler_test.go
@@ -581,6 +581,11 @@ func TestScheduler_recentCurrencySnapshotSkipsFirstFetch(t *testing.T) {
 }
 
 func TestScheduler_304RetriesUpToMaxThenFallback(t *testing.T) {
+	// MaxRetries=3: the scheduler retries 3 times (retryCount 1..3), then on the
+	// 4th 304 (retryCount > MaxRetries) it resets and sleeps FallbackInterval.
+	// With MinSleep=1ms the first retry cycle completes almost immediately, so
+	// we assert at least MaxRetries+1 fetches occurred (exhausting one full cycle).
+	const maxRetries = 3
 	var fetchCount int32
 
 	ep := EndpointConfig{
@@ -588,7 +593,7 @@ func TestScheduler_304RetriesUpToMaxThenFallback(t *testing.T) {
 		Source:           "ninja",
 		MaxAge:           50 * time.Millisecond,
 		FallbackInterval: 50 * time.Millisecond,
-		MaxRetries:       3,
+		MaxRetries:       maxRetries,
 		MinSleep:         1 * time.Millisecond,
 		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
 			atomic.AddInt32(&fetchCount, 1)
@@ -607,15 +612,14 @@ func TestScheduler_304RetriesUpToMaxThenFallback(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() { done <- s.Run(ctx) }()
-	// The test uses MinSleep=1ms so the scheduler can iterate quickly.
-	// Verify at least one fetch happens and the scheduler does not crash on 304 responses.
 	time.Sleep(100 * time.Millisecond)
 	cancel()
 	<-done
 
+	// At minimum one full retry cycle (MaxRetries+1 fetches) must have completed.
 	count := atomic.LoadInt32(&fetchCount)
-	if count == 0 {
-		t.Error("expected at least one fetch call for 304 retry logic")
+	if count <= maxRetries {
+		t.Errorf("expected >%d fetch calls to exhaust one retry cycle, got %d", maxRetries, count)
 	}
 }
 

--- a/internal/collector/scheduler_test.go
+++ b/internal/collector/scheduler_test.go
@@ -451,10 +451,10 @@ func TestScheduler_calculateSleep(t *testing.T) {
 		want       time.Duration
 	}{
 		{
-			name: "fresh response sleeps near MaxAge",
+			name: "fresh response sleeps near MaxAge, capped by FallbackInterval",
 			ep: EndpointConfig{
 				MaxAge:           30 * time.Minute,
-				FallbackInterval: 30 * time.Minute,
+				FallbackInterval: 35 * time.Minute, // enough room for MaxAge + 5s buffer
 				MinSleep:         30 * time.Second,
 			},
 			ageSeconds: 0,

--- a/internal/collector/scheduler_test.go
+++ b/internal/collector/scheduler_test.go
@@ -694,8 +694,9 @@ func TestScheduler_recentCurrencySnapshotSkipsFirstFetch(t *testing.T) {
 }
 
 func TestScheduler_304RetriesUpToMaxThenFallback(t *testing.T) {
-	// MaxRetries=3: the scheduler retries 3 times (retryCount 1..3), then on the
-	// 4th 304 (retryCount > MaxRetries) it resets and sleeps FallbackInterval.
+	// MaxRetries=3: allows 304 responses at MinSleep while retryCount <= MaxRetries
+	// (1..3), then the 4th 304 (retryCount=4 > MaxRetries) resets and sleeps
+	// FallbackInterval.
 	// With MinSleep=1ms the first retry cycle completes almost immediately, so
 	// we assert at least MaxRetries+1 fetches occurred (exhausting one full cycle).
 	const maxRetries = 3
@@ -1244,5 +1245,159 @@ func TestScheduler_mercurePublishFiresPerEndpoint(t *testing.T) {
 	}
 	if !hasCurrency {
 		t.Error("expected Mercure publish for currency endpoint")
+	}
+}
+
+func TestNewScheduler_emptyNameReturnsError(t *testing.T) {
+	ep := EndpointConfig{
+		Name:             "", // empty
+		Source:           "ninja",
+		FetchFunc:        func(ctx context.Context, league string, etag string) (*FetchResult, error) { return nil, nil },
+		FallbackInterval: 30 * time.Minute,
+	}
+
+	_, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err == nil {
+		t.Fatal("expected error for empty Name, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty Name") {
+		t.Errorf("error = %q, want it to mention 'empty Name'", err.Error())
+	}
+}
+
+func TestNewScheduler_nilFetchFuncReturnsError(t *testing.T) {
+	ep := EndpointConfig{
+		Name:             "test-endpoint",
+		Source:           "ninja",
+		FetchFunc:        nil, // nil
+		FallbackInterval: 30 * time.Minute,
+	}
+
+	_, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err == nil {
+		t.Fatal("expected error for nil FetchFunc, got nil")
+	}
+	if !strings.Contains(err.Error(), "nil FetchFunc") {
+		t.Errorf("error = %q, want it to mention 'nil FetchFunc'", err.Error())
+	}
+}
+
+func TestNewScheduler_nonPositiveFallbackIntervalReturnsError(t *testing.T) {
+	tests := []struct {
+		name             string
+		fallbackInterval time.Duration
+	}{
+		{name: "zero FallbackInterval", fallbackInterval: 0},
+		{name: "negative FallbackInterval", fallbackInterval: -5 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := EndpointConfig{
+				Name:             "test-endpoint",
+				Source:           "ninja",
+				FetchFunc:        func(ctx context.Context, league string, etag string) (*FetchResult, error) { return nil, nil },
+				FallbackInterval: tt.fallbackInterval,
+			}
+
+			_, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+			if err == nil {
+				t.Fatal("expected error for non-positive FallbackInterval, got nil")
+			}
+			if !strings.Contains(err.Error(), "non-positive FallbackInterval") {
+				t.Errorf("error = %q, want it to mention 'non-positive FallbackInterval'", err.Error())
+			}
+		})
+	}
+}
+
+func TestScheduler_invalidFetchResultDoesNotCallStore(t *testing.T) {
+	// When FetchFunc returns a FetchResult that fails Validate() (both GemData
+	// and CurrencyData populated), StoreFunc must NOT be called and the
+	// scheduler should continue running (sleep FallbackInterval, not crash).
+	var storeCalled int32
+	var fetchCount int32
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           50 * time.Millisecond,
+		FallbackInterval: 50 * time.Millisecond,
+		MaxRetries:       3,
+		MinSleep:         1 * time.Millisecond,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCount, 1)
+			// Return an invalid result: both data fields populated.
+			return &FetchResult{
+				GemData:      []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}},
+				CurrencyData: []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}},
+			}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			atomic.AddInt32(&storeCalled, 1)
+			return 0, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&storeCalled) != 0 {
+		t.Error("StoreFunc should NOT be called when FetchResult.Validate() fails")
+	}
+	if atomic.LoadInt32(&fetchCount) == 0 {
+		t.Error("FetchFunc should have been called at least once")
+	}
+}
+
+func TestScheduler_emptySourceNoSemaphore(t *testing.T) {
+	// An endpoint with Source="" should run without panic and no semaphore
+	// should be created for it.
+	var fetchCalled int32
+
+	ep := EndpointConfig{
+		Name:             "custom-endpoint",
+		Source:           "", // empty source
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCalled, 1)
+			return &FetchResult{GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 1, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	// Verify no semaphore was created for empty source.
+	if len(s.semaphores) != 0 {
+		t.Errorf("expected 0 semaphores for empty source, got %d", len(s.semaphores))
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&fetchCalled) == 0 {
+		t.Error("endpoint with empty Source should still execute fetches")
 	}
 }

--- a/internal/collector/scheduler_test.go
+++ b/internal/collector/scheduler_test.go
@@ -504,6 +504,119 @@ func TestScheduler_calculateSleep(t *testing.T) {
 	}
 }
 
+func TestScheduler_startupJitter(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+
+	tests := []struct {
+		name      string
+		jitterMin time.Duration
+		jitterMax time.Duration
+		wantZero  bool
+	}{
+		{
+			name:      "JitterMax=0 returns 0",
+			jitterMin: 0,
+			jitterMax: 0,
+			wantZero:  true,
+		},
+		{
+			name:      "JitterMax <= JitterMin returns 0",
+			jitterMin: 5 * time.Second,
+			jitterMax: 5 * time.Second,
+			wantZero:  true,
+		},
+		{
+			name:      "JitterMax < JitterMin returns 0",
+			jitterMin: 10 * time.Second,
+			jitterMax: 5 * time.Second,
+			wantZero:  true,
+		},
+		{
+			name:      "valid range returns value in [JitterMin, JitterMax)",
+			jitterMin: 2 * time.Second,
+			jitterMax: 7 * time.Second,
+			wantZero:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ep := EndpointConfig{
+				JitterMin: tt.jitterMin,
+				JitterMax: tt.jitterMax,
+			}
+			got := s.startupJitter(ep)
+			if tt.wantZero {
+				if got != 0 {
+					t.Errorf("startupJitter() = %v, want 0", got)
+				}
+			} else {
+				if got < tt.jitterMin || got >= tt.jitterMax {
+					t.Errorf("startupJitter() = %v, want in [%v, %v)", got, tt.jitterMin, tt.jitterMax)
+				}
+			}
+		})
+	}
+}
+
+func TestScheduler_nilStoreFuncDoesNotPanic(t *testing.T) {
+	// Verifies the nil StoreFunc guard in fetchAndStore: the scheduler should
+	// complete without panic when StoreFunc is nil.
+	var fetchCalled int32
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCalled, 1)
+			return &FetchResult{GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}}, nil
+		},
+		StoreFunc: nil, // intentionally nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&fetchCalled) == 0 {
+		t.Error("fetch should have been called with nil StoreFunc")
+	}
+}
+
+func TestScheduler_calculateSleepZeroMaxAge(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+
+	ep := EndpointConfig{
+		MaxAge:           0, // misconfigured zero MaxAge
+		FallbackInterval: 30 * time.Minute,
+		MinSleep:         30 * time.Second,
+	}
+
+	// With MaxAge=0, sleep = 0 - 0 + 5s = 5s, which is < MinSleep 30s, so clamps to MinSleep.
+	got := s.calculateSleep(ep, 0)
+	if got != 30*time.Second {
+		t.Errorf("calculateSleep(MaxAge=0, age=0) = %v, want %v (MinSleep)", got, 30*time.Second)
+	}
+
+	// With MaxAge=0 and age=100, sleep = 0 - 100s + 5s = -95s, clamps to MinSleep.
+	got = s.calculateSleep(ep, 100)
+	if got != 30*time.Second {
+		t.Errorf("calculateSleep(MaxAge=0, age=100) = %v, want %v (MinSleep)", got, 30*time.Second)
+	}
+}
+
 func TestScheduler_storeErrorDoesNotCrash(t *testing.T) {
 	var fetchCount int32
 
@@ -924,6 +1037,132 @@ func TestScheduler_upsertDiscoveriesCalledOnlyForGems(t *testing.T) {
 	}
 	if atomic.LoadInt32(&currStoreCalled) == 0 {
 		t.Error("currency endpoint store should have been called")
+	}
+}
+
+func TestScheduler_etagPropagatedAcrossFetchCycles(t *testing.T) {
+	// Verifies the core cache-aware polling contract: a 200 response with
+	// ETag="abc" causes the next FetchFunc call to receive etag="abc".
+	var mu sync.Mutex
+	var receivedEtags []string
+	callCount := 0
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           50 * time.Millisecond,
+		FallbackInterval: 50 * time.Millisecond,
+		MaxRetries:       3,
+		MinSleep:         1 * time.Millisecond,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			mu.Lock()
+			receivedEtags = append(receivedEtags, etag)
+			callCount++
+			c := callCount
+			mu.Unlock()
+
+			if c == 1 {
+				// First call: return 200 with ETag.
+				return &FetchResult{
+					GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}},
+					ETag:    `"abc"`,
+					Age:     0,
+				}, nil
+			}
+			// Subsequent calls: return 304 to keep looping quickly.
+			return &FetchResult{NotModified: true, ETag: `"abc"`, Age: 0}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return len(result.GemData), nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(receivedEtags) < 2 {
+		t.Fatalf("expected at least 2 fetch calls, got %d", len(receivedEtags))
+	}
+	if receivedEtags[0] != "" {
+		t.Errorf("first fetch etag = %q, want empty string", receivedEtags[0])
+	}
+	if receivedEtags[1] != `"abc"` {
+		t.Errorf("second fetch etag = %q, want %q (ETag should propagate)", receivedEtags[1], `"abc"`)
+	}
+}
+
+func TestScheduler_retryCountResetsOn200AfterMultiple304s(t *testing.T) {
+	// Verifies that retryCount resets to 0 on a 200 response, so subsequent
+	// 304s get the full retry budget again instead of exhausting immediately.
+	var mu sync.Mutex
+	callCount := 0
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           50 * time.Millisecond,
+		FallbackInterval: 50 * time.Millisecond,
+		MaxRetries:       2,
+		MinSleep:         1 * time.Millisecond,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			mu.Lock()
+			callCount++
+			c := callCount
+			mu.Unlock()
+
+			// Calls 1-2: 304, call 3: 200, calls 4+: 304
+			switch {
+			case c <= 2:
+				return &FetchResult{NotModified: true, ETag: `"v1"`, Age: 0}, nil
+			case c == 3:
+				return &FetchResult{
+					GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}},
+					ETag:    `"v2"`,
+					Age:     0,
+				}, nil
+			default:
+				return &FetchResult{NotModified: true, ETag: `"v2"`, Age: 0}, nil
+			}
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return len(result.GemData), nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// With MaxRetries=2: calls 1,2 are 304 (retryCount 1,2), call 3 is 200
+	// (retryCount resets to 0), calls 4,5 are 304 (retryCount 1,2), call 6
+	// would exhaust. If reset did NOT happen, call 4 would already exhaust
+	// (retryCount would be 3 > MaxRetries=2) and we would get a long sleep.
+	// With MinSleep=1ms and 200ms window, we should get at least 5 calls.
+	if callCount < 5 {
+		t.Errorf("expected at least 5 fetch calls (proving retry reset), got %d", callCount)
 	}
 }
 

--- a/internal/collector/scheduler_test.go
+++ b/internal/collector/scheduler_test.go
@@ -7,45 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
-// mockFetcher implements Fetcher with configurable function fields.
-type mockFetcher struct {
-	FetchGemsFn     func(ctx context.Context, league string) ([]GemSnapshot, error)
-	FetchCurrencyFn func(ctx context.Context, league string) ([]CurrencySnapshot, error)
-}
-
-func (m *mockFetcher) FetchGems(ctx context.Context, league string) ([]GemSnapshot, error) {
-	return m.FetchGemsFn(ctx, league)
-}
-
-func (m *mockFetcher) FetchCurrency(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-	return m.FetchCurrencyFn(ctx, league)
-}
-
-// newTestScheduler builds a Scheduler with a short interval suitable for tests.
-// Panics on invalid configuration since test inputs should always be valid.
-func newTestScheduler(store SnapshotStore, fetcher Fetcher, interval time.Duration) *Scheduler {
-	s, err := NewScheduler(
-		store,
-		[]Fetcher{fetcher},
-		nil, // no gem color resolver in unit tests
-		interval,
-		"Standard",
-		"", // no Mercure in unit tests
-		"",
-		slog.Default(),
-	)
-	if err != nil {
-		panic("newTestScheduler: " + err.Error())
-	}
-	return s
-}
-
 // newFailingMercureServer creates an httptest server that always returns 500
-// for Mercure publish requests. Used to verify that Mercure failures are non-fatal.
+// for Mercure publish requests.
 func newFailingMercureServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -54,457 +22,279 @@ func newFailingMercureServer(t *testing.T) *httptest.Server {
 }
 
 func TestScheduler_recentSnapshotSkipsFirstFetch(t *testing.T) {
-	// When the last snapshot is recent (within interval), Run should skip the
-	// first collect call and wait for the next tick.
 	recentTime := time.Now().UTC().Add(-5 * time.Minute)
-	fetchCalled := false
+	var fetchCalled int32
 
-	store := &mockStore{
-		LastGemSnapshotTimeFn: func(ctx context.Context) (time.Time, error) {
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCalled, 1)
+			return &FetchResult{GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return len(result.GemData), nil
+		},
+		StalenessFunc: func(ctx context.Context) (time.Time, error) {
 			return recentTime, nil
-		},
-		InsertGemSnapshotsFn: func(ctx context.Context, st time.Time, s []GemSnapshot) (int, error) {
-			return len(s), nil
-		},
-		InsertCurrencySnapshotsFn: func(ctx context.Context, st time.Time, s []CurrencySnapshot) (int, error) {
-			return len(s), nil
-		},
-	}
-
-	fetcher := &mockFetcher{
-		FetchGemsFn: func(ctx context.Context, league string) ([]GemSnapshot, error) {
-			fetchCalled = true
-			return []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}, nil
-		},
-		FetchCurrencyFn: func(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-			return nil, nil
 		},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	s := newTestScheduler(store, fetcher, 15*time.Minute)
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
 
-	// Run briefly then cancel — enough time for the startup check, not a full tick.
 	done := make(chan error, 1)
 	go func() { done <- s.Run(ctx) }()
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	cancel()
 	<-done
 
-	if fetchCalled {
+	if atomic.LoadInt32(&fetchCalled) != 0 {
 		t.Error("fetcher should not have been called when snapshot is recent")
 	}
 }
 
 func TestScheduler_staleSnapshotFetchesImmediately(t *testing.T) {
-	// When the last snapshot is older than the interval, Run should call collect
-	// immediately on startup.
-	staleTime := time.Now().UTC().Add(-30 * time.Minute)
-	fetchCalled := false
+	staleTime := time.Now().UTC().Add(-60 * time.Minute)
+	var fetchCalled int32
 
-	store := &mockStore{
-		LastGemSnapshotTimeFn: func(ctx context.Context) (time.Time, error) {
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCalled, 1)
+			return &FetchResult{GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return len(result.GemData), nil
+		},
+		StalenessFunc: func(ctx context.Context) (time.Time, error) {
 			return staleTime, nil
-		},
-		InsertGemSnapshotsFn: func(ctx context.Context, st time.Time, s []GemSnapshot) (int, error) {
-			return len(s), nil
-		},
-		InsertCurrencySnapshotsFn: func(ctx context.Context, st time.Time, s []CurrencySnapshot) (int, error) {
-			return len(s), nil
-		},
-	}
-
-	fetcher := &mockFetcher{
-		FetchGemsFn: func(ctx context.Context, league string) ([]GemSnapshot, error) {
-			fetchCalled = true
-			return []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}, nil
-		},
-		FetchCurrencyFn: func(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-			return nil, nil
 		},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	s := newTestScheduler(store, fetcher, 15*time.Minute)
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
 
 	done := make(chan error, 1)
 	go func() { done <- s.Run(ctx) }()
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	cancel()
 	<-done
 
-	if !fetchCalled {
+	if atomic.LoadInt32(&fetchCalled) == 0 {
 		t.Error("fetcher should have been called immediately when snapshot is stale")
 	}
 }
 
 func TestScheduler_emptyTableFetchesImmediately(t *testing.T) {
-	// When no snapshots exist (zero time returned), Run should fetch immediately.
-	fetchCalled := false
+	var fetchCalled int32
 
-	store := &mockStore{
-		LastGemSnapshotTimeFn: func(ctx context.Context) (time.Time, error) {
-			return time.Time{}, nil
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCalled, 1)
+			return &FetchResult{}, nil
 		},
-		InsertGemSnapshotsFn: func(ctx context.Context, st time.Time, s []GemSnapshot) (int, error) {
-			return len(s), nil
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
 		},
-		InsertCurrencySnapshotsFn: func(ctx context.Context, st time.Time, s []CurrencySnapshot) (int, error) {
-			return len(s), nil
-		},
-	}
-
-	fetcher := &mockFetcher{
-		FetchGemsFn: func(ctx context.Context, league string) ([]GemSnapshot, error) {
-			fetchCalled = true
-			return nil, nil
-		},
-		FetchCurrencyFn: func(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-			return nil, nil
+		StalenessFunc: func(ctx context.Context) (time.Time, error) {
+			return time.Time{}, nil // zero time = no data
 		},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	s := newTestScheduler(store, fetcher, 15*time.Minute)
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
 
 	done := make(chan error, 1)
 	go func() { done <- s.Run(ctx) }()
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	cancel()
 	<-done
 
-	if !fetchCalled {
+	if atomic.LoadInt32(&fetchCalled) == 0 {
 		t.Error("fetcher should have been called when no snapshots exist")
 	}
 }
 
-func TestScheduler_gemFetchErrorDoesNotBlockCurrencyFetch(t *testing.T) {
-	// When gem fetch fails, currency fetch should still run and be stored.
-	gemErr := errors.New("ninja API timeout")
-	currencyInserted := 0
+func TestScheduler_fetchErrorSleepsFallbackInterval(t *testing.T) {
+	var fetchCount int32
 
-	store := &mockStore{
-		LastGemSnapshotTimeFn: func(ctx context.Context) (time.Time, error) {
-			return time.Time{}, nil // force immediate collect
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCount, 1)
+			return nil, errors.New("ninja API timeout")
 		},
-		InsertGemSnapshotsFn: func(ctx context.Context, st time.Time, s []GemSnapshot) (int, error) {
-			return len(s), nil
-		},
-		InsertCurrencySnapshotsFn: func(ctx context.Context, st time.Time, s []CurrencySnapshot) (int, error) {
-			currencyInserted += len(s)
-			return len(s), nil
-		},
-	}
-
-	fetcher := &mockFetcher{
-		FetchGemsFn: func(ctx context.Context, league string) ([]GemSnapshot, error) {
-			return nil, gemErr
-		},
-		FetchCurrencyFn: func(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-			return []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}}, nil
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
 		},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	s := newTestScheduler(store, fetcher, 15*time.Minute)
-
-	done := make(chan error, 1)
-	go func() { done <- s.Run(ctx) }()
-	time.Sleep(20 * time.Millisecond)
-	cancel()
-	<-done
-
-	if currencyInserted != 1 {
-		t.Errorf("currency inserted = %d, want 1 (gem error should not block currency)", currencyInserted)
-	}
-}
-
-func TestScheduler_leaguePassedToFetchers(t *testing.T) {
-	// Verify that the scheduler passes the configured league to fetchers.
-	var receivedGemLeague, receivedCurrencyLeague string
-
-	store := &mockStore{
-		LastGemSnapshotTimeFn: func(ctx context.Context) (time.Time, error) {
-			return time.Time{}, nil // force immediate collect
-		},
-		InsertGemSnapshotsFn: func(ctx context.Context, st time.Time, s []GemSnapshot) (int, error) {
-			return len(s), nil
-		},
-		InsertCurrencySnapshotsFn: func(ctx context.Context, st time.Time, s []CurrencySnapshot) (int, error) {
-			return len(s), nil
-		},
-	}
-
-	fetcher := &mockFetcher{
-		FetchGemsFn: func(ctx context.Context, league string) ([]GemSnapshot, error) {
-			receivedGemLeague = league
-			return nil, nil
-		},
-		FetchCurrencyFn: func(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-			receivedCurrencyLeague = league
-			return nil, nil
-		},
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	s, err := NewScheduler(store, []Fetcher{fetcher}, nil, 15*time.Minute, "Mirage", "", "", slog.Default())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
 	if err != nil {
 		t.Fatalf("NewScheduler: %v", err)
 	}
 
 	done := make(chan error, 1)
 	go func() { done <- s.Run(ctx) }()
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	cancel()
 	<-done
 
-	if receivedGemLeague != "Mirage" {
-		t.Errorf("FetchGems received league = %q, want %q", receivedGemLeague, "Mirage")
+	if atomic.LoadInt32(&fetchCount) != 1 {
+		t.Errorf("fetch count = %d, want 1 (should fetch once then sleep on error)", atomic.LoadInt32(&fetchCount))
 	}
-	if receivedCurrencyLeague != "Mirage" {
-		t.Errorf("FetchCurrency received league = %q, want %q", receivedCurrencyLeague, "Mirage")
+}
+
+func TestScheduler_leaguePassedToFetchFunc(t *testing.T) {
+	var receivedLeague string
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			receivedLeague = league
+			return &FetchResult{}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Mirage", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if receivedLeague != "Mirage" {
+		t.Errorf("FetchFunc received league = %q, want %q", receivedLeague, "Mirage")
 	}
 }
 
 func TestScheduler_mercureFailureIsNonFatal(t *testing.T) {
-	// A Mercure publish failure should not prevent the collect cycle from
-	// completing successfully or affect snapshot insertion.
-	gemsInserted := 0
+	var storeCount int32
 
-	store := &mockStore{
-		LastGemSnapshotTimeFn: func(ctx context.Context) (time.Time, error) {
-			return time.Time{}, nil // force immediate collect
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			return &FetchResult{GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}}, nil
 		},
-		InsertGemSnapshotsFn: func(ctx context.Context, st time.Time, s []GemSnapshot) (int, error) {
-			gemsInserted += len(s)
-			return len(s), nil
-		},
-		InsertCurrencySnapshotsFn: func(ctx context.Context, st time.Time, s []CurrencySnapshot) (int, error) {
-			return len(s), nil
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			atomic.AddInt32(&storeCount, 1)
+			return len(result.GemData), nil
 		},
 	}
 
-	fetcher := &mockFetcher{
-		FetchGemsFn: func(ctx context.Context, league string) ([]GemSnapshot, error) {
-			return []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}, nil
-		},
-		FetchCurrencyFn: func(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-			return nil, nil
-		},
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	// Point Mercure at a server that always returns 500.
 	mercureServer := newFailingMercureServer(t)
 	defer mercureServer.Close()
 
-	s, err := NewScheduler(store, []Fetcher{fetcher}, nil, 15*time.Minute, "Standard",
-		mercureServer.URL, "test-secret", slog.Default())
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", mercureServer.URL, "test-secret", slog.Default())
 	if err != nil {
 		t.Fatalf("NewScheduler: %v", err)
 	}
 
 	done := make(chan error, 1)
 	go func() { done <- s.Run(ctx) }()
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	cancel()
 	<-done
 
-	if gemsInserted != 1 {
-		t.Errorf("gems inserted = %d, want 1 (Mercure failure should not block snapshot insertion)", gemsInserted)
+	if atomic.LoadInt32(&storeCount) == 0 {
+		t.Error("store should have been called despite Mercure failure")
 	}
 }
 
-func TestNewScheduler_zeroIntervalReturnsError(t *testing.T) {
-	store := &mockStore{}
-	fetcher := &mockFetcher{}
-
-	_, err := NewScheduler(store, []Fetcher{fetcher}, nil, 0, "Standard", "", "", slog.Default())
+func TestNewScheduler_emptyEndpointsReturnsError(t *testing.T) {
+	_, err := NewScheduler([]EndpointConfig{}, nil, "Standard", "", "", slog.Default())
 	if err == nil {
-		t.Fatal("expected error for zero interval, got nil")
+		t.Fatal("expected error for empty endpoints, got nil")
 	}
-	if !strings.Contains(err.Error(), "interval must be positive") {
-		t.Errorf("error = %q, want it to mention 'interval must be positive'", err.Error())
+	if !strings.Contains(err.Error(), "at least one endpoint") {
+		t.Errorf("error = %q, want it to mention 'at least one endpoint'", err.Error())
 	}
 }
 
-func TestNewScheduler_negativeIntervalReturnsError(t *testing.T) {
-	store := &mockStore{}
-	fetcher := &mockFetcher{}
-
-	_, err := NewScheduler(store, []Fetcher{fetcher}, nil, -5*time.Second, "Standard", "", "", slog.Default())
+func TestNewScheduler_nilEndpointsReturnsError(t *testing.T) {
+	_, err := NewScheduler(nil, nil, "Standard", "", "", slog.Default())
 	if err == nil {
-		t.Fatal("expected error for negative interval, got nil")
+		t.Fatal("expected error for nil endpoints, got nil")
 	}
-	if !strings.Contains(err.Error(), "interval must be positive") {
-		t.Errorf("error = %q, want it to mention 'interval must be positive'", err.Error())
-	}
-}
-
-func TestNewScheduler_emptyFetchersReturnsError(t *testing.T) {
-	store := &mockStore{}
-
-	_, err := NewScheduler(store, []Fetcher{}, nil, 15*time.Minute, "Standard", "", "", slog.Default())
-	if err == nil {
-		t.Fatal("expected error for empty fetchers, got nil")
-	}
-	if !strings.Contains(err.Error(), "at least one fetcher") {
-		t.Errorf("error = %q, want it to mention 'at least one fetcher'", err.Error())
-	}
-}
-
-func TestNewScheduler_nilFetchersReturnsError(t *testing.T) {
-	store := &mockStore{}
-
-	_, err := NewScheduler(store, nil, nil, 15*time.Minute, "Standard", "", "", slog.Default())
-	if err == nil {
-		t.Fatal("expected error for nil fetchers, got nil")
-	}
-	if !strings.Contains(err.Error(), "at least one fetcher") {
-		t.Errorf("error = %q, want it to mention 'at least one fetcher'", err.Error())
-	}
-}
-
-func TestScheduler_gemInsertErrorDoesNotBlockCurrencyInsert(t *testing.T) {
-	// When gem snapshot insertion fails, currency snapshots should still be inserted.
-	currencyInserted := 0
-
-	store := &mockStore{
-		LastGemSnapshotTimeFn: func(ctx context.Context) (time.Time, error) {
-			return time.Time{}, nil // force immediate collect
-		},
-		InsertGemSnapshotsFn: func(ctx context.Context, st time.Time, s []GemSnapshot) (int, error) {
-			return 0, errors.New("gem insert: disk full")
-		},
-		InsertCurrencySnapshotsFn: func(ctx context.Context, st time.Time, s []CurrencySnapshot) (int, error) {
-			currencyInserted += len(s)
-			return len(s), nil
-		},
-	}
-
-	fetcher := &mockFetcher{
-		FetchGemsFn: func(ctx context.Context, league string) ([]GemSnapshot, error) {
-			return []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}, nil
-		},
-		FetchCurrencyFn: func(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-			return []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}}, nil
-		},
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	s := newTestScheduler(store, fetcher, 15*time.Minute)
-
-	done := make(chan error, 1)
-	go func() { done <- s.Run(ctx) }()
-	time.Sleep(20 * time.Millisecond)
-	cancel()
-	<-done
-
-	if currencyInserted != 1 {
-		t.Errorf("currency inserted = %d, want 1 (gem insert error should not block currency)", currencyInserted)
-	}
-}
-
-func TestScheduler_currencyInsertErrorDoesNotBlockGemInsert(t *testing.T) {
-	// When currency snapshot insertion fails, gem snapshots should still have been inserted.
-	gemsInserted := 0
-
-	store := &mockStore{
-		LastGemSnapshotTimeFn: func(ctx context.Context) (time.Time, error) {
-			return time.Time{}, nil // force immediate collect
-		},
-		InsertGemSnapshotsFn: func(ctx context.Context, st time.Time, s []GemSnapshot) (int, error) {
-			gemsInserted += len(s)
-			return len(s), nil
-		},
-		InsertCurrencySnapshotsFn: func(ctx context.Context, st time.Time, s []CurrencySnapshot) (int, error) {
-			return 0, errors.New("currency insert: connection lost")
-		},
-	}
-
-	fetcher := &mockFetcher{
-		FetchGemsFn: func(ctx context.Context, league string) ([]GemSnapshot, error) {
-			return []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}, nil
-		},
-		FetchCurrencyFn: func(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-			return []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}}, nil
-		},
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	s := newTestScheduler(store, fetcher, 15*time.Minute)
-
-	done := make(chan error, 1)
-	go func() { done <- s.Run(ctx) }()
-	time.Sleep(20 * time.Millisecond)
-	cancel()
-	<-done
-
-	if gemsInserted != 1 {
-		t.Errorf("gems inserted = %d, want 1 (currency insert error should not block gems)", gemsInserted)
-	}
-}
-
-func TestScheduler_lastSnapshotTimeErrorCollectsImmediately(t *testing.T) {
-	// When LastGemSnapshotTime returns an error, the scheduler should fall back
-	// to collecting immediately rather than skipping or waiting.
-	fetchCalled := false
-
-	store := &mockStore{
-		LastGemSnapshotTimeFn: func(ctx context.Context) (time.Time, error) {
-			return time.Time{}, errors.New("connection refused")
-		},
-		InsertGemSnapshotsFn: func(ctx context.Context, st time.Time, s []GemSnapshot) (int, error) {
-			return len(s), nil
-		},
-		InsertCurrencySnapshotsFn: func(ctx context.Context, st time.Time, s []CurrencySnapshot) (int, error) {
-			return len(s), nil
-		},
-	}
-
-	fetcher := &mockFetcher{
-		FetchGemsFn: func(ctx context.Context, league string) ([]GemSnapshot, error) {
-			fetchCalled = true
-			return []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}, nil
-		},
-		FetchCurrencyFn: func(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-			return nil, nil
-		},
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	s := newTestScheduler(store, fetcher, 15*time.Minute)
-
-	done := make(chan error, 1)
-	go func() { done <- s.Run(ctx) }()
-	time.Sleep(20 * time.Millisecond)
-	cancel()
-	<-done
-
-	if !fetchCalled {
-		t.Error("fetcher should have been called immediately when LastGemSnapshotTime returns an error")
+	if !strings.Contains(err.Error(), "at least one endpoint") {
+		t.Errorf("error = %q, want it to mention 'at least one endpoint'", err.Error())
 	}
 }
 
 func TestScheduler_contextCancellationStopsRun(t *testing.T) {
-	// Run should return nil promptly when ctx is cancelled.
-	store := &mockStore{
-		LastGemSnapshotTimeFn: func(ctx context.Context) (time.Time, error) {
-			return time.Now().UTC(), nil // recent — skip first collect
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: time.Hour,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			return &FetchResult{}, nil
 		},
-	}
-
-	fetcher := &mockFetcher{
-		FetchGemsFn: func(ctx context.Context, league string) ([]GemSnapshot, error) {
-			return nil, nil
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
 		},
-		FetchCurrencyFn: func(ctx context.Context, league string) ([]CurrencySnapshot, error) {
-			return nil, nil
+		StalenessFunc: func(ctx context.Context) (time.Time, error) {
+			return time.Now().UTC(), nil
 		},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	s := newTestScheduler(store, fetcher, time.Hour) // long interval — won't tick
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
 
 	done := make(chan error, 1)
 	go func() { done <- s.Run(ctx) }()
@@ -518,5 +308,232 @@ func TestScheduler_contextCancellationStopsRun(t *testing.T) {
 		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("Run did not stop within 500ms after context cancellation")
+	}
+}
+
+func TestScheduler_multipleEndpointsRunConcurrently(t *testing.T) {
+	var gemFetchCount, currencyFetchCount int32
+
+	gemEp := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&gemFetchCount, 1)
+			return &FetchResult{GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 1, nil
+		},
+	}
+
+	currencyEp := EndpointConfig{
+		Name:             EndpointNinjaCurrency,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&currencyFetchCount, 1)
+			return &FetchResult{CurrencyData: []CurrencySnapshot{{CurrencyID: "divine", Chaos: 210}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 1, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{gemEp, currencyEp}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&gemFetchCount) == 0 {
+		t.Error("gem endpoint should have been fetched")
+	}
+	if atomic.LoadInt32(&currencyFetchCount) == 0 {
+		t.Error("currency endpoint should have been fetched")
+	}
+}
+
+func TestScheduler_stalenessCheckErrorFetchesImmediately(t *testing.T) {
+	var fetchCalled int32
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCalled, 1)
+			return &FetchResult{}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
+		},
+		StalenessFunc: func(ctx context.Context) (time.Time, error) {
+			return time.Time{}, errors.New("connection refused")
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&fetchCalled) == 0 {
+		t.Error("fetcher should have been called immediately when StalenessFunc returns an error")
+	}
+}
+
+func TestScheduler_nilStalenessFuncFetchesImmediately(t *testing.T) {
+	var fetchCalled int32
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCalled, 1)
+			return &FetchResult{}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&fetchCalled) == 0 {
+		t.Error("fetcher should have been called when StalenessFunc is nil")
+	}
+}
+
+func TestScheduler_calculateSleep(t *testing.T) {
+	s := &Scheduler{logger: slog.Default()}
+
+	tests := []struct {
+		name       string
+		ep         EndpointConfig
+		ageSeconds int
+		want       time.Duration
+	}{
+		{
+			name: "fresh response sleeps near MaxAge",
+			ep: EndpointConfig{
+				MaxAge:           30 * time.Minute,
+				FallbackInterval: 30 * time.Minute,
+				MinSleep:         30 * time.Second,
+			},
+			ageSeconds: 0,
+			want:       30*time.Minute + 5*time.Second,
+		},
+		{
+			name: "aged response sleeps shorter",
+			ep: EndpointConfig{
+				MaxAge:           30 * time.Minute,
+				FallbackInterval: 30 * time.Minute,
+				MinSleep:         30 * time.Second,
+			},
+			ageSeconds: 1500,
+			want:       5*time.Minute + 5*time.Second,
+		},
+		{
+			name: "stale response clamps to MinSleep",
+			ep: EndpointConfig{
+				MaxAge:           30 * time.Minute,
+				FallbackInterval: 30 * time.Minute,
+				MinSleep:         30 * time.Second,
+			},
+			ageSeconds: 2000,
+			want:       30 * time.Second,
+		},
+		{
+			name: "sleep capped at FallbackInterval",
+			ep: EndpointConfig{
+				MaxAge:           60 * time.Minute,
+				FallbackInterval: 30 * time.Minute,
+				MinSleep:         30 * time.Second,
+			},
+			ageSeconds: 0,
+			want:       30 * time.Minute, // capped by FallbackInterval
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := s.calculateSleep(tt.ep, tt.ageSeconds)
+			if got != tt.want {
+				t.Errorf("calculateSleep() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScheduler_storeErrorDoesNotCrash(t *testing.T) {
+	var fetchCount int32
+
+	ep := EndpointConfig{
+		Name:             EndpointNinjaGems,
+		Source:           "ninja",
+		MaxAge:           30 * time.Minute,
+		FallbackInterval: 30 * time.Minute,
+		MaxRetries:       3,
+		MinSleep:         30 * time.Second,
+		FetchFunc: func(ctx context.Context, league string, etag string) (*FetchResult, error) {
+			atomic.AddInt32(&fetchCount, 1)
+			return &FetchResult{GemData: []GemSnapshot{{Name: "Arc", Variant: "default", Chaos: 10}}}, nil
+		},
+		StoreFunc: func(ctx context.Context, snapTime time.Time, result *FetchResult) (int, error) {
+			return 0, errors.New("disk full")
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	s, err := NewScheduler([]EndpointConfig{ep}, nil, "Standard", "", "", slog.Default())
+	if err != nil {
+		t.Fatalf("NewScheduler: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	if atomic.LoadInt32(&fetchCount) == 0 {
+		t.Error("fetch should have been called even though store will fail")
 	}
 }


### PR DESCRIPTION
## Summary
- Replace fixed-interval scheduler with goroutine-per-endpoint model
- Add cache-aware sleep calculation using poe.ninja `age` header (`sleep = max-age - age + 5s`)
- Implement ETag/If-None-Match conditional requests (304 = no-op instead of 7MB download)
- Add per-endpoint config with env var overrides (fallback interval, max retries, min sleep)
- 304 consecutive retry limit (5) with fallback to configurable interval
- Startup staleness check per endpoint to skip redundant initial fetches

## Tracker
https://softsolution.youtrack.cloud/issue/POE-22

## Test Plan
- [ ] All tests pass (`make qa`)
- [ ] Manual testing completed
- [ ] Fixtures updated (if applicable)

Generated with [Claude Code](https://claude.com/claude-code)