### PR TITLE
POE-24: Collector publish Mercure events after snapshot save

### DIFF
--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -18,6 +18,16 @@ import (
 // rate-limiting.
 const perSourceSemaphoreCapacity = 3
 
+// mercureTopicPrefix namespaces Mercure topics for the shared hub.
+const mercureTopicPrefix = "poe/collector/"
+
+// mercureTopicSuffix maps endpoint names to source-agnostic topic suffixes.
+// Falls back to the raw endpoint name if not present in the map.
+var mercureTopicSuffix = map[string]string{
+	EndpointNinjaGems:     "gems",
+	EndpointNinjaCurrency: "currency",
+}
+
 // Scheduler orchestrates price data collection with independent goroutines per
 // endpoint. Each endpoint runs its own fetch-sleep loop with cache-aware sleep
 // calculation. Endpoints sharing a Source field share a rate-limit semaphore.
@@ -291,7 +301,7 @@ func (s *Scheduler) fetchAndStore(ctx context.Context, ep EndpointConfig, state 
 		)
 
 		// Post-collect: conditional gem color upsert (gems only) + Mercure publish.
-		s.postCollect(ctx, ep.Name, snapTime)
+		s.postCollect(ctx, ep.Name, snapTime, inserted)
 	} else {
 		s.logger.Warn("no StoreFunc configured, fetch result discarded",
 			"endpoint", ep.Name,
@@ -329,8 +339,10 @@ func (s *Scheduler) calculateSleep(ep EndpointConfig, ageSeconds int) time.Durat
 }
 
 // postCollect handles actions after a successful fetch: Mercure publish for all
-// endpoints, gem color upsert for the gems endpoint only.
-func (s *Scheduler) postCollect(ctx context.Context, endpointName string, snapTime time.Time) {
+// endpoints, gem color upsert for the gems endpoint only. The inserted count
+// is forwarded to downstream subscribers so they can short-circuit analysis
+// when no new data arrived.
+func (s *Scheduler) postCollect(ctx context.Context, endpointName string, snapTime time.Time, inserted int) {
 	// Gem color resolver — only for the gems endpoint.
 	if endpointName == EndpointNinjaGems && s.resolver != nil {
 		if err := s.resolver.UpsertDiscoveries(ctx); err != nil {
@@ -341,11 +353,19 @@ func (s *Scheduler) postCollect(ctx context.Context, endpointName string, snapTi
 		}
 	}
 
+	// Build per-endpoint topic: "poe/collector/gems", "poe/collector/currency".
+	suffix, ok := mercureTopicSuffix[endpointName]
+	if !ok {
+		suffix = endpointName
+	}
+	topic := mercureTopicPrefix + suffix
+
 	// Mercure publish (non-fatal on failure).
-	payload, err := json.Marshal(map[string]string{
+	payload, err := json.Marshal(map[string]any{
 		"league":    s.league,
 		"endpoint":  endpointName,
 		"timestamp": snapTime.Format(time.RFC3339),
+		"inserted":  inserted,
 	})
 	if err != nil {
 		s.logger.Error("marshal mercure payload",
@@ -355,7 +375,7 @@ func (s *Scheduler) postCollect(ctx context.Context, endpointName string, snapTi
 		return
 	}
 
-	if err := PublishMercureEvent(ctx, s.mercureURL, s.mercureSecret, "prices-updated", string(payload)); err != nil {
+	if err := PublishMercureEvent(ctx, s.mercureURL, s.mercureSecret, topic, string(payload)); err != nil {
 		s.logger.Warn("mercure publish failed",
 			"endpoint", endpointName,
 			"error", err,

--- a/internal/collector/scheduler_test.go
+++ b/internal/collector/scheduler_test.go
@@ -1169,16 +1169,29 @@ func TestScheduler_retryCountResetsOn200AfterMultiple304s(t *testing.T) {
 }
 
 func TestScheduler_mercurePublishFiresPerEndpoint(t *testing.T) {
+	type publishEvent struct {
+		Topic    string
+		Endpoint string
+		Inserted float64 // JSON numbers decode as float64
+	}
+
 	var mu sync.Mutex
-	var publishedEndpoints []string
+	var events []publishEvent
 
 	mercureServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err == nil {
+			topic := r.FormValue("topic")
 			data := r.FormValue("data")
-			var payload map[string]string
+			var payload map[string]any
 			if err := json.Unmarshal([]byte(data), &payload); err == nil {
+				ep, _ := payload["endpoint"].(string)
+				inserted, _ := payload["inserted"].(float64)
 				mu.Lock()
-				publishedEndpoints = append(publishedEndpoints, payload["endpoint"])
+				events = append(events, publishEvent{
+					Topic:    topic,
+					Endpoint: ep,
+					Inserted: inserted,
+				})
 				mu.Unlock()
 			}
 		}
@@ -1233,12 +1246,24 @@ func TestScheduler_mercurePublishFiresPerEndpoint(t *testing.T) {
 
 	hasGems := false
 	hasCurrency := false
-	for _, ep := range publishedEndpoints {
-		if ep == EndpointNinjaGems {
+	for _, ev := range events {
+		if ev.Endpoint == EndpointNinjaGems {
 			hasGems = true
+			if ev.Topic != "poe/collector/gems" {
+				t.Errorf("gems topic = %q, want %q", ev.Topic, "poe/collector/gems")
+			}
+			if ev.Inserted != 1 {
+				t.Errorf("gems inserted = %v, want 1", ev.Inserted)
+			}
 		}
-		if ep == EndpointNinjaCurrency {
+		if ev.Endpoint == EndpointNinjaCurrency {
 			hasCurrency = true
+			if ev.Topic != "poe/collector/currency" {
+				t.Errorf("currency topic = %q, want %q", ev.Topic, "poe/collector/currency")
+			}
+			if ev.Inserted != 1 {
+				t.Errorf("currency inserted = %v, want 1", ev.Inserted)
+			}
 		}
 	}
 	if !hasGems {


### PR DESCRIPTION
## Summary
- Align Mercure publish to event-driven pipeline spec: per-endpoint topics (`poe/collector/gems`, `poe/collector/currency`) instead of flat `prices-updated`
- Thread `inserted` row count through `postCollect` and include in payload
- Always publish even when inserted=0 (downstream uses count to short-circuit)

## Tracker
https://softsolution.youtrack.cloud/issue/POE-24

## Test Plan
- [ ] All tests pass (`make qa`)
- [ ] Manual testing completed
- [ ] Fixtures updated (if applicable)

Generated with [Claude Code](https://claude.com/claude-code)