### PR TITLE
POE-60: Temporal model — hourly + weekday phase biases

### DIFF
--- a/internal/db/migrations/20260319212618_add_temporal_fields_to_market_context.down.sql
+++ b/internal/db/migrations/20260319212618_add_temporal_fields_to_market_context.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE market_context DROP COLUMN IF EXISTS hourly_volatility;
+ALTER TABLE market_context DROP COLUMN IF EXISTS hourly_activity;
+ALTER TABLE market_context DROP COLUMN IF EXISTS weekday_volatility;
+ALTER TABLE market_context DROP COLUMN IF EXISTS weekday_activity;

--- a/internal/db/migrations/20260319212618_add_temporal_fields_to_market_context.up.sql
+++ b/internal/db/migrations/20260319212618_add_temporal_fields_to_market_context.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE market_context ADD COLUMN hourly_volatility JSONB NOT NULL DEFAULT '[]';
+ALTER TABLE market_context ADD COLUMN hourly_activity JSONB NOT NULL DEFAULT '[]';
+ALTER TABLE market_context ADD COLUMN weekday_volatility JSONB NOT NULL DEFAULT '[]';
+ALTER TABLE market_context ADD COLUMN weekday_activity JSONB NOT NULL DEFAULT '[]';

--- a/internal/lab/gem_features_test.go
+++ b/internal/lab/gem_features_test.go
@@ -25,8 +25,12 @@ func testMarketContext() MarketContext {
 			High: 100,
 			Mid:  30,
 		},
-		HourlyBias:  make([]float64, 24),
-		WeekdayBias: make([]float64, 7),
+		HourlyBias:        make([]float64, 24),
+		HourlyVolatility:  make([]float64, 24),
+		HourlyActivity:    make([]float64, 24),
+		WeekdayBias:       make([]float64, 7),
+		WeekdayVolatility: make([]float64, 7),
+		WeekdayActivity:   make([]float64, 7),
 	}
 }
 
@@ -438,7 +442,11 @@ func TestComputeGemFeatures_ZeroMarketContext(t *testing.T) {
 		PricePercentiles:   make(map[string]float64),
 		ListingPercentiles: make(map[string]float64),
 		HourlyBias:         make([]float64, 24),
+		HourlyVolatility:   make([]float64, 24),
+		HourlyActivity:     make([]float64, 24),
 		WeekdayBias:        make([]float64, 7),
+		WeekdayVolatility:  make([]float64, 7),
+		WeekdayActivity:    make([]float64, 7),
 	}
 
 	features := ComputeGemFeatures(snapTime, gems, nil, mc)

--- a/internal/lab/market_context.go
+++ b/internal/lab/market_context.go
@@ -20,17 +20,16 @@ func ComputeMarketContext(snapTime time.Time, gems []GemPrice, history []GemPric
 		Time:               snapTime,
 		PricePercentiles:   make(map[string]float64),
 		ListingPercentiles: make(map[string]float64),
-		HourlyBias:         make([]float64, 24),
-		WeekdayBias:        make([]float64, 7),
 	}
 
-	// Stub bias values: 1.0 (neutral). POE-60 fills in real temporal patterns.
-	for i := range mc.HourlyBias {
-		mc.HourlyBias[i] = 1.0
-	}
-	for i := range mc.WeekdayBias {
-		mc.WeekdayBias[i] = 1.0
-	}
+	// Compute temporal biases from historical data.
+	tb := computeTemporalBiases(history)
+	mc.HourlyBias = tb.HourlyBias[:]
+	mc.HourlyVolatility = tb.HourlyVolatility[:]
+	mc.HourlyActivity = tb.HourlyActivity[:]
+	mc.WeekdayBias = tb.WeekdayBias[:]
+	mc.WeekdayVolatility = tb.WeekdayVolatility[:]
+	mc.WeekdayActivity = tb.WeekdayActivity[:]
 
 	// Filter to active transfigured gems (not corrupted, exclude Trarthus).
 	var active []GemPrice

