### PR TITLE
POE-62: Pre-computed storage layer (v2 tables)

### DIFF
--- a/internal/db/migrations/20260318223100_create_market_context.down.sql
+++ b/internal/db/migrations/20260318223100_create_market_context.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS market_context;

--- a/internal/db/migrations/20260318223100_create_market_context.up.sql
+++ b/internal/db/migrations/20260318223100_create_market_context.up.sql
@@ -1,0 +1,27 @@
+CREATE TABLE market_context (
+    time                TIMESTAMPTZ      NOT NULL,
+    price_percentiles   JSONB            NOT NULL DEFAULT '{}',
+    listing_percentiles JSONB            NOT NULL DEFAULT '{}',
+    velocity_mean       DOUBLE PRECISION NOT NULL DEFAULT 0,
+    velocity_sigma      DOUBLE PRECISION NOT NULL DEFAULT 0,
+    listing_vel_mean    DOUBLE PRECISION NOT NULL DEFAULT 0,
+    listing_vel_sigma   DOUBLE PRECISION NOT NULL DEFAULT 0,
+    total_gems          INTEGER          NOT NULL DEFAULT 0,
+    total_listings      INTEGER          NOT NULL DEFAULT 0,
+    tier_boundaries     JSONB            NOT NULL DEFAULT '{}',
+    hourly_bias         JSONB            NOT NULL DEFAULT '[]',
+    weekday_bias        JSONB            NOT NULL DEFAULT '[]',
+    PRIMARY KEY (time)
+);
+
+SELECT create_hypertable('market_context', 'time');
+
+CREATE INDEX idx_market_context_time ON market_context (time DESC);
+
+ALTER TABLE market_context SET (
+    timescaledb.compress,
+    timescaledb.compress_orderby = 'time DESC'
+);
+
+SELECT add_compression_policy('market_context', INTERVAL '7 days');
+SELECT add_retention_policy('market_context', INTERVAL '120 days');

--- a/internal/db/migrations/20260318223200_create_gem_features.down.sql
+++ b/internal/db/migrations/20260318223200_create_gem_features.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS gem_features;

--- a/internal/db/migrations/20260318223200_create_gem_features.up.sql
+++ b/internal/db/migrations/20260318223200_create_gem_features.up.sql
@@ -1,0 +1,38 @@
+CREATE TABLE gem_features (
+    time                TIMESTAMPTZ      NOT NULL,
+    name                TEXT             NOT NULL,
+    variant             TEXT             NOT NULL,
+    chaos               DOUBLE PRECISION NOT NULL DEFAULT 0,
+    listings            INTEGER          NOT NULL DEFAULT 0,
+    tier                TEXT             NOT NULL DEFAULT 'LOW',
+    vel_short_price     DOUBLE PRECISION NOT NULL DEFAULT 0,
+    vel_short_listing   DOUBLE PRECISION NOT NULL DEFAULT 0,
+    vel_med_price       DOUBLE PRECISION NOT NULL DEFAULT 0,
+    vel_med_listing     DOUBLE PRECISION NOT NULL DEFAULT 0,
+    vel_long_price      DOUBLE PRECISION NOT NULL DEFAULT 0,
+    vel_long_listing    DOUBLE PRECISION NOT NULL DEFAULT 0,
+    cv                  DOUBLE PRECISION NOT NULL DEFAULT 0,
+    hist_position       DOUBLE PRECISION NOT NULL DEFAULT 50,
+    high_7d             DOUBLE PRECISION NOT NULL DEFAULT 0,
+    low_7d              DOUBLE PRECISION NOT NULL DEFAULT 0,
+    flood_count         INTEGER          NOT NULL DEFAULT 0,
+    crash_count         INTEGER          NOT NULL DEFAULT 0,
+    listing_elasticity  DOUBLE PRECISION NOT NULL DEFAULT 0,
+    relative_price      DOUBLE PRECISION NOT NULL DEFAULT 0,
+    relative_listings   DOUBLE PRECISION NOT NULL DEFAULT 0,
+    PRIMARY KEY (time, name, variant)
+);
+
+SELECT create_hypertable('gem_features', 'time');
+
+CREATE INDEX idx_gem_features_tier ON gem_features (time DESC, tier);
+CREATE INDEX idx_gem_features_variant ON gem_features (variant, time DESC);
+
+ALTER TABLE gem_features SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'variant',
+    timescaledb.compress_orderby = 'time DESC'
+);
+
+SELECT add_compression_policy('gem_features', INTERVAL '7 days');
+SELECT add_retention_policy('gem_features', INTERVAL '120 days');

--- a/internal/db/migrations/20260318223300_create_gem_signals.down.sql
+++ b/internal/db/migrations/20260318223300_create_gem_signals.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS gem_signals;

