### PR TITLE
POE-56: Market-relative foundation — percentile/σ context

### DIFF
--- a/cmd/optimize/main.go
+++ b/cmd/optimize/main.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -85,7 +86,6 @@ func main() {
 	fmt.Fprintf(os.Stderr, "Pre-computed %d evaluation points in %s\n", len(features), time.Since(t1).Round(time.Millisecond))
 	fmt.Fprintf(os.Stderr, "Market context: %d gems, vel_mean=%.2f vel_sigma=%.2f\n",
 		marketCtx.TotalGems, marketCtx.VelocityMean, marketCtx.VelocitySigma)
-	_ = marketCtx // available for future relative-threshold sweep
 
 	grid := generateGrid()
 	fmt.Fprintf(os.Stderr, "Sweeping %d parameter combos...\n", len(grid))
@@ -258,10 +258,25 @@ func precomputeFeatures(snapshots []Snapshot) ([]precomputed, []lab.GemPrice, *l
 		}
 	}
 
-	// Build GemPriceHistory from rolling history for MarketContext computation.
+	// Build a set of transfigured gem keys from the last snapshot so that
+	// histSlice only includes history for the active population (matching the
+	// analyzer's GemPriceHistoryByVariant which filters to transfigured,
+	// non-corrupted, non-Trarthus gems with chaos > 5).
+	transfiguredKeys := make(map[gemKey]bool)
+	if len(times) > 0 {
+		for _, s := range timeMap[times[len(times)-1]] {
+			if s.IsTransfigured && !strings.Contains(s.Name, "Trarthus") {
+				transfiguredKeys[gemKey{s.Name, s.Variant}] = true
+			}
+		}
+	}
+
 	var histSlice []lab.GemPriceHistory
 	for gk, h := range gemHist {
 		if len(h.points) < 2 {
+			continue
+		}
+		if !transfiguredKeys[gk] {
 			continue
 		}
 		histSlice = append(histSlice, lab.GemPriceHistory{

--- a/cmd/optimize/main.go
+++ b/cmd/optimize/main.go
@@ -81,8 +81,11 @@ func main() {
 
 	fmt.Fprintln(os.Stderr, "Pre-computing features (velocities, CVs, future outcomes)...")
 	t1 := time.Now()
-	features, lastGems := precomputeFeatures(snapshots)
+	features, lastGems, marketCtx := precomputeFeatures(snapshots)
 	fmt.Fprintf(os.Stderr, "Pre-computed %d evaluation points in %s\n", len(features), time.Since(t1).Round(time.Millisecond))
+	fmt.Fprintf(os.Stderr, "Market context: %d gems, vel_mean=%.2f vel_sigma=%.2f\n",
+		marketCtx.TotalGems, marketCtx.VelocityMean, marketCtx.VelocitySigma)
+	_ = marketCtx // available for future relative-threshold sweep
 
 	grid := generateGrid()
 	fmt.Fprintf(os.Stderr, "Sweeping %d parameter combos...\n", len(grid))
@@ -152,8 +155,9 @@ func loadFromDB(ctx context.Context, pool *pgxpool.Pool) []Snapshot {
 }
 
 // precomputeFeatures builds all config-independent evaluation points in one pass.
-// Returns the feature slice and the last snapshot's gem prices (for tier computation).
-func precomputeFeatures(snapshots []Snapshot) ([]precomputed, []lab.GemPrice) {
+// Returns the feature slice, the last snapshot's gem prices (for tier computation),
+// and a MarketContext computed from the last snapshot.
+func precomputeFeatures(snapshots []Snapshot) ([]precomputed, []lab.GemPrice, *lab.MarketContext) {
 	// Group snapshots by time.
 	timeMap := make(map[time.Time]map[gemKey]Snapshot)
 	var times []time.Time
@@ -254,7 +258,27 @@ func precomputeFeatures(snapshots []Snapshot) ([]precomputed, []lab.GemPrice) {
 		}
 	}
 
-	return features, lastGems
+	// Build GemPriceHistory from rolling history for MarketContext computation.
+	var histSlice []lab.GemPriceHistory
+	for gk, h := range gemHist {
+		if len(h.points) < 2 {
+			continue
+		}
+		histSlice = append(histSlice, lab.GemPriceHistory{
+			Name:    gk.Name,
+			Variant: gk.Variant,
+			Points:  h.points,
+		})
+	}
+
+	// Compute market context from the last snapshot's gems and accumulated history.
+	var snapTime time.Time
+	if len(times) > 0 {
+		snapTime = times[len(times)-1]
+	}
+	mc := lab.ComputeMarketContext(snapTime, lastGems, histSlice)
+
+	return features, lastGems, &mc
 }
 
 // sweep evaluates every config against pre-computed features.

--- a/internal/lab/analyzer.go
+++ b/internal/lab/analyzer.go
@@ -226,9 +226,14 @@ func (a *Analyzer) RunV2(ctx context.Context) error {
 		return nil
 	}
 
-	// TODO(POE-56): compute market context from gems
-	mc := MarketContext{Time: snapTime}
-	a.logger.Warn("v2: saving stub market context (no computation yet)", "snapTime", snapTime)
+	// Fetch history for velocity computation (same call RunTrends uses).
+	history, err := a.repo.GemPriceHistoryByVariant(ctx, "", 168)
+	if err != nil {
+		a.logger.Error("v2: failed to load gem price history", "error", err)
+		return err
+	}
+
+	mc := ComputeMarketContext(snapTime, gems, history)
 	if err := a.repo.SaveMarketContext(ctx, mc); err != nil {
 		a.logger.Error("v2: failed to save market context", "error", err)
 		return err

--- a/internal/lab/market_context.go
+++ b/internal/lab/market_context.go
@@ -1,0 +1,164 @@
+package lab
+
+import (
+	"math"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ComputeMarketContext produces market-wide statistics from raw gem data and history.
+// It is a pure function with no side effects — called from RunV2 and the optimizer.
+// History may be nil when no historical data is available; velocity stats will be zero.
+func ComputeMarketContext(snapTime time.Time, gems []GemPrice, history []GemPriceHistory) MarketContext {
+	mc := MarketContext{
+		Time:               snapTime,
+		PricePercentiles:   make(map[string]float64),
+		ListingPercentiles: make(map[string]float64),
+		HourlyBias:         make([]float64, 24),
+		WeekdayBias:        make([]float64, 7),
+	}
+
+	// Stub bias values: 1.0 (neutral). POE-60 fills in real temporal patterns.
+	for i := range mc.HourlyBias {
+		mc.HourlyBias[i] = 1.0
+	}
+	for i := range mc.WeekdayBias {
+		mc.WeekdayBias[i] = 1.0
+	}
+
+	// Filter to active transfigured gems (not corrupted, exclude Trarthus).
+	var active []GemPrice
+	for _, g := range gems {
+		if !g.IsTransfigured || g.IsCorrupted {
+			continue
+		}
+		if strings.Contains(g.Name, "Trarthus") {
+			continue
+		}
+		active = append(active, g)
+	}
+
+	mc.TotalGems = len(active)
+	for _, g := range active {
+		mc.TotalListings += g.Listings
+	}
+
+	// Compute percentiles from active gems.
+	if len(active) > 0 {
+		prices := make([]float64, len(active))
+		listings := make([]float64, len(active))
+		for i, g := range active {
+			prices[i] = g.Chaos
+			listings[i] = float64(g.Listings)
+		}
+		sort.Float64s(prices)
+		sort.Float64s(listings)
+
+		for _, key := range []string{"P5", "P10", "P25", "P50", "P75", "P90", "P99"} {
+			p := percentileKeyToFraction(key)
+			mc.PricePercentiles[key] = percentile(prices, p)
+			mc.ListingPercentiles[key] = percentile(listings, p)
+		}
+	}
+
+	// Compute velocity distribution from history.
+	if len(history) > 0 {
+		var velPrices, velListings []float64
+		for _, h := range history {
+			if len(h.Points) < 2 {
+				continue
+			}
+			pv := velocity(h.Points, func(p PricePoint) float64 { return p.Chaos })
+			lv := velocity(h.Points, func(p PricePoint) float64 { return float64(p.Listings) })
+			pv = sanitizeFloat(pv)
+			lv = sanitizeFloat(lv)
+			velPrices = append(velPrices, pv)
+			velListings = append(velListings, lv)
+		}
+		mc.VelocityMean, mc.VelocitySigma = meanStddev(velPrices)
+		mc.ListingVelMean, mc.ListingVelSigma = meanStddev(velListings)
+	}
+
+	// Compute tier boundaries using existing computePriceTiers.
+	// Pass all gems (including non-transfigured) since computePriceTiers filters internally.
+	top, mid := computePriceTiers(gems)
+	mc.TierBoundaries.Top = top
+	mc.TierBoundaries.Mid = mid
+	// High = midpoint between Top and Mid (placeholder — POE-57 adds gap detection).
+	mc.TierBoundaries.High = (top + mid) / 2
+
+	return mc
+}
+
+// percentile computes the p-th percentile (0..1) from a sorted slice using
+// fractional index p*(n-1) with linear interpolation (numpy "linear" method).
+func percentile(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return sorted[0]
+	}
+
+	idx := p * float64(n-1)
+	lower := int(math.Floor(idx))
+	upper := lower + 1
+	if upper >= n {
+		return sorted[n-1]
+	}
+
+	frac := idx - float64(lower)
+	return sorted[lower] + frac*(sorted[upper]-sorted[lower])
+}
+
+// percentileKeyToFraction converts "P5", "P10", etc. to 0.05, 0.10, etc.
+func percentileKeyToFraction(key string) float64 {
+	switch key {
+	case "P5":
+		return 0.05
+	case "P10":
+		return 0.10
+	case "P25":
+		return 0.25
+	case "P50":
+		return 0.50
+	case "P75":
+		return 0.75
+	case "P90":
+		return 0.90
+	case "P99":
+		return 0.99
+	default:
+		return 0.50
+	}
+}
+
+// meanStddev computes the mean and population standard deviation of a float slice.
+// Returns (0, 0) for empty input.
+func meanStddev(vals []float64) (float64, float64) {
+	n := len(vals)
+	if n == 0 {
+		return 0, 0
+	}
+
+	var sum float64
+	for _, v := range vals {
+		sum += v
+	}
+	mean := sum / float64(n)
+
+	if n == 1 {
+		return mean, 0
+	}
+
+	var variance float64
+	for _, v := range vals {
+		d := v - mean
+		variance += d * d
+	}
+	variance /= float64(n)
+
+	return mean, math.Sqrt(variance)
+}

--- a/internal/lab/market_context.go
+++ b/internal/lab/market_context.go
@@ -1,11 +1,17 @@
 package lab
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"strings"
 	"time"
 )
+
+// PercentileKeys is the canonical list of percentile keys used for market context
+// price and listing distributions. All call sites should iterate this slice
+// rather than hardcoding key strings.
+var PercentileKeys = []string{"P5", "P10", "P25", "P50", "P75", "P90", "P99"}
 
 // ComputeMarketContext produces market-wide statistics from raw gem data and history.
 // It is a pure function with no side effects — called from RunV2 and the optimizer.
@@ -55,7 +61,7 @@ func ComputeMarketContext(snapTime time.Time, gems []GemPrice, history []GemPric
 		sort.Float64s(prices)
 		sort.Float64s(listings)
 
-		for _, key := range []string{"P5", "P10", "P25", "P50", "P75", "P90", "P99"} {
+		for _, key := range PercentileKeys {
 			p := percentileKeyToFraction(key)
 			mc.PricePercentiles[key] = percentile(prices, p)
 			mc.ListingPercentiles[key] = percentile(listings, p)
@@ -63,10 +69,16 @@ func ComputeMarketContext(snapTime time.Time, gems []GemPrice, history []GemPric
 	}
 
 	// Compute velocity distribution from history.
+	// Only include gems where velocity is computable (positive time span).
+	// Entries with hours <= 0 (identical/very close timestamps) produce
+	// false-zero velocities that would bias market-wide statistics.
 	if len(history) > 0 {
 		var velPrices, velListings []float64
 		for _, h := range history {
 			if len(h.Points) < 2 {
+				continue
+			}
+			if !velocityComputable(h.Points) {
 				continue
 			}
 			pv := velocity(h.Points, func(p PricePoint) float64 { return p.Chaos })
@@ -114,6 +126,9 @@ func percentile(sorted []float64, p float64) float64 {
 }
 
 // percentileKeyToFraction converts "P5", "P10", etc. to 0.05, 0.10, etc.
+// Panics on unknown keys — the key list is hardcoded in PercentileKeys, so any
+// mismatch is a programmer error that must be caught immediately rather than
+// silently returning a wrong value.
 func percentileKeyToFraction(key string) float64 {
 	switch key {
 	case "P5":
@@ -131,12 +146,29 @@ func percentileKeyToFraction(key string) float64 {
 	case "P99":
 		return 0.99
 	default:
-		return 0.50
+		panic(fmt.Sprintf("percentileKeyToFraction: unknown key %q — update PercentileKeys and this switch together", key))
 	}
 }
 
+// velocityComputable checks whether a price point series has a positive time span
+// between first and last relevant points (matching the velocity() function's windowing).
+// Returns false when timestamps are identical or reversed, which would cause velocity()
+// to return a degenerate zero that does not represent genuine zero price change.
+func velocityComputable(points []PricePoint) bool {
+	n := len(points)
+	if n < 2 {
+		return false
+	}
+	start := 0
+	if n > 4 {
+		start = n - 4
+	}
+	return points[n-1].Time.Sub(points[start].Time).Hours() > 0
+}
+
 // meanStddev computes the mean and population standard deviation of a float slice.
-// Returns (0, 0) for empty input.
+// Returns (0, 0) for empty input. Output is sanitized to prevent NaN/Inf
+// propagation from floating point overflow on extreme input magnitudes.
 func meanStddev(vals []float64) (float64, float64) {
 	n := len(vals)
 	if n == 0 {
@@ -150,7 +182,7 @@ func meanStddev(vals []float64) (float64, float64) {
 	mean := sum / float64(n)
 
 	if n == 1 {
-		return mean, 0
+		return sanitizeFloat(mean), 0
 	}
 
 	var variance float64
@@ -160,5 +192,5 @@ func meanStddev(vals []float64) (float64, float64) {
 	}
 	variance /= float64(n)
 
-	return mean, math.Sqrt(variance)
+	return sanitizeFloat(mean), sanitizeFloat(math.Sqrt(variance))
 }

--- a/internal/lab/market_context_test.go
+++ b/internal/lab/market_context_test.go
@@ -222,7 +222,7 @@ func TestComputeMarketContext_SingleGem(t *testing.T) {
 		t.Errorf("TotalListings = %d, want 7", mc.TotalListings)
 	}
 	// Single gem: all percentiles equal that gem's price.
-	for _, key := range []string{"P5", "P10", "P25", "P50", "P75", "P90", "P99"} {
+	for _, key := range PercentileKeys {
 		if got := mc.PricePercentiles[key]; !approxEqual(got, 42, 0.01) {
 			t.Errorf("PricePercentiles[%q] = %.2f, want 42", key, got)
 		}
@@ -247,7 +247,7 @@ func TestComputeMarketContext_AllSamePrice(t *testing.T) {
 
 	mc := ComputeMarketContext(snapTime, gems, nil)
 
-	for _, key := range []string{"P5", "P10", "P25", "P50", "P75", "P90", "P99"} {
+	for _, key := range PercentileKeys {
 		if got := mc.PricePercentiles[key]; !approxEqual(got, 100, 0.01) {
 			t.Errorf("PricePercentiles[%q] = %.2f, want 100", key, got)
 		}

--- a/internal/lab/market_context_test.go
+++ b/internal/lab/market_context_test.go
@@ -1,0 +1,367 @@
+package lab
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// helper: approximate float comparison
+func approxEqual(a, b, tolerance float64) bool {
+	return math.Abs(a-b) <= tolerance
+}
+
+func TestComputeMarketContext_Percentiles(t *testing.T) {
+	// 10 transfigured gems with known prices and listings.
+	// Prices: 5, 10, 20, 30, 50, 80, 100, 200, 500, 1000
+	// Listings: 1, 2, 3, 5, 8, 10, 15, 20, 30, 50
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	gems := []GemPrice{
+		{Name: "Gem A of X", Variant: "20/20", Chaos: 5, Listings: 1, IsTransfigured: true},
+		{Name: "Gem B of X", Variant: "20/20", Chaos: 10, Listings: 2, IsTransfigured: true},
+		{Name: "Gem C of X", Variant: "20/20", Chaos: 20, Listings: 3, IsTransfigured: true},
+		{Name: "Gem D of X", Variant: "20/20", Chaos: 30, Listings: 5, IsTransfigured: true},
+		{Name: "Gem E of X", Variant: "20/20", Chaos: 50, Listings: 8, IsTransfigured: true},
+		{Name: "Gem F of X", Variant: "20/20", Chaos: 80, Listings: 10, IsTransfigured: true},
+		{Name: "Gem G of X", Variant: "20/20", Chaos: 100, Listings: 15, IsTransfigured: true},
+		{Name: "Gem H of X", Variant: "20/20", Chaos: 200, Listings: 20, IsTransfigured: true},
+		{Name: "Gem I of X", Variant: "20/20", Chaos: 500, Listings: 30, IsTransfigured: true},
+		{Name: "Gem J of X", Variant: "20/20", Chaos: 1000, Listings: 50, IsTransfigured: true},
+	}
+
+	mc := ComputeMarketContext(snapTime, gems, nil)
+
+	if mc.Time != snapTime {
+		t.Errorf("Time = %v, want %v", mc.Time, snapTime)
+	}
+
+	// Percentile method: p * (n-1) with linear interpolation.
+	// For prices sorted: [5, 10, 20, 30, 50, 80, 100, 200, 500, 1000], n=10
+	// P50: 0.50 * 9 = 4.5 → lerp(50, 80, 0.5) = 65
+	// P10: 0.10 * 9 = 0.9 → lerp(5, 10, 0.9) = 9.5
+	// P25: 0.25 * 9 = 2.25 → lerp(20, 30, 0.25) = 22.5
+	// P75: 0.75 * 9 = 6.75 → lerp(100, 200, 0.75) = 175
+	// P90: 0.90 * 9 = 8.1 → lerp(500, 1000, 0.1) = 550
+	// P99: 0.99 * 9 = 8.91 → lerp(500, 1000, 0.91) = 955
+	// P5: 0.05 * 9 = 0.45 → lerp(5, 10, 0.45) = 7.25
+
+	priceTests := map[string]float64{
+		"P5":  7.25,
+		"P10": 9.5,
+		"P25": 22.5,
+		"P50": 65,
+		"P75": 175,
+		"P90": 550,
+		"P99": 955,
+	}
+	for key, want := range priceTests {
+		got, ok := mc.PricePercentiles[key]
+		if !ok {
+			t.Errorf("PricePercentiles[%q] missing", key)
+			continue
+		}
+		if !approxEqual(got, want, 0.01) {
+			t.Errorf("PricePercentiles[%q] = %.2f, want %.2f", key, got, want)
+		}
+	}
+
+	// Listings sorted: [1, 2, 3, 5, 8, 10, 15, 20, 30, 50], n=10
+	// P50: 0.50 * 9 = 4.5 → lerp(8, 10, 0.5) = 9
+	// P10: 0.10 * 9 = 0.9 → lerp(1, 2, 0.9) = 1.9
+	// P25: 0.25 * 9 = 2.25 → lerp(3, 5, 0.25) = 3.5
+	// P75: 0.75 * 9 = 6.75 → lerp(15, 20, 0.75) = 18.75
+	// P90: 0.90 * 9 = 8.1 → lerp(30, 50, 0.1) = 32
+	// P99: 0.99 * 9 = 8.91 → lerp(30, 50, 0.91) = 48.2
+	// P5: 0.05 * 9 = 0.45 → lerp(1, 2, 0.45) = 1.45
+
+	listingTests := map[string]float64{
+		"P5":  1.45,
+		"P10": 1.9,
+		"P25": 3.5,
+		"P50": 9,
+		"P75": 18.75,
+		"P90": 32,
+		"P99": 48.2,
+	}
+	for key, want := range listingTests {
+		got, ok := mc.ListingPercentiles[key]
+		if !ok {
+			t.Errorf("ListingPercentiles[%q] missing", key)
+			continue
+		}
+		if !approxEqual(got, want, 0.01) {
+			t.Errorf("ListingPercentiles[%q] = %.2f, want %.2f", key, got, want)
+		}
+	}
+}
+
+func TestComputeMarketContext_VelocityStats(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	gems := []GemPrice{
+		{Name: "Gem A of X", Variant: "20/20", Chaos: 50, Listings: 10, IsTransfigured: true},
+		{Name: "Gem B of X", Variant: "20/20", Chaos: 100, Listings: 20, IsTransfigured: true},
+	}
+
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				{Time: t0, Chaos: 40, Listings: 12},
+				{Time: t0.Add(time.Hour), Chaos: 50, Listings: 10},
+			},
+		},
+		{
+			Name: "Gem B of X", Variant: "20/20", GemColor: "BLUE",
+			Points: []PricePoint{
+				{Time: t0, Chaos: 90, Listings: 25},
+				{Time: t0.Add(time.Hour), Chaos: 100, Listings: 20},
+			},
+		},
+	}
+
+	mc := ComputeMarketContext(snapTime, gems, history)
+
+	// Gem A: priceVel = (50-40)/1h = 10, listingVel = (10-12)/1h = -2
+	// Gem B: priceVel = (100-90)/1h = 10, listingVel = (20-25)/1h = -5
+	// VelocityMean = (10+10)/2 = 10
+	// VelocitySigma = stddev([10,10]) = 0
+	// ListingVelMean = (-2 + -5)/2 = -3.5
+	// ListingVelSigma = stddev([-2,-5]) = 1.5
+
+	if !approxEqual(mc.VelocityMean, 10, 0.01) {
+		t.Errorf("VelocityMean = %.2f, want 10.0", mc.VelocityMean)
+	}
+	if !approxEqual(mc.VelocitySigma, 0, 0.01) {
+		t.Errorf("VelocitySigma = %.2f, want 0.0", mc.VelocitySigma)
+	}
+	if !approxEqual(mc.ListingVelMean, -3.5, 0.01) {
+		t.Errorf("ListingVelMean = %.2f, want -3.5", mc.ListingVelMean)
+	}
+	if !approxEqual(mc.ListingVelSigma, 1.5, 0.01) {
+		t.Errorf("ListingVelSigma = %.2f, want 1.5", mc.ListingVelSigma)
+	}
+}
+
+func TestComputeMarketContext_Totals(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	gems := []GemPrice{
+		{Name: "Gem A of X", Variant: "20/20", Chaos: 50, Listings: 10, IsTransfigured: true},
+		{Name: "Gem B of X", Variant: "20/20", Chaos: 100, Listings: 20, IsTransfigured: true},
+		{Name: "Gem C of X", Variant: "20/20", Chaos: 200, Listings: 5, IsTransfigured: true},
+		// Excluded: corrupted
+		{Name: "Gem D of X", Variant: "20/20", Chaos: 300, Listings: 8, IsTransfigured: true, IsCorrupted: true},
+		// Excluded: not transfigured
+		{Name: "Gem E", Variant: "20/20", Chaos: 400, Listings: 12, IsTransfigured: false},
+		// Excluded: Trarthus
+		{Name: "Trarthus of X", Variant: "20/20", Chaos: 500, Listings: 15, IsTransfigured: true},
+	}
+
+	mc := ComputeMarketContext(snapTime, gems, nil)
+
+	if mc.TotalGems != 3 {
+		t.Errorf("TotalGems = %d, want 3", mc.TotalGems)
+	}
+	// 10 + 20 + 5 = 35
+	if mc.TotalListings != 35 {
+		t.Errorf("TotalListings = %d, want 35", mc.TotalListings)
+	}
+}
+
+func TestComputeMarketContext_EmptyGems(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	mc := ComputeMarketContext(snapTime, nil, nil)
+
+	if mc.TotalGems != 0 {
+		t.Errorf("TotalGems = %d, want 0", mc.TotalGems)
+	}
+	if mc.TotalListings != 0 {
+		t.Errorf("TotalListings = %d, want 0", mc.TotalListings)
+	}
+	if mc.VelocityMean != 0 {
+		t.Errorf("VelocityMean = %f, want 0", mc.VelocityMean)
+	}
+	if mc.VelocitySigma != 0 {
+		t.Errorf("VelocitySigma = %f, want 0", mc.VelocitySigma)
+	}
+
+	// Maps must be initialized (not nil) for JSON marshaling.
+	if mc.PricePercentiles == nil {
+		t.Error("PricePercentiles is nil, must be initialized map")
+	}
+	if mc.ListingPercentiles == nil {
+		t.Error("ListingPercentiles is nil, must be initialized map")
+	}
+	if mc.HourlyBias == nil {
+		t.Error("HourlyBias is nil, must be initialized slice")
+	}
+	if len(mc.HourlyBias) != 24 {
+		t.Errorf("HourlyBias length = %d, want 24", len(mc.HourlyBias))
+	}
+	if mc.WeekdayBias == nil {
+		t.Error("WeekdayBias is nil, must be initialized slice")
+	}
+	if len(mc.WeekdayBias) != 7 {
+		t.Errorf("WeekdayBias length = %d, want 7", len(mc.WeekdayBias))
+	}
+}
+
+func TestComputeMarketContext_SingleGem(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	gems := []GemPrice{
+		{Name: "Gem A of X", Variant: "20/20", Chaos: 42, Listings: 7, IsTransfigured: true},
+	}
+
+	mc := ComputeMarketContext(snapTime, gems, nil)
+
+	if mc.TotalGems != 1 {
+		t.Errorf("TotalGems = %d, want 1", mc.TotalGems)
+	}
+	if mc.TotalListings != 7 {
+		t.Errorf("TotalListings = %d, want 7", mc.TotalListings)
+	}
+	// Single gem: all percentiles equal that gem's price.
+	for _, key := range []string{"P5", "P10", "P25", "P50", "P75", "P90", "P99"} {
+		if got := mc.PricePercentiles[key]; !approxEqual(got, 42, 0.01) {
+			t.Errorf("PricePercentiles[%q] = %.2f, want 42", key, got)
+		}
+		if got := mc.ListingPercentiles[key]; !approxEqual(got, 7, 0.01) {
+			t.Errorf("ListingPercentiles[%q] = %.2f, want 7", key, got)
+		}
+	}
+}
+
+func TestComputeMarketContext_AllSamePrice(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	gems := make([]GemPrice, 5)
+	for i := range gems {
+		gems[i] = GemPrice{
+			Name:           "Gem " + string(rune('A'+i)) + " of X",
+			Variant:        "20/20",
+			Chaos:          100,
+			Listings:       10,
+			IsTransfigured: true,
+		}
+	}
+
+	mc := ComputeMarketContext(snapTime, gems, nil)
+
+	for _, key := range []string{"P5", "P10", "P25", "P50", "P75", "P90", "P99"} {
+		if got := mc.PricePercentiles[key]; !approxEqual(got, 100, 0.01) {
+			t.Errorf("PricePercentiles[%q] = %.2f, want 100", key, got)
+		}
+	}
+
+	// Velocity sigma = 0 when no history
+	if mc.VelocitySigma != 0 {
+		t.Errorf("VelocitySigma = %f, want 0", mc.VelocitySigma)
+	}
+}
+
+func TestComputeMarketContext_BiasStubs(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	gems := []GemPrice{
+		{Name: "Gem A of X", Variant: "20/20", Chaos: 50, Listings: 10, IsTransfigured: true},
+	}
+
+	mc := ComputeMarketContext(snapTime, gems, nil)
+
+	if len(mc.HourlyBias) != 24 {
+		t.Fatalf("HourlyBias length = %d, want 24", len(mc.HourlyBias))
+	}
+	for i, v := range mc.HourlyBias {
+		if v != 1.0 {
+			t.Errorf("HourlyBias[%d] = %f, want 1.0", i, v)
+		}
+	}
+
+	if len(mc.WeekdayBias) != 7 {
+		t.Fatalf("WeekdayBias length = %d, want 7", len(mc.WeekdayBias))
+	}
+	for i, v := range mc.WeekdayBias {
+		if v != 1.0 {
+			t.Errorf("WeekdayBias[%d] = %f, want 1.0", i, v)
+		}
+	}
+}
+
+func TestComputeMarketContext_TierBoundaries(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	// Create enough gems for computePriceTiers to produce real thresholds.
+	// We need at least 15 transfigured gems with Chaos > 0.
+	var gems []GemPrice
+	prices := []float64{5, 10, 15, 20, 30, 40, 50, 60, 80, 100, 120, 150, 200, 300, 500, 800, 1000}
+	for i, p := range prices {
+		gems = append(gems, GemPrice{
+			Name:           "Gem " + string(rune('A'+i)) + " of X",
+			Variant:        "20/20",
+			Chaos:          p,
+			Listings:       10,
+			IsTransfigured: true,
+		})
+	}
+
+	mc := ComputeMarketContext(snapTime, gems, nil)
+
+	// Tier boundaries should be non-zero and Top > High > Mid.
+	if mc.TierBoundaries.Top <= 0 {
+		t.Errorf("TierBoundaries.Top = %f, want > 0", mc.TierBoundaries.Top)
+	}
+	if mc.TierBoundaries.Mid <= 0 {
+		t.Errorf("TierBoundaries.Mid = %f, want > 0", mc.TierBoundaries.Mid)
+	}
+	if mc.TierBoundaries.High <= 0 {
+		t.Errorf("TierBoundaries.High = %f, want > 0", mc.TierBoundaries.High)
+	}
+	if mc.TierBoundaries.Top <= mc.TierBoundaries.High {
+		t.Errorf("Top (%.2f) should be > High (%.2f)", mc.TierBoundaries.Top, mc.TierBoundaries.High)
+	}
+	if mc.TierBoundaries.High <= mc.TierBoundaries.Mid {
+		t.Errorf("High (%.2f) should be > Mid (%.2f)", mc.TierBoundaries.High, mc.TierBoundaries.Mid)
+	}
+}
+
+func TestPercentile(t *testing.T) {
+	sorted := []float64{5, 10, 20, 30, 50, 80, 100, 200, 500, 1000}
+
+	tests := []struct {
+		p    float64
+		want float64
+	}{
+		{0.0, 5},
+		{1.0, 1000},
+		{0.5, 65},     // index 4.5 → lerp(50, 80, 0.5) = 65
+		{0.25, 22.5},  // index 2.25 → lerp(20, 30, 0.25) = 22.5
+		{0.10, 9.5},   // index 0.9 → lerp(5, 10, 0.9) = 9.5
+		{0.75, 175},   // index 6.75 → lerp(100, 200, 0.75) = 175
+		{0.90, 550},   // index 8.1 → lerp(500, 1000, 0.1) = 550
+		{0.99, 955},   // index 8.91 → lerp(500, 1000, 0.91) = 955
+		{0.05, 7.25},  // index 0.45 → lerp(5, 10, 0.45) = 7.25
+	}
+
+	for _, tt := range tests {
+		got := percentile(sorted, tt.p)
+		if !approxEqual(got, tt.want, 0.01) {
+			t.Errorf("percentile(sorted, %.2f) = %.2f, want %.2f", tt.p, got, tt.want)
+		}
+	}
+}
+
+func TestPercentile_SingleElement(t *testing.T) {
+	sorted := []float64{42}
+	got := percentile(sorted, 0.5)
+	if got != 42 {
+		t.Errorf("percentile([42], 0.5) = %f, want 42", got)
+	}
+}
+
+func TestPercentile_TwoElements(t *testing.T) {
+	sorted := []float64{10, 20}
+	// P50: 0.5 * 1 = 0.5 → lerp(10, 20, 0.5) = 15
+	got := percentile(sorted, 0.5)
+	if !approxEqual(got, 15, 0.01) {
+		t.Errorf("percentile([10,20], 0.5) = %f, want 15", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Implement ComputeMarketContext() pure function with percentile/σ computation
- Compute P5/P10/P25/P50/P75/P90/P99 for both prices and listings
- Compute velocity mean/sigma across all gem price histories
- Wire into RunV2 analyzer (replaces TODO stub from POE-62)
- Integrate into optimizer pre-computation for future relative threshold sweeps
- Stub HourlyBias/WeekdayBias with neutral 1.0 values (POE-60 fills in)

## Tracker
https://softsolution.youtrack.cloud/issue/POE-56

## Test Plan
- [x] All tests pass (236 tests, go test ./...)
- [x] Unit tests for percentile computation, velocity stats, edge cases
- [ ] Verify market_context populated after RunV2 fires

Generated with [Claude Code](https://claude.com/claude-code)