--- a/internal/lab/market_context_test.go
+++ b/internal/lab/market_context_test.go
@@ -193,17 +193,50 @@ func TestComputeMarketContext_EmptyGems(t *testing.T) {
 	if mc.ListingPercentiles == nil {
 		t.Error("ListingPercentiles is nil, must be initialized map")
 	}
-	if mc.HourlyBias == nil {
-		t.Error("HourlyBias is nil, must be initialized slice")
+	// All temporal slices must be initialized (not nil) for JSON marshaling.
+	temporalSlices := map[string][]float64{
+		"HourlyBias":        mc.HourlyBias,
+		"HourlyVolatility":  mc.HourlyVolatility,
+		"HourlyActivity":    mc.HourlyActivity,
+		"WeekdayBias":       mc.WeekdayBias,
+		"WeekdayVolatility": mc.WeekdayVolatility,
+		"WeekdayActivity":   mc.WeekdayActivity,
 	}
-	if len(mc.HourlyBias) != 24 {
-		t.Errorf("HourlyBias length = %d, want 24", len(mc.HourlyBias))
+	for name, s := range temporalSlices {
+		if s == nil {
+			t.Errorf("%s is nil, must be initialized slice", name)
+			continue
+		}
+		wantLen := 24
+		if name[:7] == "Weekday" {
+			wantLen = 7
+		}
+		if len(s) != wantLen {
+			t.Errorf("%s length = %d, want %d", name, len(s), wantLen)
+		}
 	}
-	if mc.WeekdayBias == nil {
-		t.Error("WeekdayBias is nil, must be initialized slice")
+
+	// With no history, hourly/weekday biases should be neutral 1.0.
+	for i, v := range mc.HourlyBias {
+		if v != 1.0 {
+			t.Errorf("HourlyBias[%d] = %f, want 1.0 (neutral)", i, v)
+		}
 	}
-	if len(mc.WeekdayBias) != 7 {
-		t.Errorf("WeekdayBias length = %d, want 7", len(mc.WeekdayBias))
+	for i, v := range mc.WeekdayBias {
+		if v != 1.0 {
+			t.Errorf("WeekdayBias[%d] = %f, want 1.0 (neutral)", i, v)
+		}
+	}
+	// Volatility and activity should be zero with no history.
+	for i, v := range mc.HourlyVolatility {
+		if v != 0 {
+			t.Errorf("HourlyVolatility[%d] = %f, want 0", i, v)
+		}
+	}
+	for i, v := range mc.WeekdayActivity {
+		if v != 0 {
+			t.Errorf("WeekdayActivity[%d] = %f, want 0", i, v)
+		}
 	}
 }
 
@@ -259,30 +292,89 @@ func TestComputeMarketContext_AllSamePrice(t *testing.T) {
 	}
 }
 
-func TestComputeMarketContext_BiasStubs(t *testing.T) {
-	snapTime := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+func TestComputeMarketContext_TemporalBiases(t *testing.T) {
+	snapTime := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC) // Monday
 	gems := []GemPrice{
 		{Name: "Gem A of X", Variant: "20/20", Chaos: 50, Listings: 10, IsTransfigured: true},
+		{Name: "Gem B of X", Variant: "20/20", Chaos: 100, Listings: 20, IsTransfigured: true},
 	}
 
-	mc := ComputeMarketContext(snapTime, gems, nil)
+	// Hour 8 (Monday): bearish -5%. Hour 20 (Monday): bullish +3%.
+	monday8am := time.Date(2026, 3, 16, 8, 0, 0, 0, time.UTC)
+	monday20pm := time.Date(2026, 3, 16, 20, 0, 0, 0, time.UTC)
 
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				{Time: monday8am, Chaos: 100, Listings: 10},
+				{Time: monday8am.Add(30 * time.Minute), Chaos: 95, Listings: 10},
+			},
+		},
+		{
+			Name: "Gem B of X", Variant: "20/20", GemColor: "BLUE",
+			Points: []PricePoint{
+				{Time: monday20pm, Chaos: 100, Listings: 20},
+				{Time: monday20pm.Add(30 * time.Minute), Chaos: 103, Listings: 20},
+			},
+		},
+	}
+
+	mc := ComputeMarketContext(snapTime, gems, history)
+
+	// Verify slice lengths.
 	if len(mc.HourlyBias) != 24 {
 		t.Fatalf("HourlyBias length = %d, want 24", len(mc.HourlyBias))
 	}
-	for i, v := range mc.HourlyBias {
-		if v != 1.0 {
-			t.Errorf("HourlyBias[%d] = %f, want 1.0", i, v)
-		}
+	if len(mc.HourlyVolatility) != 24 {
+		t.Fatalf("HourlyVolatility length = %d, want 24", len(mc.HourlyVolatility))
 	}
-
+	if len(mc.HourlyActivity) != 24 {
+		t.Fatalf("HourlyActivity length = %d, want 24", len(mc.HourlyActivity))
+	}
 	if len(mc.WeekdayBias) != 7 {
 		t.Fatalf("WeekdayBias length = %d, want 7", len(mc.WeekdayBias))
 	}
-	for i, v := range mc.WeekdayBias {
-		if v != 1.0 {
-			t.Errorf("WeekdayBias[%d] = %f, want 1.0", i, v)
+	if len(mc.WeekdayVolatility) != 7 {
+		t.Fatalf("WeekdayVolatility length = %d, want 7", len(mc.WeekdayVolatility))
+	}
+	if len(mc.WeekdayActivity) != 7 {
+		t.Fatalf("WeekdayActivity length = %d, want 7", len(mc.WeekdayActivity))
+	}
+
+	// Bearish hour should have bias < 1.0.
+	if mc.HourlyBias[8] >= 1.0 {
+		t.Errorf("HourlyBias[8] = %.4f, want < 1.0 (bearish)", mc.HourlyBias[8])
+	}
+
+	// Bullish hour should have bias > 1.0.
+	if mc.HourlyBias[20] <= 1.0 {
+		t.Errorf("HourlyBias[20] = %.4f, want > 1.0 (bullish)", mc.HourlyBias[20])
+	}
+
+	// Empty hours should be neutral.
+	if mc.HourlyBias[0] != 1.0 {
+		t.Errorf("HourlyBias[0] = %f, want 1.0 (neutral/empty)", mc.HourlyBias[0])
+	}
+
+	// Monday (1) should have a non-neutral weekday bias (both data points are Monday).
+	if mc.WeekdayBias[1] == 1.0 {
+		t.Error("WeekdayBias[1] (Monday) = 1.0, expected non-neutral with data")
+	}
+
+	// Other weekdays should be neutral.
+	for _, d := range []int{0, 2, 3, 4, 5, 6} {
+		if mc.WeekdayBias[d] != 1.0 {
+			t.Errorf("WeekdayBias[%d] = %f, want 1.0 (neutral)", d, mc.WeekdayBias[d])
 		}
+	}
+
+	// Activity for populated hours should be > 0 (both changes are > 2%).
+	if mc.HourlyActivity[8] <= 0 {
+		t.Errorf("HourlyActivity[8] = %f, want > 0", mc.HourlyActivity[8])
+	}
+	if mc.HourlyActivity[20] <= 0 {
+		t.Errorf("HourlyActivity[20] = %f, want > 0", mc.HourlyActivity[20])
 	}
 }
 

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -749,6 +749,10 @@ func (r *Repository) SignalHistory(ctx context.Context, name, variant string, li
 // SaveMarketContext persists a single market context snapshot.
 // Uses ON CONFLICT DO NOTHING so re-runs for the same time are idempotent.
 func (r *Repository) SaveMarketContext(ctx context.Context, mc MarketContext) error {
+	if err := mc.ValidateTemporalSlices(); err != nil {
+		return fmt.Errorf("lab repo: save market context: %w", err)
+	}
+
 	pricePerc, err := json.Marshal(mc.PricePercentiles)
 	if err != nil {
 		return fmt.Errorf("lab repo: marshal price percentiles: %w", err)
@@ -844,29 +848,27 @@ func (r *Repository) LatestMarketContext(ctx context.Context) (*MarketContext, e
 	if err := json.Unmarshal(tierBounds, &mc.TierBoundaries); err != nil {
 		return nil, fmt.Errorf("lab repo: unmarshal tier boundaries: %w", err)
 	}
-	mc.HourlyBias = make([]float64, 24)
 	if err := json.Unmarshal(hourly, &mc.HourlyBias); err != nil {
 		return nil, fmt.Errorf("lab repo: unmarshal hourly bias: %w", err)
 	}
-	mc.HourlyVolatility = make([]float64, 24)
 	if err := json.Unmarshal(hourlyVol, &mc.HourlyVolatility); err != nil {
 		return nil, fmt.Errorf("lab repo: unmarshal hourly volatility: %w", err)
 	}
-	mc.HourlyActivity = make([]float64, 24)
 	if err := json.Unmarshal(hourlyAct, &mc.HourlyActivity); err != nil {
 		return nil, fmt.Errorf("lab repo: unmarshal hourly activity: %w", err)
 	}
-	mc.WeekdayBias = make([]float64, 7)
 	if err := json.Unmarshal(weekday, &mc.WeekdayBias); err != nil {
 		return nil, fmt.Errorf("lab repo: unmarshal weekday bias: %w", err)
 	}
-	mc.WeekdayVolatility = make([]float64, 7)
 	if err := json.Unmarshal(weekdayVol, &mc.WeekdayVolatility); err != nil {
 		return nil, fmt.Errorf("lab repo: unmarshal weekday volatility: %w", err)
 	}
-	mc.WeekdayActivity = make([]float64, 7)
 	if err := json.Unmarshal(weekdayAct, &mc.WeekdayActivity); err != nil {
 		return nil, fmt.Errorf("lab repo: unmarshal weekday activity: %w", err)
+	}
+
+	if err := mc.ValidateTemporalSlices(); err != nil {
+		return nil, fmt.Errorf("lab repo: latest market context: %w", err)
 	}
 
 	return &mc, nil

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -765,21 +765,41 @@ func (r *Repository) SaveMarketContext(ctx context.Context, mc MarketContext) er
 	if err != nil {
 		return fmt.Errorf("lab repo: marshal hourly bias: %w", err)
 	}
+	hourlyVol, err := json.Marshal(mc.HourlyVolatility)
+	if err != nil {
+		return fmt.Errorf("lab repo: marshal hourly volatility: %w", err)
+	}
+	hourlyAct, err := json.Marshal(mc.HourlyActivity)
+	if err != nil {
+		return fmt.Errorf("lab repo: marshal hourly activity: %w", err)
+	}
 	weekday, err := json.Marshal(mc.WeekdayBias)
 	if err != nil {
 		return fmt.Errorf("lab repo: marshal weekday bias: %w", err)
+	}
+	weekdayVol, err := json.Marshal(mc.WeekdayVolatility)
+	if err != nil {
+		return fmt.Errorf("lab repo: marshal weekday volatility: %w", err)
+	}
+	weekdayAct, err := json.Marshal(mc.WeekdayActivity)
+	if err != nil {
+		return fmt.Errorf("lab repo: marshal weekday activity: %w", err)
 	}
 
 	_, err = r.pool.Exec(ctx, `
 		INSERT INTO market_context
 		 (time, price_percentiles, listing_percentiles,
 		  velocity_mean, velocity_sigma, listing_vel_mean, listing_vel_sigma,
-		  total_gems, total_listings, tier_boundaries, hourly_bias, weekday_bias)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		  total_gems, total_listings, tier_boundaries,
+		  hourly_bias, hourly_volatility, hourly_activity,
+		  weekday_bias, weekday_volatility, weekday_activity)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
 		ON CONFLICT DO NOTHING`,
 		mc.Time, pricePerc, listPerc,
 		mc.VelocityMean, mc.VelocitySigma, mc.ListingVelMean, mc.ListingVelSigma,
-		mc.TotalGems, mc.TotalListings, tierBounds, hourly, weekday,
+		mc.TotalGems, mc.TotalListings, tierBounds,
+		hourly, hourlyVol, hourlyAct,
+		weekday, weekdayVol, weekdayAct,
 	)
 	if err != nil {
 		return fmt.Errorf("lab repo: insert market context: %w", err)
@@ -791,17 +811,23 @@ func (r *Repository) SaveMarketContext(ctx context.Context, mc MarketContext) er
 // Returns (nil, nil) when no rows exist.
 func (r *Repository) LatestMarketContext(ctx context.Context) (*MarketContext, error) {
 	var mc MarketContext
-	var pricePerc, listPerc, tierBounds, hourly, weekday []byte
+	var pricePerc, listPerc, tierBounds []byte
+	var hourly, hourlyVol, hourlyAct []byte
+	var weekday, weekdayVol, weekdayAct []byte
 
 	err := r.pool.QueryRow(ctx, `
 		SELECT time, price_percentiles, listing_percentiles,
 		       velocity_mean, velocity_sigma, listing_vel_mean, listing_vel_sigma,
-		       total_gems, total_listings, tier_boundaries, hourly_bias, weekday_bias
+		       total_gems, total_listings, tier_boundaries,
+		       hourly_bias, hourly_volatility, hourly_activity,
+		       weekday_bias, weekday_volatility, weekday_activity
 		FROM market_context
 		WHERE time = (SELECT MAX(time) FROM market_context)`).
 		Scan(&mc.Time, &pricePerc, &listPerc,
 			&mc.VelocityMean, &mc.VelocitySigma, &mc.ListingVelMean, &mc.ListingVelSigma,
-			&mc.TotalGems, &mc.TotalListings, &tierBounds, &hourly, &weekday)
+			&mc.TotalGems, &mc.TotalListings, &tierBounds,
+			&hourly, &hourlyVol, &hourlyAct,
+			&weekday, &weekdayVol, &weekdayAct)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
@@ -818,11 +844,29 @@ func (r *Repository) LatestMarketContext(ctx context.Context) (*MarketContext, e
 	if err := json.Unmarshal(tierBounds, &mc.TierBoundaries); err != nil {
 		return nil, fmt.Errorf("lab repo: unmarshal tier boundaries: %w", err)
 	}
+	mc.HourlyBias = make([]float64, 24)
 	if err := json.Unmarshal(hourly, &mc.HourlyBias); err != nil {
 		return nil, fmt.Errorf("lab repo: unmarshal hourly bias: %w", err)
 	}
+	mc.HourlyVolatility = make([]float64, 24)
+	if err := json.Unmarshal(hourlyVol, &mc.HourlyVolatility); err != nil {
+		return nil, fmt.Errorf("lab repo: unmarshal hourly volatility: %w", err)
+	}
+	mc.HourlyActivity = make([]float64, 24)
+	if err := json.Unmarshal(hourlyAct, &mc.HourlyActivity); err != nil {
+		return nil, fmt.Errorf("lab repo: unmarshal hourly activity: %w", err)
+	}
+	mc.WeekdayBias = make([]float64, 7)
 	if err := json.Unmarshal(weekday, &mc.WeekdayBias); err != nil {
 		return nil, fmt.Errorf("lab repo: unmarshal weekday bias: %w", err)
+	}
+	mc.WeekdayVolatility = make([]float64, 7)
+	if err := json.Unmarshal(weekdayVol, &mc.WeekdayVolatility); err != nil {
+		return nil, fmt.Errorf("lab repo: unmarshal weekday volatility: %w", err)
+	}
+	mc.WeekdayActivity = make([]float64, 7)
+	if err := json.Unmarshal(weekdayAct, &mc.WeekdayActivity); err != nil {
+		return nil, fmt.Errorf("lab repo: unmarshal weekday activity: %w", err)
 	}
 
 	return &mc, nil

--- a/internal/lab/temporal.go
+++ b/internal/lab/temporal.go
@@ -21,6 +21,9 @@ const movingThreshold = 0.02
 // computeTemporalBiases computes direction bias, volatility, and activity ratio
 // for each hour of day (0-23 UTC) and day of week (Sun=0..Sat=6).
 //
+// Precondition: each GemPriceHistory.Points slice must be sorted by Time ASC.
+// This invariant is enforced at the data-loading boundary (see trends.go).
+//
 // For each gem's price history, consecutive point pairs produce a percent change.
 // These are bucketed by the earlier point's timestamp (the "cause" time).
 //

--- a/internal/lab/temporal.go
+++ b/internal/lab/temporal.go
@@ -1,0 +1,108 @@
+package lab
+
+import "math"
+
+// TemporalBiases holds all computed temporal patterns for hourly and weekday buckets.
+// Fixed-size arrays are used internally; the caller copies to slices for MarketContext.
+type TemporalBiases struct {
+	HourlyBias        [24]float64 // direction: 1.0+mean(pctChange), neutral=1.0
+	HourlyVolatility  [24]float64 // σ of pctChanges per hour
+	HourlyActivity    [24]float64 // fraction of observations with |pctChange|>2%
+	WeekdayBias       [7]float64  // direction per weekday (Sun=0..Sat=6)
+	WeekdayVolatility [7]float64
+	WeekdayActivity   [7]float64
+}
+
+// movingThreshold defines the minimum absolute percent change for a gem to be
+// considered "moving" in activity ratio calculations. 2% is relative to each
+// gem's own price, not a hardcoded chaos amount.
+const movingThreshold = 0.02
+
+// computeTemporalBiases computes direction bias, volatility, and activity ratio
+// for each hour of day (0-23 UTC) and day of week (Sun=0..Sat=6).
+//
+// For each gem's price history, consecutive point pairs produce a percent change.
+// These are bucketed by the earlier point's timestamp (the "cause" time).
+//
+// Per bucket:
+//   - DirectionBias = 1.0 + mean(pctChanges) — neutral=1.0, bearish<1.0, bullish>1.0
+//   - Volatility = σ(pctChanges) — raw standard deviation of price movements
+//   - Activity = count(|pctChange|>2%) / count(total) — fraction of moving observations
+//
+// Empty buckets get direction=1.0, volatility=0, activity=0.
+func computeTemporalBiases(history []GemPriceHistory) TemporalBiases {
+	var tb TemporalBiases
+
+	// Initialize direction biases to neutral 1.0.
+	for i := range tb.HourlyBias {
+		tb.HourlyBias[i] = 1.0
+	}
+	for i := range tb.WeekdayBias {
+		tb.WeekdayBias[i] = 1.0
+	}
+
+	// Collect pctChanges per hourly and weekday bucket.
+	type bucketData struct {
+		pctChanges []float64
+		movingCnt  int
+	}
+
+	hourlyBuckets := make([]bucketData, 24)
+	weekdayBuckets := make([]bucketData, 7)
+
+	for _, h := range history {
+		for i := 0; i < len(h.Points)-1; i++ {
+			prev := h.Points[i]
+			curr := h.Points[i+1]
+
+			if prev.Chaos <= 0 {
+				continue
+			}
+
+			pctChange := (curr.Chaos - prev.Chaos) / prev.Chaos
+			pctChange = sanitizeFloat(pctChange)
+			if math.IsNaN(pctChange) || math.IsInf(pctChange, 0) {
+				continue
+			}
+
+			isMoving := math.Abs(pctChange) > movingThreshold
+
+			hour := prev.Time.UTC().Hour()
+			hourlyBuckets[hour].pctChanges = append(hourlyBuckets[hour].pctChanges, pctChange)
+			if isMoving {
+				hourlyBuckets[hour].movingCnt++
+			}
+
+			weekday := int(prev.Time.UTC().Weekday())
+			weekdayBuckets[weekday].pctChanges = append(weekdayBuckets[weekday].pctChanges, pctChange)
+			if isMoving {
+				weekdayBuckets[weekday].movingCnt++
+			}
+		}
+	}
+
+	// Compute stats per bucket.
+	for i := 0; i < 24; i++ {
+		b := hourlyBuckets[i]
+		if len(b.pctChanges) == 0 {
+			continue
+		}
+		mean, sigma := meanStddev(b.pctChanges)
+		tb.HourlyBias[i] = sanitizeFloat(1.0 + mean)
+		tb.HourlyVolatility[i] = sanitizeFloat(sigma)
+		tb.HourlyActivity[i] = sanitizeFloat(float64(b.movingCnt) / float64(len(b.pctChanges)))
+	}
+
+	for i := 0; i < 7; i++ {
+		b := weekdayBuckets[i]
+		if len(b.pctChanges) == 0 {
+			continue
+		}
+		mean, sigma := meanStddev(b.pctChanges)
+		tb.WeekdayBias[i] = sanitizeFloat(1.0 + mean)
+		tb.WeekdayVolatility[i] = sanitizeFloat(sigma)
+		tb.WeekdayActivity[i] = sanitizeFloat(float64(b.movingCnt) / float64(len(b.pctChanges)))
+	}
+
+	return tb
+}

--- a/internal/lab/temporal_test.go
+++ b/internal/lab/temporal_test.go
@@ -1,0 +1,428 @@
+package lab
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// makePoint is a helper to create a PricePoint at a specific time with a chaos price.
+func makePoint(t time.Time, chaos float64) PricePoint {
+	return PricePoint{Time: t, Chaos: chaos, Listings: 10}
+}
+
+func TestComputeTemporalBiases_DirectionBias(t *testing.T) {
+	// Create history where hour 8 has a -5% price drop and hour 20 has a +3% rise.
+	// Use a Monday (weekday=1) for all points.
+	monday8am := time.Date(2026, 3, 16, 8, 0, 0, 0, time.UTC)  // Monday
+	monday20pm := time.Date(2026, 3, 16, 20, 0, 0, 0, time.UTC) // Monday
+
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(monday8am, 100),
+				makePoint(monday8am.Add(30*time.Minute), 95), // -5% at hour 8
+			},
+		},
+		{
+			Name: "Gem B of X", Variant: "20/20", GemColor: "BLUE",
+			Points: []PricePoint{
+				makePoint(monday20pm, 100),
+				makePoint(monday20pm.Add(30*time.Minute), 103), // +3% at hour 20
+			},
+		},
+	}
+
+	tb := computeTemporalBiases(history)
+
+	// Hour 8: mean pctChange = -0.05, bias = 1.0 + (-0.05) = 0.95
+	if !approxEqual(tb.HourlyBias[8], 0.95, 0.001) {
+		t.Errorf("HourlyBias[8] = %.4f, want 0.95 (bearish)", tb.HourlyBias[8])
+	}
+
+	// Hour 20: mean pctChange = +0.03, bias = 1.0 + 0.03 = 1.03
+	if !approxEqual(tb.HourlyBias[20], 1.03, 0.001) {
+		t.Errorf("HourlyBias[20] = %.4f, want 1.03 (bullish)", tb.HourlyBias[20])
+	}
+
+	// Unpopulated hours should remain neutral.
+	for _, h := range []int{0, 1, 5, 12, 15} {
+		if tb.HourlyBias[h] != 1.0 {
+			t.Errorf("HourlyBias[%d] = %f, want 1.0 (neutral/empty)", h, tb.HourlyBias[h])
+		}
+	}
+}
+
+func TestComputeTemporalBiases_WeekdayBias(t *testing.T) {
+	// Monday (1) has a -4% drop, Saturday (6) has a +6% rise.
+	monday := time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC)   // Monday
+	saturday := time.Date(2026, 3, 21, 10, 0, 0, 0, time.UTC)  // Saturday
+
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(monday, 200),
+				makePoint(monday.Add(30*time.Minute), 192), // -4%
+			},
+		},
+		{
+			Name: "Gem B of X", Variant: "20/20", GemColor: "BLUE",
+			Points: []PricePoint{
+				makePoint(saturday, 200),
+				makePoint(saturday.Add(30*time.Minute), 212), // +6%
+			},
+		},
+	}
+
+	tb := computeTemporalBiases(history)
+
+	// Weekday 1 (Monday): bias = 1.0 + (-0.04) = 0.96
+	if !approxEqual(tb.WeekdayBias[1], 0.96, 0.001) {
+		t.Errorf("WeekdayBias[1] = %.4f, want 0.96 (bearish Monday)", tb.WeekdayBias[1])
+	}
+
+	// Weekday 6 (Saturday): bias = 1.0 + 0.06 = 1.06
+	if !approxEqual(tb.WeekdayBias[6], 1.06, 0.001) {
+		t.Errorf("WeekdayBias[6] = %.4f, want 1.06 (bullish Saturday)", tb.WeekdayBias[6])
+	}
+
+	// Other weekdays neutral.
+	for _, d := range []int{0, 2, 3, 4, 5} {
+		if tb.WeekdayBias[d] != 1.0 {
+			t.Errorf("WeekdayBias[%d] = %f, want 1.0 (neutral)", d, tb.WeekdayBias[d])
+		}
+	}
+}
+
+func TestComputeTemporalBiases_Volatility(t *testing.T) {
+	// Hour 10: two gems with divergent price changes → high volatility.
+	// Hour 14: two gems with same price change → zero volatility.
+	base := time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC) // Monday 10:00
+	calm := time.Date(2026, 3, 16, 14, 0, 0, 0, time.UTC)  // Monday 14:00
+
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(base, 100),
+				makePoint(base.Add(30*time.Minute), 110), // +10%
+			},
+		},
+		{
+			Name: "Gem B of X", Variant: "20/20", GemColor: "BLUE",
+			Points: []PricePoint{
+				makePoint(base, 100),
+				makePoint(base.Add(30*time.Minute), 90), // -10%
+			},
+		},
+		{
+			Name: "Gem C of X", Variant: "20/20", GemColor: "GREEN",
+			Points: []PricePoint{
+				makePoint(calm, 100),
+				makePoint(calm.Add(30*time.Minute), 105), // +5%
+			},
+		},
+		{
+			Name: "Gem D of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(calm, 100),
+				makePoint(calm.Add(30*time.Minute), 105), // +5%
+			},
+		},
+	}
+
+	tb := computeTemporalBiases(history)
+
+	// Hour 10: pctChanges = [+0.10, -0.10], mean=0, σ=0.10
+	if !approxEqual(tb.HourlyVolatility[10], 0.10, 0.001) {
+		t.Errorf("HourlyVolatility[10] = %.4f, want ~0.10 (high)", tb.HourlyVolatility[10])
+	}
+
+	// Hour 14: pctChanges = [+0.05, +0.05], mean=0.05, σ=0.0
+	if !approxEqual(tb.HourlyVolatility[14], 0.0, 0.001) {
+		t.Errorf("HourlyVolatility[14] = %.4f, want ~0.0 (calm)", tb.HourlyVolatility[14])
+	}
+
+	// Volatile hour should have higher volatility than calm hour.
+	if tb.HourlyVolatility[10] <= tb.HourlyVolatility[14] {
+		t.Errorf("HourlyVolatility[10] (%.4f) should be > HourlyVolatility[14] (%.4f)",
+			tb.HourlyVolatility[10], tb.HourlyVolatility[14])
+	}
+}
+
+func TestComputeTemporalBiases_Activity(t *testing.T) {
+	// Hour 6: all gems move > 2% → activity = 1.0
+	// Hour 12: all gems flat (< 2%) → activity = 0.0
+	active := time.Date(2026, 3, 16, 6, 0, 0, 0, time.UTC) // Monday 06:00
+	flat := time.Date(2026, 3, 16, 12, 0, 0, 0, time.UTC)  // Monday 12:00
+
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(active, 100),
+				makePoint(active.Add(30*time.Minute), 110), // +10%, moving
+			},
+		},
+		{
+			Name: "Gem B of X", Variant: "20/20", GemColor: "BLUE",
+			Points: []PricePoint{
+				makePoint(active, 100),
+				makePoint(active.Add(30*time.Minute), 95), // -5%, moving
+			},
+		},
+		{
+			Name: "Gem C of X", Variant: "20/20", GemColor: "GREEN",
+			Points: []PricePoint{
+				makePoint(flat, 100),
+				makePoint(flat.Add(30*time.Minute), 100.5), // +0.5%, flat
+			},
+		},
+		{
+			Name: "Gem D of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(flat, 100),
+				makePoint(flat.Add(30*time.Minute), 99.5), // -0.5%, flat
+			},
+		},
+	}
+
+	tb := computeTemporalBiases(history)
+
+	// Hour 6: 2/2 moving → activity = 1.0
+	if !approxEqual(tb.HourlyActivity[6], 1.0, 0.001) {
+		t.Errorf("HourlyActivity[6] = %.4f, want 1.0 (all moving)", tb.HourlyActivity[6])
+	}
+
+	// Hour 12: 0/2 moving → activity = 0.0
+	if !approxEqual(tb.HourlyActivity[12], 0.0, 0.001) {
+		t.Errorf("HourlyActivity[12] = %.4f, want 0.0 (all flat)", tb.HourlyActivity[12])
+	}
+}
+
+func TestComputeTemporalBiases_MixedActivity(t *testing.T) {
+	// Hour 8: 1 moving + 1 flat → activity = 0.5
+	base := time.Date(2026, 3, 16, 8, 0, 0, 0, time.UTC) // Monday 08:00
+
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(base, 100),
+				makePoint(base.Add(30*time.Minute), 110), // +10%, moving
+			},
+		},
+		{
+			Name: "Gem B of X", Variant: "20/20", GemColor: "BLUE",
+			Points: []PricePoint{
+				makePoint(base, 100),
+				makePoint(base.Add(30*time.Minute), 101), // +1%, flat
+			},
+		},
+	}
+
+	tb := computeTemporalBiases(history)
+
+	if !approxEqual(tb.HourlyActivity[8], 0.5, 0.001) {
+		t.Errorf("HourlyActivity[8] = %.4f, want 0.5 (half moving)", tb.HourlyActivity[8])
+	}
+}
+
+func TestComputeTemporalBiases_EmptyHistory(t *testing.T) {
+	tb := computeTemporalBiases(nil)
+
+	for i := 0; i < 24; i++ {
+		if tb.HourlyBias[i] != 1.0 {
+			t.Errorf("HourlyBias[%d] = %f, want 1.0", i, tb.HourlyBias[i])
+		}
+		if tb.HourlyVolatility[i] != 0 {
+			t.Errorf("HourlyVolatility[%d] = %f, want 0", i, tb.HourlyVolatility[i])
+		}
+		if tb.HourlyActivity[i] != 0 {
+			t.Errorf("HourlyActivity[%d] = %f, want 0", i, tb.HourlyActivity[i])
+		}
+	}
+	for i := 0; i < 7; i++ {
+		if tb.WeekdayBias[i] != 1.0 {
+			t.Errorf("WeekdayBias[%d] = %f, want 1.0", i, tb.WeekdayBias[i])
+		}
+		if tb.WeekdayVolatility[i] != 0 {
+			t.Errorf("WeekdayVolatility[%d] = %f, want 0", i, tb.WeekdayVolatility[i])
+		}
+		if tb.WeekdayActivity[i] != 0 {
+			t.Errorf("WeekdayActivity[%d] = %f, want 0", i, tb.WeekdayActivity[i])
+		}
+	}
+}
+
+func TestComputeTemporalBiases_SingleHour(t *testing.T) {
+	// Only hour 15 has data; all others should be neutral/zero.
+	base := time.Date(2026, 3, 16, 15, 0, 0, 0, time.UTC) // Monday 15:00
+
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(base, 100),
+				makePoint(base.Add(30*time.Minute), 108), // +8%
+			},
+		},
+	}
+
+	tb := computeTemporalBiases(history)
+
+	// Hour 15: bias = 1.0 + 0.08 = 1.08
+	if !approxEqual(tb.HourlyBias[15], 1.08, 0.001) {
+		t.Errorf("HourlyBias[15] = %.4f, want 1.08", tb.HourlyBias[15])
+	}
+
+	// All other hours neutral.
+	for i := 0; i < 24; i++ {
+		if i == 15 {
+			continue
+		}
+		if tb.HourlyBias[i] != 1.0 {
+			t.Errorf("HourlyBias[%d] = %f, want 1.0 (neutral)", i, tb.HourlyBias[i])
+		}
+		if tb.HourlyVolatility[i] != 0 {
+			t.Errorf("HourlyVolatility[%d] = %f, want 0 (empty)", i, tb.HourlyVolatility[i])
+		}
+	}
+}
+
+func TestComputeTemporalBiases_SkipsZeroPrev(t *testing.T) {
+	// Points with prev.Chaos = 0 should be skipped (no division by zero).
+	base := time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC)
+
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(base, 0),
+				makePoint(base.Add(30*time.Minute), 100),
+			},
+		},
+	}
+
+	tb := computeTemporalBiases(history)
+
+	// Hour 10 should still be neutral since the pair was skipped.
+	if tb.HourlyBias[10] != 1.0 {
+		t.Errorf("HourlyBias[10] = %f, want 1.0 (skipped zero prev)", tb.HourlyBias[10])
+	}
+}
+
+func TestComputeTemporalBiases_MultiplePointsPerGem(t *testing.T) {
+	// A gem with 3 points produces 2 pctChange pairs at different hours.
+	t0 := time.Date(2026, 3, 16, 8, 0, 0, 0, time.UTC)  // Monday 08:00
+	t1 := time.Date(2026, 3, 16, 9, 0, 0, 0, time.UTC)  // Monday 09:00 (pair 0→1 at hour 8)
+	t2 := time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC) // Monday 10:00 (pair 1→2 at hour 9)
+
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(t0, 100),
+				makePoint(t1, 110), // +10% at hour 8
+				makePoint(t2, 99),  // -10% at hour 9
+			},
+		},
+	}
+
+	tb := computeTemporalBiases(history)
+
+	// Hour 8: pctChange = +0.10, bias = 1.10
+	if !approxEqual(tb.HourlyBias[8], 1.10, 0.001) {
+		t.Errorf("HourlyBias[8] = %.4f, want 1.10", tb.HourlyBias[8])
+	}
+
+	// Hour 9: pctChange = (99-110)/110 = -0.1, bias = 1.0 + (-0.1) = 0.9
+	if !approxEqual(tb.HourlyBias[9], 0.9, 0.001) {
+		t.Errorf("HourlyBias[9] = %.4f, want 0.90", tb.HourlyBias[9])
+	}
+}
+
+func TestComputeTemporalBiases_WeekdayVolatility(t *testing.T) {
+	// Monday: two gems with opposing changes → σ > 0.
+	// Tuesday: one gem with single change → σ = 0 (only 1 sample).
+	monday := time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC)
+	tuesday := time.Date(2026, 3, 17, 10, 0, 0, 0, time.UTC)
+
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(monday, 100),
+				makePoint(monday.Add(30*time.Minute), 120), // +20%
+			},
+		},
+		{
+			Name: "Gem B of X", Variant: "20/20", GemColor: "BLUE",
+			Points: []PricePoint{
+				makePoint(monday, 100),
+				makePoint(monday.Add(30*time.Minute), 80), // -20%
+			},
+		},
+		{
+			Name: "Gem C of X", Variant: "20/20", GemColor: "GREEN",
+			Points: []PricePoint{
+				makePoint(tuesday, 100),
+				makePoint(tuesday.Add(30*time.Minute), 105), // +5%
+			},
+		},
+	}
+
+	tb := computeTemporalBiases(history)
+
+	// Monday (1): pctChanges = [+0.20, -0.20], mean=0, σ=0.20
+	if !approxEqual(tb.WeekdayVolatility[1], 0.20, 0.001) {
+		t.Errorf("WeekdayVolatility[1] = %.4f, want ~0.20", tb.WeekdayVolatility[1])
+	}
+
+	// Tuesday (2): single observation → σ=0
+	if !approxEqual(tb.WeekdayVolatility[2], 0.0, 0.001) {
+		t.Errorf("WeekdayVolatility[2] = %.4f, want 0.0", tb.WeekdayVolatility[2])
+	}
+}
+
+func TestComputeTemporalBiases_NaNSafe(t *testing.T) {
+	// Ensure no NaN or Inf in output even with extreme values.
+	base := time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC)
+
+	history := []GemPriceHistory{
+		{
+			Name: "Gem A of X", Variant: "20/20", GemColor: "RED",
+			Points: []PricePoint{
+				makePoint(base, math.SmallestNonzeroFloat64),
+				makePoint(base.Add(30*time.Minute), math.MaxFloat64),
+			},
+		},
+	}
+
+	tb := computeTemporalBiases(history)
+
+	for i := 0; i < 24; i++ {
+		if math.IsNaN(tb.HourlyBias[i]) || math.IsInf(tb.HourlyBias[i], 0) {
+			t.Errorf("HourlyBias[%d] is NaN/Inf", i)
+		}
+		if math.IsNaN(tb.HourlyVolatility[i]) || math.IsInf(tb.HourlyVolatility[i], 0) {
+			t.Errorf("HourlyVolatility[%d] is NaN/Inf", i)
+		}
+		if math.IsNaN(tb.HourlyActivity[i]) || math.IsInf(tb.HourlyActivity[i], 0) {
+			t.Errorf("HourlyActivity[%d] is NaN/Inf", i)
+		}
+	}
+	for i := 0; i < 7; i++ {
+		if math.IsNaN(tb.WeekdayBias[i]) || math.IsInf(tb.WeekdayBias[i], 0) {
+			t.Errorf("WeekdayBias[%d] is NaN/Inf", i)
+		}
+		if math.IsNaN(tb.WeekdayVolatility[i]) || math.IsInf(tb.WeekdayVolatility[i], 0) {
+			t.Errorf("WeekdayVolatility[%d] is NaN/Inf", i)
+		}
+		if math.IsNaN(tb.WeekdayActivity[i]) || math.IsInf(tb.WeekdayActivity[i], 0) {
+			t.Errorf("WeekdayActivity[%d] is NaN/Inf", i)
+		}
+	}
+}