--- a/internal/db/migrations/20260318223300_create_gem_signals.up.sql
+++ b/internal/db/migrations/20260318223300_create_gem_signals.up.sql
@@ -1,0 +1,32 @@
+CREATE TABLE gem_signals (
+    time                TIMESTAMPTZ      NOT NULL,
+    name                TEXT             NOT NULL,
+    variant             TEXT             NOT NULL,
+    signal              TEXT             NOT NULL DEFAULT 'STABLE',
+    confidence          INTEGER          NOT NULL DEFAULT 0,
+    sell_urgency        TEXT             NOT NULL DEFAULT '',
+    sell_reason         TEXT             NOT NULL DEFAULT '',
+    sellability         INTEGER          NOT NULL DEFAULT 50,
+    sellability_label   TEXT             NOT NULL DEFAULT 'MODERATE',
+    window_signal       TEXT             NOT NULL DEFAULT 'CLOSED',
+    advanced_signal     TEXT             NOT NULL DEFAULT '',
+    phase_modifier      DOUBLE PRECISION NOT NULL DEFAULT 1.0,
+    recommendation      TEXT             NOT NULL DEFAULT '',
+    tier                TEXT             NOT NULL DEFAULT 'LOW',
+    PRIMARY KEY (time, name, variant)
+);
+
+SELECT create_hypertable('gem_signals', 'time');
+
+CREATE INDEX idx_gem_signals_confidence ON gem_signals (time DESC, confidence DESC);
+CREATE INDEX idx_gem_signals_variant ON gem_signals (variant, time DESC);
+CREATE INDEX idx_gem_signals_tier ON gem_signals (tier, time DESC);
+
+ALTER TABLE gem_signals SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'variant',
+    timescaledb.compress_orderby = 'time DESC'
+);
+
+SELECT add_compression_policy('gem_signals', INTERVAL '7 days');
+SELECT add_retention_policy('gem_signals', INTERVAL '120 days');

--- a/internal/lab/analyzer.go
+++ b/internal/lab/analyzer.go
@@ -17,6 +17,7 @@ type Analyzer struct {
 	muFont         sync.Mutex
 	muQuality      sync.Mutex
 	muTrends       sync.Mutex
+	muV2           sync.Mutex
 }
 
 // NewAnalyzer creates an analyzer wired to the given repository.
@@ -203,6 +204,42 @@ func (a *Analyzer) RunQuality(ctx context.Context) error {
 		"results", len(results),
 		"inserted", inserted,
 	)
+	a.throttler.Signal()
+	return nil
+}
+
+// RunV2 is the entry point for the v2 pre-computed analysis pipeline.
+// It computes MarketContext, GemFeatures, and GemSignals in sequence.
+// Currently a stub — actual computation logic will be filled by POE-56 through POE-61.
+// It is safe to call from multiple goroutines; concurrent runs are serialized.
+func (a *Analyzer) RunV2(ctx context.Context) error {
+	a.muV2.Lock()
+	defer a.muV2.Unlock()
+
+	gems, snapTime, err := a.repo.LatestGemPrices(ctx)
+	if err != nil {
+		a.logger.Error("v2: failed to load gem prices", "error", err)
+		return err
+	}
+	if len(gems) == 0 {
+		a.logger.Info("v2: no gem snapshots available yet, skipping")
+		return nil
+	}
+
+	// TODO(POE-56): compute market context from gems
+	mc := MarketContext{Time: snapTime}
+	if err := a.repo.SaveMarketContext(ctx, mc); err != nil {
+		a.logger.Error("v2: failed to save market context", "error", err)
+		return err
+	}
+	if a.cache != nil {
+		a.cache.SetMarketContext(&mc)
+	}
+
+	// TODO(POE-58): compute gem features using market context
+	// TODO(POE-61): compute gem signals using features
+
+	a.logger.Info("v2 analysis stub complete", "snapTime", snapTime, "gems", len(gems))
 	a.throttler.Signal()
 	return nil
 }

--- a/internal/lab/analyzer.go
+++ b/internal/lab/analyzer.go
@@ -209,8 +209,8 @@ func (a *Analyzer) RunQuality(ctx context.Context) error {
 }
 
 // RunV2 is the entry point for the v2 pre-computed analysis pipeline.
-// It computes MarketContext, GemFeatures, and GemSignals in sequence.
-// Currently a stub — actual computation logic will be filled by POE-56 through POE-61.
+// Currently only persists a stub MarketContext — GemFeatures (POE-58) and
+// GemSignals (POE-61) computation will be added later.
 // It is safe to call from multiple goroutines; concurrent runs are serialized.
 func (a *Analyzer) RunV2(ctx context.Context) error {
 	a.muV2.Lock()
@@ -228,6 +228,7 @@ func (a *Analyzer) RunV2(ctx context.Context) error {
 
 	// TODO(POE-56): compute market context from gems
 	mc := MarketContext{Time: snapTime}
+	a.logger.Warn("v2: saving stub market context (no computation yet)", "snapTime", snapTime)
 	if err := a.repo.SaveMarketContext(ctx, mc); err != nil {
 		a.logger.Error("v2: failed to save market context", "error", err)
 		return err

--- a/internal/lab/cache.go
+++ b/internal/lab/cache.go
@@ -22,7 +22,9 @@ type Cache struct {
 	nextFetch   time.Time
 	divineRate  float64
 
-	// V2 pre-computed results
+	// V2 pre-computed results. These three fields are populated together by
+	// Analyzer.RunV2 from the same snapshot time, but may be nil independently
+	// during startup or if a pipeline stage fails.
 	marketContext *MarketContext
 	gemFeatures   []GemFeature
 	gemSignals    []GemSignal

--- a/internal/lab/cache.go
+++ b/internal/lab/cache.go
@@ -21,6 +21,11 @@ type Cache struct {
 	lastUpdated time.Time
 	nextFetch   time.Time
 	divineRate  float64
+
+	// V2 pre-computed results
+	marketContext *MarketContext
+	gemFeatures   []GemFeature
+	gemSignals    []GemSignal
 }
 
 // NewCache creates an empty analysis cache.
@@ -165,4 +170,49 @@ func (c *Cache) DivineRate() float64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.divineRate
+}
+
+// SetMarketContext replaces the cached market context.
+func (c *Cache) SetMarketContext(mc *MarketContext) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.marketContext = mc
+	c.lastUpdated = time.Now()
+}
+
+// MarketContext returns the cached market context (nil if empty).
+func (c *Cache) MarketContext() *MarketContext {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.marketContext
+}
+
+// SetGemFeatures replaces the cached gem features.
+func (c *Cache) SetGemFeatures(features []GemFeature) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.gemFeatures = features
+	c.lastUpdated = time.Now()
+}
+
+// GemFeatures returns the cached gem features (nil if empty).
+func (c *Cache) GemFeatures() []GemFeature {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.gemFeatures
+}
+
+// SetGemSignals replaces the cached gem signals.
+func (c *Cache) SetGemSignals(signals []GemSignal) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.gemSignals = signals
+	c.lastUpdated = time.Now()
+}
+
+// GemSignals returns the cached gem signals (nil if empty).
+func (c *Cache) GemSignals() []GemSignal {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.gemSignals
 }

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -2,6 +2,7 @@ package lab
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -738,4 +739,299 @@ func (r *Repository) SignalHistory(ctx context.Context, name, variant string, li
 	}
 
 	return changes, nil
