### PR TITLE
POE-58: Multi-window time-based velocity computation

### DIFF
--- a/cmd/optimize/main.go
+++ b/cmd/optimize/main.go
@@ -236,8 +236,8 @@ func precomputeFeatures(snapshots []Snapshot) ([]precomputed, []lab.GemPrice, *l
 				continue
 			}
 
-			priceVel := velocityFromPoints(h.points, func(p lab.PricePoint) float64 { return p.Chaos })
-			listingVel := velocityFromPoints(h.points, func(p lab.PricePoint) float64 { return float64(p.Listings) })
+			priceVel := lab.VelocityWindow(h.points, 2*time.Hour, func(p lab.PricePoint) float64 { return p.Chaos })
+			listingVel := lab.VelocityWindow(h.points, 2*time.Hour, func(p lab.PricePoint) float64 { return float64(p.Listings) })
 			cv := cvFromPoints(h.points)
 
 			var futurePct float64
@@ -424,24 +424,7 @@ func generateGrid() []lab.SignalConfig {
 	return grid // 5x4x4x4 = 320 combos
 }
 
-// velocityFromPoints computes rate of change per hour using last 4 points.
-func velocityFromPoints(points []lab.PricePoint, extract func(lab.PricePoint) float64) float64 {
-	n := len(points)
-	if n < 2 {
-		return 0
-	}
-	start := 0
-	if n > 4 {
-		start = n - 4
-	}
-	first := points[start]
-	last := points[n-1]
-	hours := last.Time.Sub(first.Time).Hours()
-	if hours <= 0 {
-		return 0
-	}
-	return (extract(last) - extract(first)) / hours
-}
+// velocityFromPoints removed — now uses lab.VelocityWindow directly.
 
 // cvFromPoints computes coefficient of variation from price history.
 func cvFromPoints(points []lab.PricePoint) float64 {

--- a/internal/lab/analyzer.go
+++ b/internal/lab/analyzer.go
@@ -209,7 +209,7 @@ func (a *Analyzer) RunQuality(ctx context.Context) error {
 }
 
 // RunV2 is the entry point for the v2 pre-computed analysis pipeline.
-// Currently only persists a stub MarketContext — GemFeatures (POE-58) and
+// Computes and persists MarketContext and GemFeatures per snapshot.
 // GemSignals (POE-61) computation will be added later.
 // It is safe to call from multiple goroutines; concurrent runs are serialized.
 func (a *Analyzer) RunV2(ctx context.Context) error {

--- a/internal/lab/analyzer.go
+++ b/internal/lab/analyzer.go
@@ -242,10 +242,24 @@ func (a *Analyzer) RunV2(ctx context.Context) error {
 		a.cache.SetMarketContext(&mc)
 	}
 
-	// TODO(POE-58): compute gem features using market context
+	features := ComputeGemFeatures(snapTime, gems, history, mc)
+	inserted, err := a.repo.SaveGemFeatures(ctx, features)
+	if err != nil {
+		a.logger.Error("v2: failed to save gem features", "error", err)
+		return err
+	}
+	if a.cache != nil {
+		a.cache.SetGemFeatures(features)
+	}
+	a.logger.Info("v2 gem features computed",
+		"snapTime", snapTime,
+		"features", len(features),
+		"inserted", inserted,
+	)
+
 	// TODO(POE-61): compute gem signals using features
 
-	a.logger.Info("v2 analysis stub complete", "snapTime", snapTime, "gems", len(gems))
+	a.logger.Info("v2 analysis complete", "snapTime", snapTime, "gems", len(gems))
 	a.throttler.Signal()
 	return nil
 }

--- a/internal/lab/gem_features.go
+++ b/internal/lab/gem_features.go
@@ -1,0 +1,116 @@
+package lab
+
+import (
+	"strings"
+	"time"
+)
+
+// ComputeGemFeatures produces per-gem feature vectors from raw gem data, history,
+// and market context. It is a pure function with no side effects -- called from RunV2.
+// Filters to transfigured, non-corrupted, non-Trarthus gems with Chaos > 5.
+func ComputeGemFeatures(snapTime time.Time, gems []GemPrice, history []GemPriceHistory, mc MarketContext) []GemFeature {
+	// Index history by (name, variant) for fast lookup.
+	type histKey struct{ name, variant string }
+	histIndex := make(map[histKey]*GemPriceHistory, len(history))
+	for i := range history {
+		h := &history[i]
+		histIndex[histKey{h.Name, h.Variant}] = h
+	}
+
+	// Precompute market averages for relative metrics.
+	var avgListings float64
+	if mc.TotalGems > 0 {
+		avgListings = float64(mc.TotalListings) / float64(mc.TotalGems)
+	}
+
+	var p50 float64
+	if mc.PricePercentiles != nil {
+		p50 = mc.PricePercentiles["P50"]
+	}
+
+	var features []GemFeature
+
+	for _, g := range gems {
+		if g.IsCorrupted || !g.IsTransfigured {
+			continue
+		}
+		if strings.Contains(g.Name, "Trarthus") {
+			continue
+		}
+		if g.Chaos <= 5 {
+			continue
+		}
+
+		f := GemFeature{
+			Time:     snapTime,
+			Name:     g.Name,
+			Variant:  g.Variant,
+			Chaos:    g.Chaos,
+			Listings: g.Listings,
+			Tier:     classifyTier(g.Chaos, mc.TierBoundaries),
+		}
+
+		h := histIndex[histKey{g.Name, g.Variant}]
+		if h != nil && len(h.Points) >= 2 {
+			// Multi-window velocities.
+			f.VelShortPrice = velocityWindow(h.Points, 1*time.Hour, extractChaos)
+			f.VelShortListing = velocityWindow(h.Points, 1*time.Hour, extractListings)
+			f.VelMedPrice = velocityWindow(h.Points, 2*time.Hour, extractChaos)
+			f.VelMedListing = velocityWindow(h.Points, 2*time.Hour, extractListings)
+			f.VelLongPrice = velocityWindow(h.Points, 6*time.Hour, extractChaos)
+			f.VelLongListing = velocityWindow(h.Points, 6*time.Hour, extractListings)
+
+			// CV from all history prices.
+			prices := make([]float64, len(h.Points))
+			for i, p := range h.Points {
+				prices[i] = p.Chaos
+			}
+			f.CV = coefficientOfVariation(prices)
+
+			// Historical position.
+			f.High7d, f.Low7d, f.HistPosition = historicalPosition(g.Chaos, prices)
+		} else {
+			// No history: defaults.
+			f.High7d = g.Chaos
+			f.Low7d = g.Chaos
+			f.HistPosition = 50
+		}
+
+		// Relative metrics.
+		if p50 > 0 {
+			f.RelativePrice = g.Chaos / p50
+		}
+		if avgListings > 0 {
+			f.RelativeListings = float64(g.Listings) / avgListings
+		}
+
+		// Stubs for POE-59.
+		f.FloodCount = 0
+		f.CrashCount = 0
+		f.ListingElasticity = 0
+
+		// Sanitize all float fields.
+		f.VelShortPrice = sanitizeFloat(f.VelShortPrice)
+		f.VelShortListing = sanitizeFloat(f.VelShortListing)
+		f.VelMedPrice = sanitizeFloat(f.VelMedPrice)
+		f.VelMedListing = sanitizeFloat(f.VelMedListing)
+		f.VelLongPrice = sanitizeFloat(f.VelLongPrice)
+		f.VelLongListing = sanitizeFloat(f.VelLongListing)
+		f.CV = sanitizeFloat(f.CV)
+		f.HistPosition = sanitizeFloat(f.HistPosition)
+		f.High7d = sanitizeFloat(f.High7d)
+		f.Low7d = sanitizeFloat(f.Low7d)
+		f.RelativePrice = sanitizeFloat(f.RelativePrice)
+		f.RelativeListings = sanitizeFloat(f.RelativeListings)
+
+		features = append(features, f)
+	}
+
+	return features
+}
+
+// extractChaos extracts the chaos price from a PricePoint.
+func extractChaos(p PricePoint) float64 { return p.Chaos }
+
+// extractListings extracts the listing count from a PricePoint as float64.
+func extractListings(p PricePoint) float64 { return float64(p.Listings) }

--- a/internal/lab/gem_features.go
+++ b/internal/lab/gem_features.go
@@ -1,7 +1,6 @@
 package lab
 
 import (
-	"strings"
 	"time"
 )
 
@@ -23,21 +22,12 @@ func ComputeGemFeatures(snapTime time.Time, gems []GemPrice, history []GemPriceH
 		avgListings = float64(mc.TotalListings) / float64(mc.TotalGems)
 	}
 
-	var p50 float64
-	if mc.PricePercentiles != nil {
-		p50 = mc.PricePercentiles["P50"]
-	}
+	p50 := mc.PriceP50()
 
 	var features []GemFeature
 
 	for _, g := range gems {
-		if g.IsCorrupted || !g.IsTransfigured {
-			continue
-		}
-		if strings.Contains(g.Name, "Trarthus") {
-			continue
-		}
-		if g.Chaos <= 5 {
+		if !isAnalyzableGem(g) || g.Chaos <= 5 {
 			continue
 		}
 
@@ -89,13 +79,9 @@ func ComputeGemFeatures(snapTime time.Time, gems []GemPrice, history []GemPriceH
 		f.CrashCount = 0
 		f.ListingElasticity = 0
 
-		// Sanitize all float fields.
-		f.VelShortPrice = sanitizeFloat(f.VelShortPrice)
-		f.VelShortListing = sanitizeFloat(f.VelShortListing)
-		f.VelMedPrice = sanitizeFloat(f.VelMedPrice)
-		f.VelMedListing = sanitizeFloat(f.VelMedListing)
-		f.VelLongPrice = sanitizeFloat(f.VelLongPrice)
-		f.VelLongListing = sanitizeFloat(f.VelLongListing)
+		// Sanitize non-velocity float fields.
+		// Velocity fields are already sanitized by velocityWindow; CV, hist, and
+		// relative fields are sanitized here because their producers do not guarantee it.
 		f.CV = sanitizeFloat(f.CV)
 		f.HistPosition = sanitizeFloat(f.HistPosition)
 		f.High7d = sanitizeFloat(f.High7d)

--- a/internal/lab/gem_features_test.go
+++ b/internal/lab/gem_features_test.go
@@ -1,0 +1,466 @@
+package lab
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// testMarketContext returns a MarketContext suitable for testing ComputeGemFeatures.
+func testMarketContext() MarketContext {
+	return MarketContext{
+		Time: time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC),
+		PricePercentiles: map[string]float64{
+			"P5": 10, "P10": 15, "P25": 30, "P50": 50,
+			"P75": 100, "P90": 200, "P99": 500,
+		},
+		ListingPercentiles: map[string]float64{
+			"P5": 2, "P10": 5, "P25": 10, "P50": 20,
+			"P75": 50, "P90": 100, "P99": 200,
+		},
+		TotalGems:     100,
+		TotalListings: 2000,
+		TierBoundaries: TierBoundaries{
+			Top:  300,
+			High: 100,
+			Mid:  30,
+		},
+		HourlyBias:  make([]float64, 24),
+		WeekdayBias: make([]float64, 7),
+	}
+}
+
+func TestComputeGemFeatures_BasicVelocities(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	t0 := snapTime.Add(-3 * time.Hour)
+
+	gems := []GemPrice{
+		{Name: "Spark of Nova", Variant: "20/20", Chaos: 200, Listings: 15, IsTransfigured: true, GemColor: "BLUE"},
+	}
+
+	history := []GemPriceHistory{
+		{
+			Name: "Spark of Nova", Variant: "20/20", GemColor: "BLUE",
+			Points: []PricePoint{
+				{Time: t0, Chaos: 160, Listings: 10},
+				{Time: t0.Add(30 * time.Minute), Chaos: 165, Listings: 11},
+				{Time: t0.Add(60 * time.Minute), Chaos: 170, Listings: 12},
+				{Time: t0.Add(90 * time.Minute), Chaos: 175, Listings: 13},
+				{Time: t0.Add(120 * time.Minute), Chaos: 180, Listings: 14},
+				{Time: t0.Add(150 * time.Minute), Chaos: 190, Listings: 15},
+				{Time: t0.Add(180 * time.Minute), Chaos: 200, Listings: 15},
+			},
+		},
+	}
+
+	mc := testMarketContext()
+	features := ComputeGemFeatures(snapTime, gems, history, mc)
+
+	if len(features) != 1 {
+		t.Fatalf("got %d features, want 1", len(features))
+	}
+
+	f := features[0]
+
+	// Verify basic fields.
+	if f.Name != "Spark of Nova" {
+		t.Errorf("Name = %s, want Spark of Nova", f.Name)
+	}
+	if f.Chaos != 200 {
+		t.Errorf("Chaos = %f, want 200", f.Chaos)
+	}
+	if f.Listings != 15 {
+		t.Errorf("Listings = %d, want 15", f.Listings)
+	}
+
+	// Short velocity (1h window): last 2 points in 1h from t0+180min.
+	// cutoff = t0+120min. Points at t0+120min, t0+150min, t0+180min.
+	// (200-180)/1h = 20
+	if f.VelShortPrice <= 0 {
+		t.Errorf("VelShortPrice = %f, want > 0", f.VelShortPrice)
+	}
+
+	// Medium velocity (2h window).
+	if f.VelMedPrice <= 0 {
+		t.Errorf("VelMedPrice = %f, want > 0", f.VelMedPrice)
+	}
+
+	// Long velocity (6h window): all points within 6h.
+	// (200-160)/3h = 13.33
+	if math.Abs(f.VelLongPrice-13.33) > 0.5 {
+		t.Errorf("VelLongPrice = %f, want ~13.33", f.VelLongPrice)
+	}
+
+	// All listing velocities should be non-negative (listings were rising).
+	if f.VelShortListing < 0 {
+		t.Errorf("VelShortListing = %f, want >= 0", f.VelShortListing)
+	}
+	if f.VelMedListing < 0 {
+		t.Errorf("VelMedListing = %f, want >= 0", f.VelMedListing)
+	}
+	if f.VelLongListing < 0 {
+		t.Errorf("VelLongListing = %f, want >= 0", f.VelLongListing)
+	}
+}
+
+func TestComputeGemFeatures_Tier(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	gems := []GemPrice{
+		{Name: "Expensive of Power", Variant: "20/20", Chaos: 500, Listings: 3, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Mid of Range", Variant: "20/20", Chaos: 50, Listings: 20, IsTransfigured: true, GemColor: "BLUE"},
+		{Name: "Cheap of Nothing", Variant: "20/20", Chaos: 10, Listings: 100, IsTransfigured: true, GemColor: "GREEN"},
+	}
+
+	mc := testMarketContext()
+	features := ComputeGemFeatures(snapTime, gems, nil, mc)
+
+	if len(features) != 3 {
+		t.Fatalf("got %d features, want 3", len(features))
+	}
+
+	tierMap := make(map[string]string)
+	for _, f := range features {
+		tierMap[f.Name] = f.Tier
+	}
+
+	if tierMap["Expensive of Power"] != "TOP" {
+		t.Errorf("Expensive tier = %s, want TOP", tierMap["Expensive of Power"])
+	}
+	if tierMap["Mid of Range"] != "MID" {
+		t.Errorf("Mid tier = %s, want MID", tierMap["Mid of Range"])
+	}
+	if tierMap["Cheap of Nothing"] != "LOW" {
+		t.Errorf("Cheap tier = %s, want LOW", tierMap["Cheap of Nothing"])
+	}
+}
+
+func TestComputeGemFeatures_CV(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	t0 := snapTime.Add(-90 * time.Minute)
+
+	gems := []GemPrice{
+		{Name: "Volatile of Storm", Variant: "20/20", Chaos: 200, Listings: 10, IsTransfigured: true, GemColor: "BLUE"},
+	}
+
+	// Wildly varying prices → high CV.
+	history := []GemPriceHistory{
+		{
+			Name: "Volatile of Storm", Variant: "20/20", GemColor: "BLUE",
+			Points: []PricePoint{
+				{Time: t0, Chaos: 50, Listings: 10},
+				{Time: t0.Add(30 * time.Minute), Chaos: 300, Listings: 10},
+				{Time: t0.Add(60 * time.Minute), Chaos: 100, Listings: 10},
+				{Time: t0.Add(90 * time.Minute), Chaos: 200, Listings: 10},
+			},
+		},
+	}
+
+	mc := testMarketContext()
+	features := ComputeGemFeatures(snapTime, gems, history, mc)
+
+	if len(features) != 1 {
+		t.Fatalf("got %d features, want 1", len(features))
+	}
+	if features[0].CV <= 30 {
+		t.Errorf("CV = %f, want > 30 (volatile prices)", features[0].CV)
+	}
+}
+
+func TestComputeGemFeatures_HistPosition(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	t0 := snapTime.Add(-90 * time.Minute)
+
+	gems := []GemPrice{
+		{Name: "Peak of Pride", Variant: "20/20", Chaos: 200, Listings: 10, IsTransfigured: true, GemColor: "RED"},
+	}
+
+	// Current price (200) is at the historical high.
+	history := []GemPriceHistory{
+		{
+			Name: "Peak of Pride", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				{Time: t0, Chaos: 100, Listings: 10},
+				{Time: t0.Add(30 * time.Minute), Chaos: 150, Listings: 10},
+				{Time: t0.Add(60 * time.Minute), Chaos: 180, Listings: 10},
+				{Time: t0.Add(90 * time.Minute), Chaos: 200, Listings: 10},
+			},
+		},
+	}
+
+	mc := testMarketContext()
+	features := ComputeGemFeatures(snapTime, gems, history, mc)
+
+	if len(features) != 1 {
+		t.Fatalf("got %d features, want 1", len(features))
+	}
+	f := features[0]
+
+	if math.Abs(f.HistPosition-100) > 0.01 {
+		t.Errorf("HistPosition = %f, want 100 (at historical high)", f.HistPosition)
+	}
+	if f.High7d != 200 {
+		t.Errorf("High7d = %f, want 200", f.High7d)
+	}
+	if f.Low7d != 100 {
+		t.Errorf("Low7d = %f, want 100", f.Low7d)
+	}
+}
+
+func TestComputeGemFeatures_RelativeMetrics(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	gems := []GemPrice{
+		{Name: "Average of Joe", Variant: "20/20", Chaos: 50, Listings: 20, IsTransfigured: true, GemColor: "BLUE"},
+	}
+
+	mc := testMarketContext()
+	// P50 = 50, avgListings = 2000/100 = 20
+	features := ComputeGemFeatures(snapTime, gems, nil, mc)
+
+	if len(features) != 1 {
+		t.Fatalf("got %d features, want 1", len(features))
+	}
+	f := features[0]
+
+	// RelativePrice = 50/50 = 1.0
+	if math.Abs(f.RelativePrice-1.0) > 0.001 {
+		t.Errorf("RelativePrice = %f, want 1.0", f.RelativePrice)
+	}
+	// RelativeListings = 20/20 = 1.0
+	if math.Abs(f.RelativeListings-1.0) > 0.001 {
+		t.Errorf("RelativeListings = %f, want 1.0", f.RelativeListings)
+	}
+}
+
+func TestComputeGemFeatures_NoHistory(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	gems := []GemPrice{
+		{Name: "New of Gem", Variant: "20/20", Chaos: 100, Listings: 10, IsTransfigured: true, GemColor: "GREEN"},
+	}
+
+	mc := testMarketContext()
+	features := ComputeGemFeatures(snapTime, gems, nil, mc)
+
+	if len(features) != 1 {
+		t.Fatalf("got %d features, want 1", len(features))
+	}
+	f := features[0]
+
+	// No history: all velocities = 0.
+	if f.VelShortPrice != 0 || f.VelShortListing != 0 {
+		t.Errorf("short vel = (%f, %f), want (0, 0)", f.VelShortPrice, f.VelShortListing)
+	}
+	if f.VelMedPrice != 0 || f.VelMedListing != 0 {
+		t.Errorf("med vel = (%f, %f), want (0, 0)", f.VelMedPrice, f.VelMedListing)
+	}
+	if f.VelLongPrice != 0 || f.VelLongListing != 0 {
+		t.Errorf("long vel = (%f, %f), want (0, 0)", f.VelLongPrice, f.VelLongListing)
+	}
+
+	if f.CV != 0 {
+		t.Errorf("CV = %f, want 0", f.CV)
+	}
+	if f.HistPosition != 50 {
+		t.Errorf("HistPosition = %f, want 50", f.HistPosition)
+	}
+	if f.High7d != 100 {
+		t.Errorf("High7d = %f, want 100", f.High7d)
+	}
+	if f.Low7d != 100 {
+		t.Errorf("Low7d = %f, want 100", f.Low7d)
+	}
+}
+
+func TestComputeGemFeatures_FilterCorrupted(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	gems := []GemPrice{
+		{Name: "Corrupted of Gem", Variant: "20/20", Chaos: 500, Listings: 5, IsTransfigured: true, IsCorrupted: true, GemColor: "RED"},
+	}
+
+	mc := testMarketContext()
+	features := ComputeGemFeatures(snapTime, gems, nil, mc)
+
+	if len(features) != 0 {
+		t.Errorf("got %d features, want 0 (corrupted filtered)", len(features))
+	}
+}
+
+func TestComputeGemFeatures_FilterNonTransfigured(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	gems := []GemPrice{
+		{Name: "Spark", Variant: "20/20", Chaos: 50, Listings: 100, IsTransfigured: false, GemColor: "BLUE"},
+	}
+
+	mc := testMarketContext()
+	features := ComputeGemFeatures(snapTime, gems, nil, mc)
+
+	if len(features) != 0 {
+		t.Errorf("got %d features, want 0 (non-transfigured filtered)", len(features))
+	}
+}
+
+func TestComputeGemFeatures_FilterTrarthus(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	gems := []GemPrice{
+		{Name: "Wave of Trarthus", Variant: "20/20", Chaos: 200, Listings: 5, IsTransfigured: true, GemColor: "RED"},
+	}
+
+	mc := testMarketContext()
+	features := ComputeGemFeatures(snapTime, gems, nil, mc)
+
+	if len(features) != 0 {
+		t.Errorf("got %d features, want 0 (Trarthus filtered)", len(features))
+	}
+}
+
+func TestComputeGemFeatures_FilterCheap(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	gems := []GemPrice{
+		{Name: "Cheap of Nothing", Variant: "20/20", Chaos: 3, Listings: 50, IsTransfigured: true, GemColor: "GREEN"},
+	}
+
+	mc := testMarketContext()
+	features := ComputeGemFeatures(snapTime, gems, nil, mc)
+
+	if len(features) != 0 {
+		t.Errorf("got %d features, want 0 (cheap gem filtered)", len(features))
+	}
+}
+
+func TestComputeGemFeatures_Stubs(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	gems := []GemPrice{
+		{Name: "Stub of Test", Variant: "20/20", Chaos: 100, Listings: 10, IsTransfigured: true, GemColor: "BLUE"},
+	}
+
+	mc := testMarketContext()
+	features := ComputeGemFeatures(snapTime, gems, nil, mc)
+
+	if len(features) != 1 {
+		t.Fatalf("got %d features, want 1", len(features))
+	}
+	f := features[0]
+
+	// POE-59 stubs.
+	if f.FloodCount != 0 {
+		t.Errorf("FloodCount = %d, want 0 (stub)", f.FloodCount)
+	}
+	if f.CrashCount != 0 {
+		t.Errorf("CrashCount = %d, want 0 (stub)", f.CrashCount)
+	}
+	if f.ListingElasticity != 0 {
+		t.Errorf("ListingElasticity = %f, want 0 (stub)", f.ListingElasticity)
+	}
+}
+
+func TestComputeGemFeatures_MultipleGems(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	t0 := snapTime.Add(-90 * time.Minute)
+
+	gems := []GemPrice{
+		{Name: "Spark of Nova", Variant: "20/20", Chaos: 200, Listings: 15, IsTransfigured: true, GemColor: "BLUE"},
+		{Name: "Cleave of Rage", Variant: "20/20", Chaos: 80, Listings: 30, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Ice Shot of Frost", Variant: "20/20", Chaos: 400, Listings: 5, IsTransfigured: true, GemColor: "GREEN"},
+	}
+
+	history := []GemPriceHistory{
+		{
+			Name: "Spark of Nova", Variant: "20/20", GemColor: "BLUE",
+			Points: []PricePoint{
+				{Time: t0, Chaos: 180, Listings: 12},
+				{Time: t0.Add(30 * time.Minute), Chaos: 190, Listings: 14},
+				{Time: t0.Add(60 * time.Minute), Chaos: 195, Listings: 15},
+				{Time: t0.Add(90 * time.Minute), Chaos: 200, Listings: 15},
+			},
+		},
+		{
+			Name: "Cleave of Rage", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				{Time: t0, Chaos: 120, Listings: 10},
+				{Time: t0.Add(30 * time.Minute), Chaos: 100, Listings: 20},
+				{Time: t0.Add(60 * time.Minute), Chaos: 90, Listings: 25},
+				{Time: t0.Add(90 * time.Minute), Chaos: 80, Listings: 30},
+			},
+		},
+	}
+
+	mc := testMarketContext()
+	features := ComputeGemFeatures(snapTime, gems, history, mc)
+
+	if len(features) != 3 {
+		t.Fatalf("got %d features, want 3", len(features))
+	}
+
+	featureMap := make(map[string]GemFeature)
+	for _, f := range features {
+		featureMap[f.Name] = f
+	}
+
+	// Spark: rising price, rising listings.
+	spark := featureMap["Spark of Nova"]
+	if spark.VelMedPrice <= 0 {
+		t.Errorf("Spark VelMedPrice = %f, want > 0 (rising)", spark.VelMedPrice)
+	}
+
+	// Cleave: falling price, rising listings.
+	cleave := featureMap["Cleave of Rage"]
+	if cleave.VelMedPrice >= 0 {
+		t.Errorf("Cleave VelMedPrice = %f, want < 0 (falling)", cleave.VelMedPrice)
+	}
+	if cleave.VelMedListing <= 0 {
+		t.Errorf("Cleave VelMedListing = %f, want > 0 (rising)", cleave.VelMedListing)
+	}
+
+	// Ice Shot: no history, velocities should be 0.
+	iceShot := featureMap["Ice Shot of Frost"]
+	if iceShot.VelMedPrice != 0 || iceShot.VelMedListing != 0 {
+		t.Errorf("Ice Shot vel = (%f, %f), want (0, 0)", iceShot.VelMedPrice, iceShot.VelMedListing)
+	}
+}
+
+func TestComputeGemFeatures_ZeroMarketContext(t *testing.T) {
+	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+
+	gems := []GemPrice{
+		{Name: "Test of Gem", Variant: "20/20", Chaos: 100, Listings: 10, IsTransfigured: true, GemColor: "BLUE"},
+	}
+
+	// Zero market context: no percentiles, no gems/listings totals.
+	mc := MarketContext{
+		Time:               snapTime,
+		PricePercentiles:   make(map[string]float64),
+		ListingPercentiles: make(map[string]float64),
+		HourlyBias:         make([]float64, 24),
+		WeekdayBias:        make([]float64, 7),
+	}
+
+	features := ComputeGemFeatures(snapTime, gems, nil, mc)
+
+	if len(features) != 1 {
+		t.Fatalf("got %d features, want 1", len(features))
+	}
+	f := features[0]
+
+	// With P50=0 and avgListings=0, relative metrics should be 0 (guarded).
+	if f.RelativePrice != 0 {
+		t.Errorf("RelativePrice = %f, want 0 (P50=0)", f.RelativePrice)
+	}
+	if f.RelativeListings != 0 {
+		t.Errorf("RelativeListings = %f, want 0 (avgListings=0)", f.RelativeListings)
+	}
+
+	// Verify no NaN/Inf.
+	if math.IsNaN(f.RelativePrice) || math.IsInf(f.RelativePrice, 0) {
+		t.Error("RelativePrice is NaN/Inf")
+	}
+	if math.IsNaN(f.RelativeListings) || math.IsInf(f.RelativeListings, 0) {
+		t.Error("RelativeListings is NaN/Inf")
+	}
+}

--- a/internal/lab/market_context.go
+++ b/internal/lab/market_context.go
@@ -154,11 +154,18 @@ func velocityComputable(points []PricePoint) bool {
 	if n < 2 {
 		return false
 	}
-	start := 0
-	if n > 4 {
-		start = n - 4
+	// Match velocity()'s 2h window: find first point within 2h of the last.
+	cutoff := points[n-1].Time.Add(-2 * time.Hour)
+	for i := 0; i < n; i++ {
+		if !points[i].Time.Before(cutoff) {
+			// Need at least 2 points in window with a positive time span.
+			if n-i < 2 {
+				return false
+			}
+			return points[n-1].Time.Sub(points[i].Time).Hours() > 0
+		}
 	}
-	return points[n-1].Time.Sub(points[start].Time).Hours() > 0
+	return false
 }
 
 // meanStddev computes the mean and population standard deviation of a float slice.

--- a/internal/lab/market_context.go
+++ b/internal/lab/market_context.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strings"
 	"time"
 )
 
@@ -36,10 +35,7 @@ func ComputeMarketContext(snapTime time.Time, gems []GemPrice, history []GemPric
 	// Filter to active transfigured gems (not corrupted, exclude Trarthus).
 	var active []GemPrice
 	for _, g := range gems {
-		if !g.IsTransfigured || g.IsCorrupted {
-			continue
-		}
-		if strings.Contains(g.Name, "Trarthus") {
+		if !isAnalyzableGem(g) {
 			continue
 		}
 		active = append(active, g)

--- a/internal/lab/transfigure.go
+++ b/internal/lab/transfigure.go
@@ -34,6 +34,13 @@ type GemPrice struct {
 	GemColor       string
 }
 
+// isAnalyzableGem returns true if the gem passes the shared baseline filter:
+// transfigured, not corrupted, and not the Trarthus outlier. Call sites may
+// layer additional filters (e.g., minimum chaos, variant set) on top.
+func isAnalyzableGem(g GemPrice) bool {
+	return g.IsTransfigured && !g.IsCorrupted && !strings.Contains(g.Name, "Trarthus")
+}
+
 // AnalyzeTransfigure computes transfigure ROI for all base→transfigured pairs.
 // Input: the latest snapshot of gem prices (non-corrupted only).
 // Variants analyzed: "1", "1/20", "20", "20/20".

--- a/internal/lab/trends.go
+++ b/internal/lab/trends.go
@@ -535,30 +535,7 @@ func sanitizeFloat(v float64) float64 {
 	return v
 }
 
-// velocity computes the rate of change per hour using last 4 data points (or fewer).
-// Uses simple (last - first) / hours between first and last point.
-func velocity(points []PricePoint, extract func(PricePoint) float64) float64 {
-	n := len(points)
-	if n < 2 {
-		return 0
-	}
-
-	// Use at most the last 4 points for rolling 2h window.
-	start := 0
-	if n > 4 {
-		start = n - 4
-	}
-
-	first := points[start]
-	last := points[n-1]
-
-	hours := last.Time.Sub(first.Time).Hours()
-	if hours <= 0 {
-		return 0
-	}
-
-	return (extract(last) - extract(first)) / hours
-}
+// velocity and velocityWindow are defined in velocity.go.
 
 // historicalPosition returns the 7-day high, low, and the current price as a
 // percentile (0-100) within that range.

--- a/internal/lab/trends.go
+++ b/internal/lab/trends.go
@@ -2,7 +2,6 @@ package lab
 
 import (
 	"math"
-	"strings"
 	"time"
 )
 
@@ -314,19 +313,7 @@ func AnalyzeTrends(snapTime time.Time, current []GemPrice, history []GemPriceHis
 	var results []TrendResult
 
 	for _, g := range current {
-		if g.IsCorrupted {
-			continue
-		}
-		if !g.IsTransfigured {
-			continue
-		}
-		if strings.Contains(g.Name, "Trarthus") {
-			continue
-		}
-		if g.Chaos <= 5 {
-			continue
-		}
-		if !analysisVariants[g.Variant] {
+		if !isAnalyzableGem(g) || g.Chaos <= 5 || !analysisVariants[g.Variant] {
 			continue
 		}
 

--- a/internal/lab/trends_backtest_test.go
+++ b/internal/lab/trends_backtest_test.go
@@ -73,9 +73,13 @@ var productionFixtures = []backtestFixture{
 		},
 	},
 	{
-		// Elemental Hit of the Spectrum (GREEN) — HERD→FALLING transition.
+		// Elemental Hit of the Spectrum (GREEN) — sustained HERD with listing flood.
 		// Sustained large listing flood (283→350) at gradually rising price.
-		// HERD fires when both price and listing velocity exceed thresholds.
+		// Time-based velocity (2h window) captures the full price trend, showing
+		// consistent price+listing growth that correctly fires HERD throughout.
+		// snap[4]: 2h window includes points 0-4, price 554.8→581.6 = RISING (lVel < 10/h)
+		// snap[5]: 2h window sees listing surge to 348, HERD fires
+		// snap[6-7]: sustained HERD as both velocities stay above thresholds
 		gemName: "Elemental Hit of the Spectrum",
 		variant: "20/20",
 		gemColor: "GREEN",
@@ -91,16 +95,20 @@ var productionFixtures = []backtestFixture{
 			{Time: mustParseUTC("2026-03-15T19:45:32.984609+00:00"), Chaos: 609.0, Listings: 350},
 		},
 		expectations: []backtestExpectation{
-			{snapIdx: 4, signal: "HERD"},    // price rising >5/h + listings rising >10/h
-			{snapIdx: 5, signal: "FALLING"}, // price velocity drops to 0 but listings still flood
-			{snapIdx: 6, signal: "HERD"},    // price velocity rebounds >5/h
-			{snapIdx: 7, signal: "HERD"},    // herd continues
+			{snapIdx: 4, signal: "RISING"}, // 2h window: pVel=13.4 but lVel=8.5 (<10/h threshold)
+			{snapIdx: 5, signal: "HERD"},   // 2h window: listing surge drives lVel >10/h
+			{snapIdx: 6, signal: "HERD"},   // sustained herd: price+listings both above thresholds
+			{snapIdx: 7, signal: "HERD"},   // herd continues
 		},
 	},
 	{
 		// Shock Nova of Procession (BLUE) — RISING→HERD transition.
 		// Steady price climb from 832c to 914c with growing listing pressure.
-		// Demonstrates threshold crossing: RISING when listings moderate, HERD when they surge.
+		// Time-based velocity (2h window) captures broader price trend, showing
+		// consistent upward movement that was missed by the old 4-point window.
+		// snap[4]: 2h window shows price+listing growth → RISING (lVel still < 10/h)
+		// snap[5-6]: 2h window captures sustained listing surge → HERD
+		// snap[7]: continued HERD with both velocities above thresholds
 		gemName: "Shock Nova of Procession",
 		variant: "20/20",
 		gemColor: "BLUE",
@@ -116,10 +124,10 @@ var productionFixtures = []backtestFixture{
 			{Time: mustParseUTC("2026-03-15T19:45:32.984609+00:00"), Chaos: 913.5, Listings: 208},
 		},
 		expectations: []backtestExpectation{
-			{snapIdx: 4, signal: "RISING"},  // price up >5/h but listing velocity < 10/h
-			{snapIdx: 5, signal: "FALLING"}, // price velocity 0 (flat snap), listings still rising
-			{snapIdx: 6, signal: "RISING"},  // price resumes climb
-			{snapIdx: 7, signal: "HERD"},    // listing velocity crosses >10/h threshold
+			{snapIdx: 4, signal: "RISING"}, // 2h window: pVel=20.1 but lVel=6.0 (<10/h threshold)
+			{snapIdx: 5, signal: "HERD"},   // 2h window: listing surge drives lVel >10/h
+			{snapIdx: 6, signal: "HERD"},   // sustained herd
+			{snapIdx: 7, signal: "HERD"},   // herd continues with strong listing velocity
 		},
 	},
 	{
@@ -274,12 +282,12 @@ func TestAnalyzeTrends_Backtest_STABLE_CV_zero(t *testing.T) {
 }
 
 // TestAnalyzeTrends_Backtest_RISING_before_HERD validates that Shock Nova of Procession
-// correctly emits RISING (not HERD) while price velocity is high but listing velocity
-// is still below the HERD threshold of 10/h, then transitions to HERD once listings surge.
+// correctly emits RISING at snap[4] (listing velocity still below HERD threshold)
+// then transitions to HERD at snap[5] once the 2h window captures enough listing growth.
 func TestAnalyzeTrends_Backtest_RISING_before_HERD(t *testing.T) {
 	fix := productionFixtures[2] // Shock Nova of Procession
 
-	// snap[4]: RISING — price velocity >5/h but listing velocity <10/h
+	// snap[4]: RISING — 2h window: price velocity >5/h but listing velocity <10/h
 	{
 		snapIdx := 4
 		currentPt := fix.points[snapIdx]
@@ -305,9 +313,9 @@ func TestAnalyzeTrends_Backtest_RISING_before_HERD(t *testing.T) {
 		}
 	}
 
-	// snap[7]: HERD — listing velocity crosses >10/h
+	// snap[5]: HERD — 2h window captures listing surge >10/h
 	{
-		snapIdx := 7
+		snapIdx := 5
 		currentPt := fix.points[snapIdx]
 		current := []GemPrice{{
 			Name: fix.gemName, Variant: fix.variant,
@@ -320,17 +328,17 @@ func TestAnalyzeTrends_Backtest_RISING_before_HERD(t *testing.T) {
 		}}
 		results := AnalyzeTrends(currentPt.Time, current, history, nil, 0)
 		if len(results) != 1 {
-			t.Fatal("snap[7]: no result")
+			t.Fatal("snap[5]: no result")
 		}
 		r := results[0]
 		if r.Signal != "HERD" {
-			t.Errorf("snap[7] HERD threshold crossed: signal=%s, want HERD", r.Signal)
+			t.Errorf("snap[5] HERD threshold crossed: signal=%s, want HERD", r.Signal)
 		}
 		if r.PriceVelocity <= 5 {
-			t.Errorf("snap[7]: price velocity %.2f should be >5/h for HERD", r.PriceVelocity)
+			t.Errorf("snap[5]: price velocity %.2f should be >5/h for HERD", r.PriceVelocity)
 		}
 		if r.ListingVelocity <= 10 {
-			t.Errorf("snap[7]: listing velocity %.2f should be >10/h for HERD", r.ListingVelocity)
+			t.Errorf("snap[5]: listing velocity %.2f should be >10/h for HERD", r.ListingVelocity)
 		}
 	}
 }

--- a/internal/lab/trends_test.go
+++ b/internal/lab/trends_test.go
@@ -71,19 +71,21 @@ func TestVelocity_TwoPoints(t *testing.T) {
 	}
 }
 
-func TestVelocity_UsesLast4Points(t *testing.T) {
+func TestVelocity_UsesTimeWindow(t *testing.T) {
+	// velocity() uses a 2h time window. 5 points spanning 2h: all points are
+	// within the window (cutoff = t0+120min - 2h = t0).
 	t0 := time.Date(2026, 3, 15, 8, 0, 0, 0, time.UTC)
 	points := []PricePoint{
-		{Time: t0, Chaos: 50, Listings: 5},                           // skipped (>4 points)
-		{Time: t0.Add(30 * time.Minute), Chaos: 60, Listings: 8},     // first used
-		{Time: t0.Add(60 * time.Minute), Chaos: 70, Listings: 10},    //
-		{Time: t0.Add(90 * time.Minute), Chaos: 75, Listings: 12},    //
-		{Time: t0.Add(120 * time.Minute), Chaos: 80, Listings: 14},   // last used
+		{Time: t0, Chaos: 50, Listings: 5},                           // first in 2h window
+		{Time: t0.Add(30 * time.Minute), Chaos: 60, Listings: 8},
+		{Time: t0.Add(60 * time.Minute), Chaos: 70, Listings: 10},
+		{Time: t0.Add(90 * time.Minute), Chaos: 75, Listings: 12},
+		{Time: t0.Add(120 * time.Minute), Chaos: 80, Listings: 14},   // last point
 	}
-	// Last 4 points: 30min to 120min. Delta = 80-60 = 20 over 1.5h = 13.33/h
+	// Delta = (80-50) / 2h = 15
 	v := velocity(points, func(p PricePoint) float64 { return p.Chaos })
-	if math.Abs(v-13.33) > 0.1 {
-		t.Errorf("price velocity = %f, want ~13.33", v)
+	if math.Abs(v-15) > 0.01 {
+		t.Errorf("price velocity = %f, want 15", v)
 	}
 }
 

--- a/internal/lab/v2types.go
+++ b/internal/lab/v2types.go
@@ -18,6 +18,15 @@ type MarketContext struct {
 	WeekdayBias        []float64 // 7 entries, Sun=0..Sat=6 (matches time.Weekday)
 }
 
+// PriceP50 returns the P50 price percentile, or 0 if not available.
+// Centralizes the key string to avoid typos at access sites.
+func (mc MarketContext) PriceP50() float64 {
+	if mc.PricePercentiles == nil {
+		return 0
+	}
+	return mc.PricePercentiles["P50"]
+}
+
 // TierBoundaries holds minimum chaos price thresholds for each tier.
 // A gem is TOP if chaos >= Top, HIGH if chaos >= High, MID if chaos >= Mid, otherwise LOW.
 type TierBoundaries struct {

--- a/internal/lab/velocity.go
+++ b/internal/lab/velocity.go
@@ -1,0 +1,51 @@
+package lab
+
+import "time"
+
+// velocityWindow computes rate of change per hour using points within
+// the given duration from the most recent point. Time-based, not point-count-based --
+// works identically regardless of data cadence (30min, 5min, etc.).
+func velocityWindow(points []PricePoint, window time.Duration, extract func(PricePoint) float64) float64 {
+	n := len(points)
+	if n < 2 {
+		return 0
+	}
+
+	cutoff := points[n-1].Time.Add(-window)
+
+	// Find first point where Time >= cutoff.
+	start := n
+	for i := 0; i < n; i++ {
+		if !points[i].Time.Before(cutoff) {
+			start = i
+			break
+		}
+	}
+
+	// Need at least 2 points in window.
+	if n-start < 2 {
+		return 0
+	}
+
+	first := points[start]
+	last := points[n-1]
+
+	hours := last.Time.Sub(first.Time).Hours()
+	if hours <= 0 {
+		return 0
+	}
+
+	return sanitizeFloat((extract(last) - extract(first)) / hours)
+}
+
+// velocity computes the rate of change per hour using a 2-hour window.
+// This preserves backward compatibility with all existing callers (AnalyzeTrends,
+// ComputeMarketContext) while delegating to the time-based velocityWindow.
+func velocity(points []PricePoint, extract func(PricePoint) float64) float64 {
+	return velocityWindow(points, 2*time.Hour, extract)
+}
+
+// VelocityWindow is the exported variant for use by the optimizer.
+func VelocityWindow(points []PricePoint, window time.Duration, extract func(PricePoint) float64) float64 {
+	return velocityWindow(points, window, extract)
+}

--- a/internal/lab/velocity_test.go
+++ b/internal/lab/velocity_test.go
@@ -1,0 +1,199 @@
+package lab
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestVelocityWindow_Empty(t *testing.T) {
+	v := velocityWindow(nil, 2*time.Hour, func(p PricePoint) float64 { return p.Chaos })
+	if v != 0 {
+		t.Errorf("velocityWindow(nil) = %f, want 0", v)
+	}
+}
+
+func TestVelocityWindow_SinglePoint(t *testing.T) {
+	points := []PricePoint{
+		{Time: time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC), Chaos: 100, Listings: 10},
+	}
+	v := velocityWindow(points, 2*time.Hour, func(p PricePoint) float64 { return p.Chaos })
+	if v != 0 {
+		t.Errorf("velocityWindow(1 point) = %f, want 0", v)
+	}
+}
+
+func TestVelocityWindow_SameTimestamp(t *testing.T) {
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	points := []PricePoint{
+		{Time: t0, Chaos: 100, Listings: 10},
+		{Time: t0, Chaos: 110, Listings: 15},
+	}
+	v := velocityWindow(points, 2*time.Hour, func(p PricePoint) float64 { return p.Chaos })
+	if v != 0 {
+		t.Errorf("velocityWindow(same time) = %f, want 0", v)
+	}
+}
+
+func TestVelocityWindow_TwoPoints(t *testing.T) {
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	points := []PricePoint{
+		{Time: t0, Chaos: 100, Listings: 10},
+		{Time: t0.Add(time.Hour), Chaos: 110, Listings: 15},
+	}
+	// 2h window includes both points: (110-100)/1h = 10
+	v := velocityWindow(points, 2*time.Hour, func(p PricePoint) float64 { return p.Chaos })
+	if math.Abs(v-10) > 0.01 {
+		t.Errorf("velocityWindow price = %f, want 10", v)
+	}
+	vl := velocityWindow(points, 2*time.Hour, func(p PricePoint) float64 { return float64(p.Listings) })
+	if math.Abs(vl-5) > 0.01 {
+		t.Errorf("velocityWindow listings = %f, want 5", vl)
+	}
+}
+
+func TestVelocityWindow_2hSelectsCorrectPoints(t *testing.T) {
+	// 6 points spanning 2.5 hours at 30min intervals.
+	// 2h window from last point (t0+150min): cutoff = t0+30min.
+	// First point >= cutoff is index 1 (t0+30min).
+	t0 := time.Date(2026, 3, 15, 8, 0, 0, 0, time.UTC)
+	points := []PricePoint{
+		{Time: t0, Chaos: 50, Listings: 5},                           // outside 2h window
+		{Time: t0.Add(30 * time.Minute), Chaos: 60, Listings: 8},     // first in 2h window
+		{Time: t0.Add(60 * time.Minute), Chaos: 70, Listings: 10},
+		{Time: t0.Add(90 * time.Minute), Chaos: 75, Listings: 12},
+		{Time: t0.Add(120 * time.Minute), Chaos: 80, Listings: 14},
+		{Time: t0.Add(150 * time.Minute), Chaos: 90, Listings: 16},   // last point
+	}
+	// Delta = (90-60) / 2h = 15
+	v := velocityWindow(points, 2*time.Hour, func(p PricePoint) float64 { return p.Chaos })
+	if math.Abs(v-15) > 0.01 {
+		t.Errorf("velocityWindow 2h = %f, want 15", v)
+	}
+}
+
+func TestVelocityWindow_1hSelectsCorrectPoints(t *testing.T) {
+	// Same 6 points, 1h window should use only points in last hour.
+	t0 := time.Date(2026, 3, 15, 8, 0, 0, 0, time.UTC)
+	points := []PricePoint{
+		{Time: t0, Chaos: 50, Listings: 5},
+		{Time: t0.Add(30 * time.Minute), Chaos: 60, Listings: 8},
+		{Time: t0.Add(60 * time.Minute), Chaos: 70, Listings: 10},
+		{Time: t0.Add(90 * time.Minute), Chaos: 75, Listings: 12},
+		{Time: t0.Add(120 * time.Minute), Chaos: 80, Listings: 14},
+		{Time: t0.Add(150 * time.Minute), Chaos: 90, Listings: 16},
+	}
+	// cutoff = t0+150min - 1h = t0+90min. First point >= cutoff is index 3 (t0+90min).
+	// Delta = (90-75) / 1h = 15
+	v := velocityWindow(points, 1*time.Hour, func(p PricePoint) float64 { return p.Chaos })
+	if math.Abs(v-15) > 0.01 {
+		t.Errorf("velocityWindow 1h = %f, want 15", v)
+	}
+}
+
+func TestVelocityWindow_6hUsesAllPoints(t *testing.T) {
+	// Same 6 points spanning 2.5h, 6h window should include all.
+	t0 := time.Date(2026, 3, 15, 8, 0, 0, 0, time.UTC)
+	points := []PricePoint{
+		{Time: t0, Chaos: 50, Listings: 5},
+		{Time: t0.Add(30 * time.Minute), Chaos: 60, Listings: 8},
+		{Time: t0.Add(60 * time.Minute), Chaos: 70, Listings: 10},
+		{Time: t0.Add(90 * time.Minute), Chaos: 75, Listings: 12},
+		{Time: t0.Add(120 * time.Minute), Chaos: 80, Listings: 14},
+		{Time: t0.Add(150 * time.Minute), Chaos: 90, Listings: 16},
+	}
+	// All points within 6h window: (90-50) / 2.5h = 16
+	v := velocityWindow(points, 6*time.Hour, func(p PricePoint) float64 { return p.Chaos })
+	if math.Abs(v-16) > 0.01 {
+		t.Errorf("velocityWindow 6h = %f, want 16", v)
+	}
+}
+
+func TestVelocityWindow_FewerThan2InWindow(t *testing.T) {
+	// Only 1 point falls within a very short window.
+	t0 := time.Date(2026, 3, 15, 8, 0, 0, 0, time.UTC)
+	points := []PricePoint{
+		{Time: t0, Chaos: 50, Listings: 5},
+		{Time: t0.Add(2 * time.Hour), Chaos: 100, Listings: 10},
+	}
+	// 30min window: cutoff = t0+2h-30min = t0+90min. Only last point qualifies.
+	v := velocityWindow(points, 30*time.Minute, func(p PricePoint) float64 { return p.Chaos })
+	if v != 0 {
+		t.Errorf("velocityWindow(<2 in window) = %f, want 0", v)
+	}
+}
+
+func TestVelocityWindow_5minCadence(t *testing.T) {
+	// Future stream cadence: 5-min intervals. Same 2h window should still work.
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	var points []PricePoint
+	// 25 points over 2 hours at 5-min intervals: price goes 100 -> 120 linearly
+	for i := 0; i <= 24; i++ {
+		points = append(points, PricePoint{
+			Time:     t0.Add(time.Duration(i) * 5 * time.Minute),
+			Chaos:    100 + float64(i)*20.0/24.0,
+			Listings: 10,
+		})
+	}
+	// Last point at t0+120min, first in 2h window is t0 (all within 2h).
+	// Delta = (120-100) / 2h = 10
+	v := velocityWindow(points, 2*time.Hour, func(p PricePoint) float64 { return p.Chaos })
+	if math.Abs(v-10) > 0.1 {
+		t.Errorf("velocityWindow 5min cadence = %f, want ~10", v)
+	}
+}
+
+func TestVelocity_BackwardCompatible(t *testing.T) {
+	// Verify that velocity() produces the same result as velocityWindow(2h)
+	// for standard 30-min cadence data.
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	points := []PricePoint{
+		{Time: t0, Chaos: 100, Listings: 10},
+		{Time: t0.Add(30 * time.Minute), Chaos: 105, Listings: 12},
+		{Time: t0.Add(60 * time.Minute), Chaos: 110, Listings: 14},
+		{Time: t0.Add(90 * time.Minute), Chaos: 120, Listings: 16},
+	}
+	extract := func(p PricePoint) float64 { return p.Chaos }
+	vOld := velocity(points, extract)
+	vNew := velocityWindow(points, 2*time.Hour, extract)
+	if math.Abs(vOld-vNew) > 0.001 {
+		t.Errorf("velocity() = %f, velocityWindow(2h) = %f, want equal", vOld, vNew)
+	}
+}
+
+func TestVelocity_BackwardCompatible_5Points(t *testing.T) {
+	// With 5 points spanning 2h, old velocity used last 4 (point-count).
+	// New velocity uses 2h window (time-based). Both should use all points
+	// that fall within the 2h window.
+	t0 := time.Date(2026, 3, 15, 8, 0, 0, 0, time.UTC)
+	points := []PricePoint{
+		{Time: t0, Chaos: 50, Listings: 5},                         // t0
+		{Time: t0.Add(30 * time.Minute), Chaos: 60, Listings: 8},   // t0+30min
+		{Time: t0.Add(60 * time.Minute), Chaos: 70, Listings: 10},  // t0+60min
+		{Time: t0.Add(90 * time.Minute), Chaos: 75, Listings: 12},  // t0+90min
+		{Time: t0.Add(120 * time.Minute), Chaos: 80, Listings: 14}, // t0+120min
+	}
+	// 2h window from t0+120min: cutoff = t0. All 5 points are in window.
+	// Old velocity used last 4: points[1] to points[4] = (80-60)/1.5h = 13.33
+	// New velocity 2h window: all 5 in window: (80-50)/2h = 15
+	// These differ because the old implementation was point-count-based.
+	// The new implementation is time-based and should use all points in window.
+	v := velocity(points, func(p PricePoint) float64 { return p.Chaos })
+	// (80-50)/2h = 15
+	if math.Abs(v-15) > 0.01 {
+		t.Errorf("velocity(5 points, 2h span) = %f, want 15", v)
+	}
+}
+
+func TestVelocityWindow_NaNProtection(t *testing.T) {
+	// Ensure NaN/Inf from extreme values are sanitized.
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	points := []PricePoint{
+		{Time: t0, Chaos: 0, Listings: 0},
+		{Time: t0.Add(time.Hour), Chaos: 0, Listings: 0},
+	}
+	v := velocityWindow(points, 2*time.Hour, func(p PricePoint) float64 { return p.Chaos })
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		t.Errorf("velocityWindow returned NaN/Inf, want 0")
+	}
+}


### PR DESCRIPTION
## Summary
- Add time-based velocityWindow(points, duration, extract) — data source agnostic
- Refactor existing velocity() to delegate to velocityWindow(2h)
- Implement ComputeGemFeatures with 3-window velocities (1h/2h/6h)
- Fill in GemFeature fields: Tier, CV, HistPosition, RelativePrice/Listings
- Wire ComputeGemFeatures into RunV2 analyzer (replaces TODO)
- Replace optimizer's local velocityFromPoints with exported VelocityWindow
- Update backtest expectations for time-based velocity behavior

## Tracker
https://softsolution.youtrack.cloud/issue/POE-58

## Test Plan
- [x] All tests pass (go test ./...)
- [x] velocityWindow unit tests (time-based windows, edge cases)
- [x] ComputeGemFeatures unit tests (multi-window, relative metrics)
- [x] Backtest regression tests updated and passing

Generated with [Claude Code](https://claude.com/claude-code)