--- a/internal/lab/v2types.go
+++ b/internal/lab/v2types.go
@@ -1,6 +1,9 @@
 package lab
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // MarketContext holds pre-computed market-wide statistics for a single snapshot.
 type MarketContext struct {
@@ -20,6 +23,31 @@ type MarketContext struct {
 	WeekdayBias        []float64 // 7 entries, Sun=0..Sat=6 (matches time.Weekday)
 	WeekdayVolatility  []float64 // 7 entries — σ of price changes per weekday
 	WeekdayActivity    []float64 // 7 entries — ratio of moving gems per weekday (0.0-1.0)
+}
+
+// ValidateTemporalSlices checks that all temporal slices have the expected lengths:
+// 24 for hourly fields and 7 for weekday fields. Returns an error describing the
+// first violation found, or nil when all lengths are correct.
+func (mc MarketContext) ValidateTemporalSlices() error {
+	if len(mc.HourlyBias) != 24 {
+		return fmt.Errorf("MarketContext: HourlyBias has %d elements, want 24", len(mc.HourlyBias))
+	}
+	if len(mc.HourlyVolatility) != 24 {
+		return fmt.Errorf("MarketContext: HourlyVolatility has %d elements, want 24", len(mc.HourlyVolatility))
+	}
+	if len(mc.HourlyActivity) != 24 {
+		return fmt.Errorf("MarketContext: HourlyActivity has %d elements, want 24", len(mc.HourlyActivity))
+	}
+	if len(mc.WeekdayBias) != 7 {
+		return fmt.Errorf("MarketContext: WeekdayBias has %d elements, want 7", len(mc.WeekdayBias))
+	}
+	if len(mc.WeekdayVolatility) != 7 {
+		return fmt.Errorf("MarketContext: WeekdayVolatility has %d elements, want 7", len(mc.WeekdayVolatility))
+	}
+	if len(mc.WeekdayActivity) != 7 {
+		return fmt.Errorf("MarketContext: WeekdayActivity has %d elements, want 7", len(mc.WeekdayActivity))
+	}
+	return nil
 }
 
 // PriceP50 returns the P50 price percentile, or 0 if not available.

--- a/internal/lab/v2types.go
+++ b/internal/lab/v2types.go
@@ -15,7 +15,11 @@ type MarketContext struct {
 	TotalListings      int
 	TierBoundaries     TierBoundaries
 	HourlyBias         []float64 // 24 entries, one per UTC hour
+	HourlyVolatility   []float64 // 24 entries — σ of price changes per hour
+	HourlyActivity     []float64 // 24 entries — ratio of moving gems per hour (0.0-1.0)
 	WeekdayBias        []float64 // 7 entries, Sun=0..Sat=6 (matches time.Weekday)
+	WeekdayVolatility  []float64 // 7 entries — σ of price changes per weekday
+	WeekdayActivity    []float64 // 7 entries — ratio of moving gems per weekday (0.0-1.0)
 }
 
 // PriceP50 returns the P50 price percentile, or 0 if not available.

--- a/internal/server/handlers/analysis.go
+++ b/internal/server/handlers/analysis.go
@@ -774,6 +774,33 @@ func MarketContextAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerF
 			WeekdayActivity    []float64          `json:"weekdayActivity"`
 		}
 