+}
+
+// ---------------------------------------------------------------------------
+// V2 Pre-computed Storage Layer
+// ---------------------------------------------------------------------------
+
+// SaveMarketContext persists a single market context snapshot.
+// Uses ON CONFLICT DO NOTHING so re-runs for the same time are idempotent.
+func (r *Repository) SaveMarketContext(ctx context.Context, mc MarketContext) error {
+	pricePerc, err := json.Marshal(mc.PricePercentiles)
+	if err != nil {
+		return fmt.Errorf("lab repo: marshal price percentiles: %w", err)
+	}
+	listPerc, err := json.Marshal(mc.ListingPercentiles)
+	if err != nil {
+		return fmt.Errorf("lab repo: marshal listing percentiles: %w", err)
+	}
+	tierBounds, err := json.Marshal(mc.TierBoundaries)
+	if err != nil {
+		return fmt.Errorf("lab repo: marshal tier boundaries: %w", err)
+	}
+	hourly, err := json.Marshal(mc.HourlyBias)
+	if err != nil {
+		return fmt.Errorf("lab repo: marshal hourly bias: %w", err)
+	}
+	weekday, err := json.Marshal(mc.WeekdayBias)
+	if err != nil {
+		return fmt.Errorf("lab repo: marshal weekday bias: %w", err)
+	}
+
+	_, err = r.pool.Exec(ctx, `
+		INSERT INTO market_context
+		 (time, price_percentiles, listing_percentiles,
+		  velocity_mean, velocity_sigma, listing_vel_mean, listing_vel_sigma,
+		  total_gems, total_listings, tier_boundaries, hourly_bias, weekday_bias)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		ON CONFLICT DO NOTHING`,
+		mc.Time, pricePerc, listPerc,
+		mc.VelocityMean, mc.VelocitySigma, mc.ListingVelMean, mc.ListingVelSigma,
+		mc.TotalGems, mc.TotalListings, tierBounds, hourly, weekday,
+	)
+	if err != nil {
+		return fmt.Errorf("lab repo: insert market context: %w", err)
+	}
+	return nil
+}
+
+// LatestMarketContext returns the most recent market context snapshot.
+// Returns (nil, nil) when no rows exist.
+func (r *Repository) LatestMarketContext(ctx context.Context) (*MarketContext, error) {
+	var mc MarketContext
+	var pricePerc, listPerc, tierBounds, hourly, weekday []byte
+
+	err := r.pool.QueryRow(ctx, `
+		SELECT time, price_percentiles, listing_percentiles,
+		       velocity_mean, velocity_sigma, listing_vel_mean, listing_vel_sigma,
+		       total_gems, total_listings, tier_boundaries, hourly_bias, weekday_bias
+		FROM market_context
+		WHERE time = (SELECT MAX(time) FROM market_context)`).
+		Scan(&mc.Time, &pricePerc, &listPerc,
+			&mc.VelocityMean, &mc.VelocitySigma, &mc.ListingVelMean, &mc.ListingVelSigma,
+			&mc.TotalGems, &mc.TotalListings, &tierBounds, &hourly, &weekday)
+	if err != nil {
+		if err.Error() == "no rows in result set" {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("lab repo: query latest market context: %w", err)
+	}
+
+	if err := json.Unmarshal(pricePerc, &mc.PricePercentiles); err != nil {
+		return nil, fmt.Errorf("lab repo: unmarshal price percentiles: %w", err)
+	}
+	if err := json.Unmarshal(listPerc, &mc.ListingPercentiles); err != nil {
+		return nil, fmt.Errorf("lab repo: unmarshal listing percentiles: %w", err)
+	}
+	if err := json.Unmarshal(tierBounds, &mc.TierBoundaries); err != nil {
+		return nil, fmt.Errorf("lab repo: unmarshal tier boundaries: %w", err)
+	}
+	if err := json.Unmarshal(hourly, &mc.HourlyBias); err != nil {
+		return nil, fmt.Errorf("lab repo: unmarshal hourly bias: %w", err)
+	}
+	if err := json.Unmarshal(weekday, &mc.WeekdayBias); err != nil {
+		return nil, fmt.Errorf("lab repo: unmarshal weekday bias: %w", err)
+	}
+
+	return &mc, nil
+}
+
+// SaveGemFeatures batch-inserts pre-computed gem feature rows.
+func (r *Repository) SaveGemFeatures(ctx context.Context, features []GemFeature) (int, error) {
+	if len(features) == 0 {
+		return 0, nil
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("lab repo: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	batch := &pgx.Batch{}
+	for _, f := range features {
+		batch.Queue(
+			`INSERT INTO gem_features
+			 (time, name, variant, chaos, listings, tier,
+			  vel_short_price, vel_short_listing, vel_med_price, vel_med_listing,
+			  vel_long_price, vel_long_listing,
+			  cv, hist_position, high_7d, low_7d,
+			  flood_count, crash_count, listing_elasticity,
+			  relative_price, relative_listings)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12,
+			         $13, $14, $15, $16, $17, $18, $19, $20, $21)
+			 ON CONFLICT DO NOTHING`,
+			f.Time, f.Name, f.Variant, f.Chaos, f.Listings, f.Tier,
+			f.VelShortPrice, f.VelShortListing, f.VelMedPrice, f.VelMedListing,
+			f.VelLongPrice, f.VelLongListing,
+			f.CV, f.HistPosition, f.High7d, f.Low7d,
+			f.FloodCount, f.CrashCount, f.ListingElasticity,
+			f.RelativePrice, f.RelativeListings,
+		)
+	}
+
+	br := tx.SendBatch(ctx, batch)
+	inserted := 0
+	for range features {
+		ct, err := br.Exec()
+		if err != nil {
+			br.Close()
+			return 0, fmt.Errorf("lab repo: insert gem feature: %w", err)
+		}
+		inserted += int(ct.RowsAffected())
+	}
+	if err := br.Close(); err != nil {
+		return 0, fmt.Errorf("lab repo: close batch: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("lab repo: commit gem features: %w", err)
+	}
+
+	return inserted, nil
+}
+
+// LatestGemFeatures returns the most recent gem feature rows, optionally filtered by variant and/or tier.
+func (r *Repository) LatestGemFeatures(ctx context.Context, variant, tier string, limit int) ([]GemFeature, error) {
+	query := `
+		SELECT time, name, variant, chaos, listings, tier,
+		       vel_short_price, vel_short_listing, vel_med_price, vel_med_listing,
+		       vel_long_price, vel_long_listing,
+		       cv, hist_position, high_7d, low_7d,
+		       flood_count, crash_count, listing_elasticity,
+		       relative_price, relative_listings
+		FROM gem_features
+		WHERE time = (SELECT MAX(time) FROM gem_features)`
+	args := []any{}
+	argIdx := 1
+
+	if variant != "" {
+		query += fmt.Sprintf(` AND variant = $%d`, argIdx)
+		args = append(args, variant)
+		argIdx++
+	}
+	if tier != "" {
+		query += fmt.Sprintf(` AND tier = $%d`, argIdx)
+		args = append(args, tier)
+		argIdx++
+	}
+
+	query += fmt.Sprintf(` ORDER BY chaos DESC LIMIT $%d`, argIdx)
+	args = append(args, limit)
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("lab repo: query gem features: %w", err)
+	}
+	defer rows.Close()
+
+	var results []GemFeature
+	for rows.Next() {
+		var f GemFeature
+		if err := rows.Scan(&f.Time, &f.Name, &f.Variant, &f.Chaos, &f.Listings, &f.Tier,
+			&f.VelShortPrice, &f.VelShortListing, &f.VelMedPrice, &f.VelMedListing,
+			&f.VelLongPrice, &f.VelLongListing,
+			&f.CV, &f.HistPosition, &f.High7d, &f.Low7d,
+			&f.FloodCount, &f.CrashCount, &f.ListingElasticity,
+			&f.RelativePrice, &f.RelativeListings); err != nil {
+			return nil, fmt.Errorf("lab repo: scan gem feature: %w", err)
+		}
+		results = append(results, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("lab repo: gem features rows iteration: %w", err)
+	}
+
+	return results, nil
+}
+
+// SaveGemSignals batch-inserts pre-computed gem signal rows.
+func (r *Repository) SaveGemSignals(ctx context.Context, signals []GemSignal) (int, error) {
+	if len(signals) == 0 {
+		return 0, nil
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("lab repo: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	batch := &pgx.Batch{}
+	for _, s := range signals {
+		batch.Queue(
+			`INSERT INTO gem_signals
+			 (time, name, variant, signal, confidence,
+			  sell_urgency, sell_reason, sellability, sellability_label,
+			  window_signal, advanced_signal, phase_modifier,
+			  recommendation, tier)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+			 ON CONFLICT DO NOTHING`,
+			s.Time, s.Name, s.Variant, s.Signal, s.Confidence,
+			s.SellUrgency, s.SellReason, s.Sellability, s.SellabilityLabel,
+			s.WindowSignal, s.AdvancedSignal, s.PhaseModifier,
+			s.Recommendation, s.Tier,
+		)
+	}
+
+	br := tx.SendBatch(ctx, batch)
+	inserted := 0
+	for range signals {
+		ct, err := br.Exec()
+		if err != nil {
+			br.Close()
+			return 0, fmt.Errorf("lab repo: insert gem signal: %w", err)
+		}
+		inserted += int(ct.RowsAffected())
+	}
+	if err := br.Close(); err != nil {
+		return 0, fmt.Errorf("lab repo: close batch: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("lab repo: commit gem signals: %w", err)
+	}
+
+	return inserted, nil
+}
+
+// LatestGemSignals returns the most recent gem signal rows, optionally filtered by variant and/or tier.
+func (r *Repository) LatestGemSignals(ctx context.Context, variant, tier string, limit int) ([]GemSignal, error) {
+	query := `
+		SELECT time, name, variant, signal, confidence,
+		       sell_urgency, sell_reason, sellability, sellability_label,
+		       window_signal, advanced_signal, phase_modifier,
+		       recommendation, tier
+		FROM gem_signals
+		WHERE time = (SELECT MAX(time) FROM gem_signals)`
+	args := []any{}
+	argIdx := 1
+
+	if variant != "" {
+		query += fmt.Sprintf(` AND variant = $%d`, argIdx)
+		args = append(args, variant)
+		argIdx++
+	}
+	if tier != "" {
+		query += fmt.Sprintf(` AND tier = $%d`, argIdx)
+		args = append(args, tier)
+		argIdx++
+	}
+
+	query += fmt.Sprintf(` ORDER BY confidence DESC, sellability DESC LIMIT $%d`, argIdx)
+	args = append(args, limit)
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("lab repo: query gem signals: %w", err)
+	}
+	defer rows.Close()
+
+	var results []GemSignal
+	for rows.Next() {
+		var s GemSignal
+		if err := rows.Scan(&s.Time, &s.Name, &s.Variant, &s.Signal, &s.Confidence,
+			&s.SellUrgency, &s.SellReason, &s.Sellability, &s.SellabilityLabel,
+			&s.WindowSignal, &s.AdvancedSignal, &s.PhaseModifier,
+			&s.Recommendation, &s.Tier); err != nil {
+			return nil, fmt.Errorf("lab repo: scan gem signal: %w", err)
+		}
+		results = append(results, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("lab repo: gem signals rows iteration: %w", err)
+	}
+
+	return results, nil
 }

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -3,6 +3,7 @@ package lab
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -802,7 +803,7 @@ func (r *Repository) LatestMarketContext(ctx context.Context) (*MarketContext, e
 			&mc.VelocityMean, &mc.VelocitySigma, &mc.ListingVelMean, &mc.ListingVelSigma,
 			&mc.TotalGems, &mc.TotalListings, &tierBounds, &hourly, &weekday)
 	if err != nil {
-		if err.Error() == "no rows in result set" {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("lab repo: query latest market context: %w", err)

--- a/internal/lab/v2types.go
+++ b/internal/lab/v2types.go
@@ -1,0 +1,69 @@
+package lab
+
+import "time"
+
+// MarketContext holds pre-computed market-wide statistics for a single snapshot.
+type MarketContext struct {
+	Time               time.Time
+	PricePercentiles   map[string]float64 // P10, P25, P50, P75, P90, P99
+	ListingPercentiles map[string]float64
+	VelocityMean       float64
+	VelocitySigma      float64
+	ListingVelMean     float64
+	ListingVelSigma    float64
+	TotalGems          int
+	TotalListings      int
+	TierBoundaries     TierBoundaries
+	HourlyBias         []float64 // 24 entries, one per UTC hour
+	WeekdayBias        []float64 // 7 entries, Mon=0..Sun=6
+}
+
+// TierBoundaries holds the price cutoffs between TOP/HIGH/MID/LOW tiers.
+type TierBoundaries struct {
+	Top  float64 `json:"top"`
+	High float64 `json:"high"`
+	Mid  float64 `json:"mid"`
+}
+
+// GemFeature holds pre-computed per-gem metrics for a single snapshot.
+type GemFeature struct {
+	Time              time.Time
+	Name              string
+	Variant           string
+	Chaos             float64
+	Listings          int
+	Tier              string
+	VelShortPrice     float64
+	VelShortListing   float64
+	VelMedPrice       float64
+	VelMedListing     float64
+	VelLongPrice      float64
+	VelLongListing    float64
+	CV                float64
+	HistPosition      float64
+	High7d            float64
+	Low7d             float64
+	FloodCount        int
+	CrashCount        int
+	ListingElasticity float64
+	RelativePrice     float64
+	RelativeListings  float64
+}
+
+// GemSignal holds the computed signal and confidence for a single gem at a snapshot.
+type GemSignal struct {
+	Time             time.Time
+	Name             string
+	Variant          string
+	Signal           string
+	Confidence       int
+	SellUrgency      string
+	SellReason       string
+	Sellability      int
+	SellabilityLabel string
+	WindowSignal     string
+	AdvancedSignal   string
+	PhaseModifier    float64
+	Recommendation   string
+	Tier             string
+}

--- a/internal/lab/v2types.go
+++ b/internal/lab/v2types.go
@@ -6,7 +6,7 @@ import "time"
 type MarketContext struct {
 	Time               time.Time
 	PricePercentiles   map[string]float64 // P10, P25, P50, P75, P90, P99
-	ListingPercentiles map[string]float64
+	ListingPercentiles map[string]float64 // P10, P25, P50, P75, P90, P99
 	VelocityMean       float64
 	VelocitySigma      float64
 	ListingVelMean     float64
@@ -15,10 +15,11 @@ type MarketContext struct {
 	TotalListings      int
 	TierBoundaries     TierBoundaries
 	HourlyBias         []float64 // 24 entries, one per UTC hour
-	WeekdayBias        []float64 // 7 entries, Mon=0..Sun=6
+	WeekdayBias        []float64 // 7 entries, Sun=0..Sat=6 (matches time.Weekday)
 }
 
-// TierBoundaries holds the price cutoffs between TOP/HIGH/MID/LOW tiers.
+// TierBoundaries holds minimum chaos price thresholds for each tier.
+// A gem is TOP if chaos >= Top, HIGH if chaos >= High, MID if chaos >= Mid, otherwise LOW.
 type TierBoundaries struct {
 	Top  float64 `json:"top"`
 	High float64 `json:"high"`

--- a/internal/server/handlers/analysis.go
+++ b/internal/server/handlers/analysis.go
@@ -697,3 +697,299 @@ func SignalHistory(repo *lab.Repository) http.HandlerFunc {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// V2 Analysis Endpoints
+// ---------------------------------------------------------------------------
+
+// MarketContextAnalysis returns the latest market context snapshot.
+// No query params — returns a single object.
+// Uses in-memory cache when available, falls back to DB query.
+func MarketContextAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var mc *lab.MarketContext
+
+		// Fast path: serve from cache.
+		if cache != nil {
+			mc = cache.MarketContext()
+		}
+
+		// Slow path: fall back to DB query.
+		if mc == nil {
+			var err error
+			mc, err = repo.LatestMarketContext(r.Context())
+			if err != nil {
+				slog.Error("market context: query failed", "error", err)
+				http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+				return
+			}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if mc == nil {
+			if err := json.NewEncoder(w).Encode(map[string]any{"data": nil}); err != nil {
+				slog.Error("market context: encode response", "error", err)
+			}
+			return
+		}
+
+		type resp struct {
+			Time               string             `json:"time"`
+			PricePercentiles   map[string]float64 `json:"pricePercentiles"`
+			ListingPercentiles map[string]float64 `json:"listingPercentiles"`
+			VelocityMean       float64            `json:"velocityMean"`
+			VelocitySigma      float64            `json:"velocitySigma"`
+			ListingVelMean     float64            `json:"listingVelMean"`
+			ListingVelSigma    float64            `json:"listingVelSigma"`
+			TotalGems          int                `json:"totalGems"`
+			TotalListings      int                `json:"totalListings"`
+			TierBoundaries     lab.TierBoundaries `json:"tierBoundaries"`
+			HourlyBias         []float64          `json:"hourlyBias"`
+			WeekdayBias        []float64          `json:"weekdayBias"`
+		}
+
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"data": resp{
+				Time:               mc.Time.UTC().Format(time.RFC3339),
+				PricePercentiles:   mc.PricePercentiles,
+				ListingPercentiles: mc.ListingPercentiles,
+				VelocityMean:       mc.VelocityMean,
+				VelocitySigma:      mc.VelocitySigma,
+				ListingVelMean:     mc.ListingVelMean,
+				ListingVelSigma:    mc.ListingVelSigma,
+				TotalGems:          mc.TotalGems,
+				TotalListings:      mc.TotalListings,
+				TierBoundaries:     mc.TierBoundaries,
+				HourlyBias:         mc.HourlyBias,
+				WeekdayBias:        mc.WeekdayBias,
+			},
+		}); err != nil {
+			slog.Error("market context: encode response", "error", err)
+		}
+	}
+}
+
+// GemFeaturesAnalysis returns the latest pre-computed gem feature metrics.
+// Query params: variant (optional), tier (optional), limit (default 50, max 500).
+// Uses in-memory cache when available, falls back to DB query.
+func GemFeaturesAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		variant := normalizeVariant(r.URL.Query().Get("variant"))
+		tier := r.URL.Query().Get("tier")
+
+		limit, ok := parseLimit(w, r, 50, 500)
+		if !ok {
+			return
+		}
+
+		var results []lab.GemFeature
+
+		// Fast path: serve from cache.
+		if cache != nil {
+			if cached := cache.GemFeatures(); len(cached) > 0 {
+				results = filterGemFeatures(cached, variant, tier, limit)
+			}
+		}
+
+		// Slow path: fall back to DB query.
+		if results == nil {
+			var err error
+			results, err = repo.LatestGemFeatures(r.Context(), variant, tier, limit)
+			if err != nil {
+				slog.Error("gem features: query failed", "error", err, "variant", variant, "tier", tier)
+				http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+				return
+			}
+		}
+
+		type row struct {
+			Time              string  `json:"time"`
+			Name              string  `json:"name"`
+			Variant           string  `json:"variant"`
+			Chaos             float64 `json:"chaos"`
+			Listings          int     `json:"listings"`
+			Tier              string  `json:"tier"`
+			VelShortPrice     float64 `json:"velShortPrice"`
+			VelShortListing   float64 `json:"velShortListing"`
+			VelMedPrice       float64 `json:"velMedPrice"`
+			VelMedListing     float64 `json:"velMedListing"`
+			VelLongPrice      float64 `json:"velLongPrice"`
+			VelLongListing    float64 `json:"velLongListing"`
+			CV                float64 `json:"cv"`
+			HistPosition      float64 `json:"histPosition"`
+			High7d            float64 `json:"high7d"`
+			Low7d             float64 `json:"low7d"`
+			FloodCount        int     `json:"floodCount"`
+			CrashCount        int     `json:"crashCount"`
+			ListingElasticity float64 `json:"listingElasticity"`
+			RelativePrice     float64 `json:"relativePrice"`
+			RelativeListings  float64 `json:"relativeListings"`
+		}
+
+		rows := make([]row, 0, len(results))
+		for _, f := range results {
+			rows = append(rows, row{
+				Time:              f.Time.UTC().Format(time.RFC3339),
+				Name:              f.Name,
+				Variant:           f.Variant,
+				Chaos:             f.Chaos,
+				Listings:          f.Listings,
+				Tier:              f.Tier,
+				VelShortPrice:     f.VelShortPrice,
+				VelShortListing:   f.VelShortListing,
+				VelMedPrice:       f.VelMedPrice,
+				VelMedListing:     f.VelMedListing,
+				VelLongPrice:      f.VelLongPrice,
+				VelLongListing:    f.VelLongListing,
+				CV:                f.CV,
+				HistPosition:      f.HistPosition,
+				High7d:            f.High7d,
+				Low7d:             f.Low7d,
+				FloodCount:        f.FloodCount,
+				CrashCount:        f.CrashCount,
+				ListingElasticity: f.ListingElasticity,
+				RelativePrice:     f.RelativePrice,
+				RelativeListings:  f.RelativeListings,
+			})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"count": len(rows),
+			"data":  rows,
+		}); err != nil {
+			slog.Error("gem features: encode response", "error", err)
+		}
+	}
+}
+
+// filterGemFeatures filters and limits cached gem features.
+// Results are sorted by Chaos descending (matching the DB query order).
+func filterGemFeatures(all []lab.GemFeature, variant, tier string, limit int) []lab.GemFeature {
+	var filtered []lab.GemFeature
+	for _, f := range all {
+		if variant != "" && f.Variant != variant {
+			continue
+		}
+		if tier != "" && f.Tier != tier {
+			continue
+		}
+		filtered = append(filtered, f)
+	}
+
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].Chaos > filtered[j].Chaos
+	})
+
+	if len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered
+}
+
+// GemSignalsAnalysis returns the latest pre-computed gem signals.
+// Query params: variant (optional), tier (optional), limit (default 50, max 500).
+// Uses in-memory cache when available, falls back to DB query.
+func GemSignalsAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		variant := normalizeVariant(r.URL.Query().Get("variant"))
+		tier := r.URL.Query().Get("tier")
+
+		limit, ok := parseLimit(w, r, 50, 500)
+		if !ok {
+			return
+		}
+
+		var results []lab.GemSignal
+
+		// Fast path: serve from cache.
+		if cache != nil {
+			if cached := cache.GemSignals(); len(cached) > 0 {
+				results = filterGemSignals(cached, variant, tier, limit)
+			}
+		}
+
+		// Slow path: fall back to DB query.
+		if results == nil {
+			var err error
+			results, err = repo.LatestGemSignals(r.Context(), variant, tier, limit)
+			if err != nil {
+				slog.Error("gem signals: query failed", "error", err, "variant", variant, "tier", tier)
+				http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+				return
+			}
+		}
+
+		type row struct {
+			Time             string  `json:"time"`
+			Name             string  `json:"name"`
+			Variant          string  `json:"variant"`
+			Signal           string  `json:"signal"`
+			Confidence       int     `json:"confidence"`
+			SellUrgency      string  `json:"sellUrgency"`
+			SellReason       string  `json:"sellReason"`
+			Sellability      int     `json:"sellability"`
+			SellabilityLabel string  `json:"sellabilityLabel"`
+			WindowSignal     string  `json:"windowSignal"`
+			AdvancedSignal   string  `json:"advancedSignal"`
+			PhaseModifier    float64 `json:"phaseModifier"`
+			Recommendation   string  `json:"recommendation"`
+			Tier             string  `json:"tier"`
+		}
+
+		rows := make([]row, 0, len(results))
+		for _, s := range results {
+			rows = append(rows, row{
+				Time:             s.Time.UTC().Format(time.RFC3339),
+				Name:             s.Name,
+				Variant:          s.Variant,
+				Signal:           s.Signal,
+				Confidence:       s.Confidence,
+				SellUrgency:      s.SellUrgency,
+				SellReason:       s.SellReason,
+				Sellability:      s.Sellability,
+				SellabilityLabel: s.SellabilityLabel,
+				WindowSignal:     s.WindowSignal,
+				AdvancedSignal:   s.AdvancedSignal,
+				PhaseModifier:    s.PhaseModifier,
+				Recommendation:   s.Recommendation,
+				Tier:             s.Tier,
+			})
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"count": len(rows),
+			"data":  rows,
+		}); err != nil {
+			slog.Error("gem signals: encode response", "error", err)
+		}
+	}
+}
+
+// filterGemSignals filters and limits cached gem signals.
+// Results are sorted by Confidence descending, then Sellability descending (matching the DB query order).
+func filterGemSignals(all []lab.GemSignal, variant, tier string, limit int) []lab.GemSignal {
+	var filtered []lab.GemSignal
+	for _, s := range all {
+		if variant != "" && s.Variant != variant {
+			continue
+		}
+		if tier != "" && s.Tier != tier {
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+
+	sort.Slice(filtered, func(i, j int) bool {
+		if filtered[i].Confidence != filtered[j].Confidence {
+			return filtered[i].Confidence > filtered[j].Confidence
+		}
+		return filtered[i].Sellability > filtered[j].Sellability
+	})
+
+	if len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered
+}

--- a/internal/server/handlers/analysis.go
+++ b/internal/server/handlers/analysis.go
@@ -46,6 +46,28 @@ func parseLimit(w http.ResponseWriter, r *http.Request, defaultLimit, maxLimit i
 	return limit, true
 }
 
+// validTiers lists the allowed tier filter values for v2 gem endpoints.
+var validTiers = map[string]bool{
+	"TOP": true, "HIGH": true, "MID": true, "LOW": true,
+}
+
+// validateTier checks whether the tier parameter is valid.
+// Returns true if valid (or empty). Writes a 400 response and returns false if invalid.
+func validateTier(w http.ResponseWriter, tier string) bool {
+	if tier == "" {
+		return true
+	}
+	if !validTiers[tier] {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{
+			"error": "invalid tier: must be one of TOP, HIGH, MID, LOW",
+		})
+		return false
+	}
+	return true
+}
+
 // TransfigureAnalysis returns the latest transfigure ROI results.
 // Query params: variant (optional, e.g. "20/20"), limit (default 50, max 500).
 // Uses in-memory cache when available, falls back to DB query.
@@ -699,7 +721,7 @@ func SignalHistory(repo *lab.Repository) http.HandlerFunc {
 }
 
 // ---------------------------------------------------------------------------
-// V2 Analysis Endpoints
+// V2 Analysis Endpoints (POE-62: scaffolding; data populated by POE-56 through POE-61)
 // ---------------------------------------------------------------------------
 
 // MarketContextAnalysis returns the latest market context snapshot.
@@ -776,6 +798,9 @@ func GemFeaturesAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFun
 	return func(w http.ResponseWriter, r *http.Request) {
 		variant := normalizeVariant(r.URL.Query().Get("variant"))
 		tier := r.URL.Query().Get("tier")
+		if !validateTier(w, tier) {
+			return
+		}
 
 		limit, ok := parseLimit(w, r, 50, 500)
 		if !ok {
@@ -783,16 +808,18 @@ func GemFeaturesAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFun
 		}
 
 		var results []lab.GemFeature
+		cacheHit := false
 
 		// Fast path: serve from cache.
 		if cache != nil {
 			if cached := cache.GemFeatures(); len(cached) > 0 {
 				results = filterGemFeatures(cached, variant, tier, limit)
+				cacheHit = true
 			}
 		}
 
-		// Slow path: fall back to DB query.
-		if results == nil {
+		// Slow path: fall back to DB query when cache was not consulted.
+		if !cacheHit {
 			var err error
 			results, err = repo.LatestGemFeatures(r.Context(), variant, tier, limit)
 			if err != nil {
@@ -894,6 +921,9 @@ func GemSignalsAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc
 	return func(w http.ResponseWriter, r *http.Request) {
 		variant := normalizeVariant(r.URL.Query().Get("variant"))
 		tier := r.URL.Query().Get("tier")
+		if !validateTier(w, tier) {
+			return
+		}
 
 		limit, ok := parseLimit(w, r, 50, 500)
 		if !ok {
@@ -901,16 +931,18 @@ func GemSignalsAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc
 		}
 
 		var results []lab.GemSignal
+		cacheHit := false
 
 		// Fast path: serve from cache.
 		if cache != nil {
 			if cached := cache.GemSignals(); len(cached) > 0 {
 				results = filterGemSignals(cached, variant, tier, limit)
+				cacheHit = true
 			}
 		}
 
-		// Slow path: fall back to DB query.
-		if results == nil {
+		// Slow path: fall back to DB query when cache was not consulted.
+		if !cacheHit {
 			var err error
 			results, err = repo.LatestGemSignals(r.Context(), variant, tier, limit)
 			if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -72,6 +72,11 @@ func NewRouter(pinger handlers.Pinger, frontendFS fs.FS, cfg RouterConfig) http.
 		r.Get("/api/analysis/gems/names", handlers.GemNamesAutocomplete(cfg.LabRepo, cfg.LabCache))
 		r.Get("/api/analysis/status", handlers.AnalysisStatus(cfg.LabCache, cfg.Pool, cfg.League))
 		r.Get("/api/analysis/history", handlers.SignalHistory(cfg.LabRepo))
+
+		// V2 pre-computed analysis endpoints
+		r.Get("/api/analysis/market-context", handlers.MarketContextAnalysis(cfg.LabRepo, cfg.LabCache))
+		r.Get("/api/analysis/gem-features", handlers.GemFeaturesAnalysis(cfg.LabRepo, cfg.LabCache))
+		r.Get("/api/analysis/gem-signals", handlers.GemSignalsAnalysis(cfg.LabRepo, cfg.LabCache))
 	}
 
 	if cfg.TradeGate != nil {


### PR DESCRIPTION
## Summary
- Add 3 new TimescaleDB hypertables: market_context, gem_features, gem_signals
- Add Go structs (MarketContext, GemFeature, GemSignal) in v2types.go
- Add Save/Latest repository methods for all three tables
- Add cache fields with Set/Get pairs
- Add API handler stubs (/api/analysis/market-context, gem-features, gem-signals)
- Add RunV2 analyzer stub wiring the pipeline end-to-end

## Tracker
https://softsolution.youtrack.cloud/issue/POE-62

## Test Plan
- [x] All tests pass (`go test ./...`)
- [ ] Manual testing: verify tables created on startup
- [ ] API endpoints return empty results (no computed data yet)

Generated with [Claude Code](https://claude.com/claude-code)