+		// Nil-coalesce temporal slices so JSON encodes [] instead of null,
+		// preventing frontend TypeError when iterating these fields.
+		hourlyBias := mc.HourlyBias
+		if hourlyBias == nil {
+			hourlyBias = make([]float64, 24)
+		}
+		hourlyVol := mc.HourlyVolatility
+		if hourlyVol == nil {
+			hourlyVol = make([]float64, 24)
+		}
+		hourlyAct := mc.HourlyActivity
+		if hourlyAct == nil {
+			hourlyAct = make([]float64, 24)
+		}
+		weekdayBias := mc.WeekdayBias
+		if weekdayBias == nil {
+			weekdayBias = make([]float64, 7)
+		}
+		weekdayVol := mc.WeekdayVolatility
+		if weekdayVol == nil {
+			weekdayVol = make([]float64, 7)
+		}
+		weekdayAct := mc.WeekdayActivity
+		if weekdayAct == nil {
+			weekdayAct = make([]float64, 7)
+		}
+
 		if err := json.NewEncoder(w).Encode(map[string]any{
 			"data": resp{
 				Time:               mc.Time.UTC().Format(time.RFC3339),
@@ -786,12 +813,12 @@ func MarketContextAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerF
 				TotalGems:          mc.TotalGems,
 				TotalListings:      mc.TotalListings,
 				TierBoundaries:     mc.TierBoundaries,
-				HourlyBias:         mc.HourlyBias,
-				HourlyVolatility:   mc.HourlyVolatility,
-				HourlyActivity:     mc.HourlyActivity,
-				WeekdayBias:        mc.WeekdayBias,
-				WeekdayVolatility:  mc.WeekdayVolatility,
-				WeekdayActivity:    mc.WeekdayActivity,
+				HourlyBias:         hourlyBias,
+				HourlyVolatility:   hourlyVol,
+				HourlyActivity:     hourlyAct,
+				WeekdayBias:        weekdayBias,
+				WeekdayVolatility:  weekdayVol,
+				WeekdayActivity:    weekdayAct,
 			},
 		}); err != nil {
 			slog.Error("market context: encode response", "error", err)

--- a/internal/server/handlers/analysis.go
+++ b/internal/server/handlers/analysis.go
@@ -767,7 +767,11 @@ func MarketContextAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerF
 			TotalListings      int                `json:"totalListings"`
 			TierBoundaries     lab.TierBoundaries `json:"tierBoundaries"`
 			HourlyBias         []float64          `json:"hourlyBias"`
+			HourlyVolatility   []float64          `json:"hourlyVolatility"`
+			HourlyActivity     []float64          `json:"hourlyActivity"`
 			WeekdayBias        []float64          `json:"weekdayBias"`
+			WeekdayVolatility  []float64          `json:"weekdayVolatility"`
+			WeekdayActivity    []float64          `json:"weekdayActivity"`
 		}
 
 		if err := json.NewEncoder(w).Encode(map[string]any{
@@ -783,7 +787,11 @@ func MarketContextAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerF
 				TotalListings:      mc.TotalListings,
 				TierBoundaries:     mc.TierBoundaries,
 				HourlyBias:         mc.HourlyBias,
+				HourlyVolatility:   mc.HourlyVolatility,
+				HourlyActivity:     mc.HourlyActivity,
 				WeekdayBias:        mc.WeekdayBias,
+				WeekdayVolatility:  mc.WeekdayVolatility,
+				WeekdayActivity:    mc.WeekdayActivity,
 			},
 		}); err != nil {
 			slog.Error("market context: encode response", "error", err)


### PR DESCRIPTION
## Summary
- Add migration: 4 new JSONB columns (hourly_volatility, hourly_activity, weekday_volatility, weekday_activity)
- Add 4 new fields to MarketContext struct + repository Save/Latest
- Implement computeTemporalBiases() — direction/volatility/activity for 24 hours + 7 weekdays
- Replace neutral 1.0 stubs in ComputeMarketContext with real temporal computation
- 11 dedicated temporal bias tests + updated market context tests

## Tracker
https://softsolution.youtrack.cloud/issue/POE-60

## Test Plan
- [x] All 364 tests pass (go test ./...)
- [x] Temporal bias unit tests (known hours/weekdays, empty history, edge cases)
- [x] Market context integration tests updated

Generated with [Claude Code](https://claude.com/claude-code)