### PR TITLE
POE-47: Optimizer v2 — σ-multiplier sweep with confidence scoring

### DIFF
--- a/cmd/optimize/main.go
+++ b/cmd/optimize/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"math"
 	"os"
 	"strings"
 	"time"
@@ -250,6 +249,7 @@ func printJSON(results []lab.SweepResultV2, mc *lab.MarketContext, evalCount, dr
 			Hours:           hours,
 			Horizon:         horizon,
 		},
+		Results: make([]JSONResult, 0, len(results)),
 	}
 
 	for i, r := range results {
@@ -294,21 +294,16 @@ func printJSON(results []lab.SweepResultV2, mc *lab.MarketContext, evalCount, dr
 
 // approxSigmaEquivalents computes approximate sigma multipliers for the current
 // default absolute thresholds by dividing by the market context's sigma values.
+// Returns 0 for any field where the corresponding sigma is zero (avoids NaN in JSON output).
 // This is a simple division for reference, not an exact inversion.
 func approxSigmaEquivalents(def lab.SignalConfig, mc *lab.MarketContext) (herdP, herdL, stableP, brewP float64) {
 	if mc.VelocitySigma > 0 {
 		herdP = (def.PreHERDPriceVel - mc.VelocityMean) / mc.VelocitySigma
 		stableP = def.StablePriceVel / mc.VelocitySigma
 		brewP = def.BrewingMinPVel / mc.VelocitySigma
-	} else {
-		herdP = math.NaN()
-		stableP = math.NaN()
-		brewP = math.NaN()
 	}
 	if mc.ListingVelSigma > 0 {
 		herdL = (def.PreHERDListingVel - mc.ListingVelMean) / mc.ListingVelSigma
-	} else {
-		herdL = math.NaN()
 	}
 	return
 }

--- a/cmd/optimize/main.go
+++ b/cmd/optimize/main.go
@@ -2,61 +2,81 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"math"
 	"os"
-	"sort"
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"profitofexile/internal/db"
 	"profitofexile/internal/lab"
 )
 
-// Snapshot represents a single gem observation at a point in time.
-type Snapshot struct {
-	Time           time.Time
-	Name           string
-	Variant        string
-	Chaos          float64
-	Listings       int
-	IsTransfigured bool
-	GemColor       string
+// JSONOutput is the structured output for --json mode.
+type JSONOutput struct {
+	Context    JSONContext        `json:"context"`
+	Results    []JSONResult       `json:"results"`
+	BestDetail *JSONBestDetail   `json:"best_detail,omitempty"`
+	Defaults   *JSONDefaults      `json:"defaults,omitempty"`
 }
 
-// gemKey uniquely identifies a gem across snapshots.
-type gemKey struct {
-	Name    string
-	Variant string
+// JSONContext holds metadata about the optimization run.
+type JSONContext struct {
+	MarketTime      time.Time `json:"market_time"`
+	TotalGems       int       `json:"total_gems"`
+	VelocityMean    float64   `json:"velocity_mean"`
+	VelocitySigma   float64   `json:"velocity_sigma"`
+	ListingVelMean  float64   `json:"listing_vel_mean"`
+	ListingVelSigma float64   `json:"listing_vel_sigma"`
+	EvalPoints      int       `json:"eval_points"`
+	DroppedPoints   int       `json:"dropped_points"`
+	GridSize        int       `json:"grid_size"`
+	Hours           int       `json:"hours"`
+	Horizon         string    `json:"horizon"`
 }
 
-// precomputed holds config-independent features for one (gem, time) evaluation point.
-type precomputed struct {
-	gem        gemKey
-	chaos      float64
-	listings   int
-	priceVel   float64
-	listingVel float64
-	cv         float64
-	futurePct  float64 // actual price change % (4 snapshots ahead)
+// JSONResult holds one sweep result row.
+type JSONResult struct {
+	Rank          int                `json:"rank"`
+	WeightedScore float64           `json:"weighted_score"`
+	TopAcc        float64           `json:"top_acc"`
+	HighAcc       float64           `json:"high_acc"`
+	MidAcc        float64           `json:"mid_acc"`
+	LowAcc        float64           `json:"low_acc"`
+	OverallAcc    float64           `json:"overall_acc"`
+	SweetSpot     int               `json:"sweet_spot"`
+	Sigma         lab.SigmaConfig   `json:"sigma"`
+	TemporalAcc   map[string]float64 `json:"temporal_acc,omitempty"`
 }
 
-// SweepResult holds the accuracy metrics for one parameter combination.
-type SweepResult struct {
-	Config     lab.SignalConfig
-	OverallAcc float64
-	TopAcc     float64
-	HighAcc    float64
-	MidAcc     float64
-	LowAcc     float64
-	Top15Acc   float64
+// JSONBestDetail holds extended info about the best result.
+type JSONBestDetail struct {
+	ConfBands   []lab.ConfidenceBand `json:"confidence_bands"`
+	TemporalAcc map[string]float64   `json:"temporal_acc"`
+}
+
+// JSONDefaults holds the approximate sigma equivalents of current defaults.
+type JSONDefaults struct {
+	ApproxHERDPriceMult    float64 `json:"approx_herd_price_mult"`
+	ApproxHERDListingMult  float64 `json:"approx_herd_listing_mult"`
+	ApproxStablePriceMult  float64 `json:"approx_stable_price_mult"`
+	ApproxBrewingPriceMult float64 `json:"approx_brewing_price_mult"`
 }
 
 func main() {
-	topN := flag.Int("top", 15, "Show top N parameter combos")
+	topN := flag.Int("top", 15, "Show top N results")
+	hours := flag.Int("hours", 168, "Backtest time range in hours")
+	horizon := flag.String("horizon", "2h", "Ground truth forward horizon (e.g. 2h, 90m)")
+	jsonMode := flag.Bool("json", false, "Output JSON instead of console table")
 	flag.Parse()
+
+	horizonDur, err := time.ParseDuration(*horizon)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid horizon %q: %v\n", *horizon, err)
+		os.Exit(1)
+	}
 
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
@@ -71,420 +91,224 @@ func main() {
 	}
 	defer pool.Close()
 
-	fmt.Fprintln(os.Stderr, "Loading snapshots from database...")
-	t0 := time.Now()
-	snapshots := loadFromDB(ctx, pool)
-	fmt.Fprintf(os.Stderr, "Loaded %d snapshots in %s\n", len(snapshots), time.Since(t0).Round(time.Millisecond))
+	repo := lab.NewRepository(pool)
 
-	if len(snapshots) == 0 {
-		fmt.Fprintln(os.Stderr, "No snapshots found")
+	// Load market context.
+	fmt.Fprintln(os.Stderr, "Loading market context...")
+	mc, err := repo.LatestMarketContext(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load market context: %v\n", err)
+		os.Exit(1)
+	}
+	if mc == nil {
+		fmt.Fprintln(os.Stderr, "No market context found — run the analyzer pipeline first")
 		os.Exit(1)
 	}
 
-	fmt.Fprintln(os.Stderr, "Pre-computing features (velocities, CVs, future outcomes)...")
+	// Load gem features.
+	fmt.Fprintf(os.Stderr, "Loading gem features (%dh range)...\n", *hours)
+	t0 := time.Now()
+	features, err := repo.AllGemFeaturesInRange(ctx, *hours)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load gem features: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "Loaded %d features in %s\n", len(features), time.Since(t0).Round(time.Millisecond))
+
+	// Load snapshot prices for ground truth.
+	fmt.Fprintf(os.Stderr, "Loading snapshot prices (%dh range)...\n", *hours)
 	t1 := time.Now()
-	features, lastGems, marketCtx := precomputeFeatures(snapshots)
-	fmt.Fprintf(os.Stderr, "Pre-computed %d evaluation points in %s\n", len(features), time.Since(t1).Round(time.Millisecond))
-	fmt.Fprintf(os.Stderr, "Market context: %d gems, vel_mean=%.2f vel_sigma=%.2f\n",
-		marketCtx.TotalGems, marketCtx.VelocityMean, marketCtx.VelocitySigma)
+	prices, err := repo.SnapshotPricesInRange(ctx, *hours)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to load snapshot prices: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "Loaded %d prices in %s\n", len(prices), time.Since(t1).Round(time.Millisecond))
 
-	grid := generateGrid()
-	fmt.Fprintf(os.Stderr, "Sweeping %d parameter combos...\n", len(grid))
+	// Build evaluation points.
+	fmt.Fprintf(os.Stderr, "Building eval points (horizon=%s)...\n", horizonDur)
+	evals, dropped := lab.BuildEvalPoints(features, prices, horizonDur)
+	fmt.Fprintf(os.Stderr, "Built %d eval points, dropped %d (no valid future price)\n", len(evals), dropped)
 
+	if len(evals) < 1000 {
+		fmt.Fprintf(os.Stderr, "WARNING: Only %d eval points — results may be unreliable (recommend >= 1000)\n", len(evals))
+	}
+
+	if len(evals) == 0 {
+		fmt.Fprintln(os.Stderr, "No eval points — cannot sweep. Check time range and data freshness.")
+		os.Exit(1)
+	}
+
+	// Generate grid and sweep.
+	grid := lab.GenerateSigmaGrid()
+	fmt.Fprintf(os.Stderr, "Sweeping %d sigma combos over %d eval points...\n", len(grid), len(evals))
 	t2 := time.Now()
-	results := sweep(features, lastGems, grid)
+	results := lab.SweepV2(evals, *mc, grid)
 	fmt.Fprintf(os.Stderr, "Sweep complete in %s\n", time.Since(t2).Round(time.Millisecond))
-
-	// Sort by top-15 accuracy descending.
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Top15Acc > results[j].Top15Acc
-	})
 
 	n := *topN
 	if n > len(results) {
 		n = len(results)
 	}
 
-	fmt.Printf("\n%-6s %-8s %-8s %-8s %-8s %-8s %-6s %-6s %-6s %-6s\n",
-		"Rank", "Top15%", "TOP%", "High%", "MID%", "Overall%", "H_pv", "H_lv", "S_pv", "B_pv")
-	fmt.Println("------ -------- -------- -------- -------- -------- ------ ------ ------ ------")
-	for i, r := range results[:n] {
-		fmt.Printf("%-6d %-8.1f %-8.1f %-8.1f %-8.1f %-8.1f %-6.1f %-6.1f %-6.1f %-6.1f\n",
-			i+1, r.Top15Acc, r.TopAcc, r.HighAcc, r.MidAcc, r.OverallAcc,
-			r.Config.PreHERDPriceVel, r.Config.PreHERDListingVel,
-			r.Config.StablePriceVel, r.Config.BrewingMinPVel)
+	if *jsonMode {
+		printJSON(results[:n], mc, len(evals), dropped, len(grid), *hours, *horizon)
+	} else {
+		printConsole(results[:n], mc, len(evals), dropped, len(grid), *hours, *horizon)
+	}
+}
+
+// printConsole outputs the multi-section human-readable report.
+func printConsole(results []lab.SweepResultV2, mc *lab.MarketContext, evalCount, droppedCount, gridSize, hours int, horizon string) {
+	// Section 1: Context
+	fmt.Println()
+	fmt.Println("=== OPTIMIZER v2 CONTEXT ===")
+	fmt.Printf("  Market time:       %s\n", mc.Time.Format(time.RFC3339))
+	fmt.Printf("  Total gems:        %d\n", mc.TotalGems)
+	fmt.Printf("  Velocity:          mean=%.2f sigma=%.2f\n", mc.VelocityMean, mc.VelocitySigma)
+	fmt.Printf("  Listing velocity:  mean=%.2f sigma=%.2f\n", mc.ListingVelMean, mc.ListingVelSigma)
+	fmt.Printf("  Eval points:       %d (dropped %d)\n", evalCount, droppedCount)
+	fmt.Printf("  Grid size:         %d combos\n", gridSize)
+	fmt.Printf("  Time range:        %dh, horizon=%s\n", hours, horizon)
+	fmt.Println()
+
+	// Section 2: Top N table
+	fmt.Println("=== TOP RESULTS (sorted by weighted score) ===")
+	fmt.Println()
+	fmt.Printf("%-5s %-9s %-7s %-7s %-7s %-7s %-9s %-6s  %-7s %-7s %-7s %-7s %-7s\n",
+		"Rank", "WtScore", "TOP%", "HIGH%", "MID%", "LOW%", "Overall%", "Sweet",
+		"HP_m", "HL_m", "SP_m", "BP_m", "DP_m")
+	fmt.Println(strings.Repeat("-", 105))
+
+	for i, r := range results {
+		sweetStr := fmt.Sprintf("%d", r.SweetSpot)
+		if r.SweetSpot < 0 {
+			sweetStr = "  -"
+		}
+		fmt.Printf("%-5d %-9.1f %-7.1f %-7.1f %-7.1f %-7.1f %-9.1f %-6s  %-7.2f %-7.2f %-7.2f %-7.2f %-7.2f\n",
+			i+1, r.WeightedScore, r.TopAcc, r.HighAcc, r.MidAcc, r.LowAcc, r.OverallAcc, sweetStr,
+			r.Sigma.HERDPriceMult, r.Sigma.HERDListingMult,
+			r.Sigma.StablePriceMult, r.Sigma.BrewingPriceMult, r.Sigma.DumpPriceMult)
 	}
 
-	// Print current defaults for comparison.
+	// Section 3: Best result confidence breakdown
+	if len(results) > 0 {
+		best := results[0]
+		fmt.Println()
+		fmt.Println("=== BEST RESULT — CONFIDENCE BANDS ===")
+		fmt.Printf("  Config: HP_m=%.2f  HL_m=%.2f  SP_m=%.2f  BP_m=%.2f  DP_m=%.2f\n",
+			best.Sigma.HERDPriceMult, best.Sigma.HERDListingMult,
+			best.Sigma.StablePriceMult, best.Sigma.BrewingPriceMult, best.Sigma.DumpPriceMult)
+		fmt.Printf("  Total evals: %d  High-conf evals (>=70): %d\n", best.TotalEvals, best.HighConfEvals)
+		fmt.Println()
+		fmt.Printf("  %-12s %-10s %-8s\n", "Conf Range", "Accuracy", "Count")
+		fmt.Printf("  %s\n", strings.Repeat("-", 32))
+		for _, b := range best.ConfBands {
+			fmt.Printf("  %-12s %-10.1f %-8d\n",
+				fmt.Sprintf("%d-%d", b.MinConf, b.MaxConf), b.Accuracy, b.Count)
+		}
+
+		// Section 4: Best result temporal accuracy
+		fmt.Println()
+		fmt.Println("=== BEST RESULT — TEMPORAL ACCURACY ===")
+		phases := []string{"weekday-peak", "weekday-offpeak", "weekend"}
+		for _, phase := range phases {
+			acc, ok := best.TemporalAcc[phase]
+			if ok {
+				fmt.Printf("  %-20s %.1f%%\n", phase, acc)
+			} else {
+				fmt.Printf("  %-20s (no data)\n", phase)
+			}
+		}
+	}
+
+	// Section 5: Current defaults comparison
+	fmt.Println()
+	fmt.Println("=== CURRENT DEFAULTS (approximate sigma equivalents) ===")
 	def := lab.DefaultSignalConfig()
-	fmt.Printf("\nCurrent defaults: H_pv=%.0f H_lv=%.0f S_pv=%.1f B_pv=%.1f\n",
-		def.PreHERDPriceVel, def.PreHERDListingVel,
-		def.StablePriceVel, def.BrewingMinPVel)
+	approxHP, approxHL, approxSP, approxBP := approxSigmaEquivalents(def, mc)
+	fmt.Printf("  PreHERDPriceVel=%.0f   -> approx HP_m=%.2f\n", def.PreHERDPriceVel, approxHP)
+	fmt.Printf("  PreHERDListingVel=%.0f  -> approx HL_m=%.2f\n", def.PreHERDListingVel, approxHL)
+	fmt.Printf("  StablePriceVel=%.1f     -> approx SP_m=%.2f\n", def.StablePriceVel, approxSP)
+	fmt.Printf("  BrewingMinPVel=%.1f     -> approx BP_m=%.2f\n", def.BrewingMinPVel, approxBP)
+	fmt.Println()
 }
 
-// loadFromDB fetches all gem snapshots ordered by time.
-func loadFromDB(ctx context.Context, pool *pgxpool.Pool) []Snapshot {
-	q := `SELECT time, name, variant, chaos, listings, is_transfigured, gem_color
-	      FROM gem_snapshots ORDER BY time`
-
-	rows, err := pool.Query(ctx, q)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Query failed: %v\n", err)
-		return nil
-	}
-	defer rows.Close()
-
-	var out []Snapshot
-	for rows.Next() {
-		var s Snapshot
-		var gemColor *string
-		if err := rows.Scan(&s.Time, &s.Name, &s.Variant, &s.Chaos, &s.Listings, &s.IsTransfigured, &gemColor); err != nil {
-			fmt.Fprintf(os.Stderr, "Scan error: %v\n", err)
-			continue
-		}
-		if gemColor != nil {
-			s.GemColor = *gemColor
-		}
-		out = append(out, s)
-	}
-	if err := rows.Err(); err != nil {
-		fmt.Fprintf(os.Stderr, "Rows error: %v\n", err)
-	}
-	return out
-}
-
-// precomputeFeatures builds all config-independent evaluation points in one pass.
-// Returns the feature slice, the last snapshot's gem prices (for tier computation),
-// and a MarketContext computed from the last snapshot.
-func precomputeFeatures(snapshots []Snapshot) ([]precomputed, []lab.GemPrice, *lab.MarketContext) {
-	// Group snapshots by time.
-	timeMap := make(map[time.Time]map[gemKey]Snapshot)
-	var times []time.Time
-
-	for _, s := range snapshots {
-		t := s.Time.Truncate(time.Minute)
-		if _, ok := timeMap[t]; !ok {
-			timeMap[t] = make(map[gemKey]Snapshot)
-			times = append(times, t)
-		}
-		timeMap[t][gemKey{s.Name, s.Variant}] = s
-	}
-	sort.Slice(times, func(i, j int) bool { return times[i].Before(times[j]) })
-
-	// Build last snapshot gem prices for tier computation.
-	var lastGems []lab.GemPrice
-	if len(times) > 0 {
-		for _, s := range timeMap[times[len(times)-1]] {
-			lastGems = append(lastGems, lab.GemPrice{
-				Name:           s.Name,
-				Variant:        s.Variant,
-				Chaos:          s.Chaos,
-				Listings:       s.Listings,
-				IsTransfigured: s.IsTransfigured,
-				GemColor:       s.GemColor,
-			})
-		}
+// printJSON outputs the structured JSON report.
+func printJSON(results []lab.SweepResultV2, mc *lab.MarketContext, evalCount, droppedCount, gridSize, hours int, horizon string) {
+	out := JSONOutput{
+		Context: JSONContext{
+			MarketTime:      mc.Time,
+			TotalGems:       mc.TotalGems,
+			VelocityMean:    mc.VelocityMean,
+			VelocitySigma:   mc.VelocitySigma,
+			ListingVelMean:  mc.ListingVelMean,
+			ListingVelSigma: mc.ListingVelSigma,
+			EvalPoints:      evalCount,
+			DroppedPoints:   droppedCount,
+			GridSize:        gridSize,
+			Hours:           hours,
+			Horizon:         horizon,
+		},
 	}
 
-	// Rolling history per gem.
-	type histEntry struct {
-		points []lab.PricePoint
-	}
-	gemHist := make(map[gemKey]*histEntry)
-
-	var features []precomputed
-
-	for ti, t := range times {
-		gems := timeMap[t]
-
-		// Update history.
-		for gk, s := range gems {
-			h, ok := gemHist[gk]
-			if !ok {
-				h = &histEntry{}
-				gemHist[gk] = h
-			}
-			h.points = append(h.points, lab.PricePoint{
-				Time:     s.Time,
-				Chaos:    s.Chaos,
-				Listings: s.Listings,
-			})
-			if len(h.points) > 8 {
-				h.points = h.points[len(h.points)-8:]
-			}
-		}
-
-		// Need history and future.
-		if ti < 1 || ti+4 >= len(times) {
-			continue
-		}
-
-		futureGems := timeMap[times[ti+4]]
-
-		for gk, s := range gems {
-			if !s.IsTransfigured || s.Chaos <= 5 {
-				continue
-			}
-
-			h := gemHist[gk]
-			if h == nil || len(h.points) < 2 {
-				continue
-			}
-
-			futureSnap, ok := futureGems[gk]
-			if !ok {
-				continue
-			}
-
-			priceVel := lab.VelocityWindow(h.points, 2*time.Hour, func(p lab.PricePoint) float64 { return p.Chaos })
-			listingVel := lab.VelocityWindow(h.points, 2*time.Hour, func(p lab.PricePoint) float64 { return float64(p.Listings) })
-			cv := cvFromPoints(h.points)
-
-			var futurePct float64
-			if s.Chaos > 0 {
-				futurePct = (futureSnap.Chaos - s.Chaos) / s.Chaos * 100
-			}
-
-			features = append(features, precomputed{
-				gem:        gk,
-				chaos:      s.Chaos,
-				listings:   s.Listings,
-				priceVel:   priceVel,
-				listingVel: listingVel,
-				cv:         cv,
-				futurePct:  futurePct,
-			})
-		}
-	}
-
-	// Build a set of transfigured gem keys from the last snapshot so that
-	// histSlice only includes history for the active population (matching the
-	// analyzer's GemPriceHistoryByVariant which filters to transfigured,
-	// non-corrupted, non-Trarthus gems with chaos > 5).
-	transfiguredKeys := make(map[gemKey]bool)
-	if len(times) > 0 {
-		for _, s := range timeMap[times[len(times)-1]] {
-			if s.IsTransfigured && !strings.Contains(s.Name, "Trarthus") {
-				transfiguredKeys[gemKey{s.Name, s.Variant}] = true
-			}
-		}
-	}
-
-	var histSlice []lab.GemPriceHistory
-	for gk, h := range gemHist {
-		if len(h.points) < 2 {
-			continue
-		}
-		if !transfiguredKeys[gk] {
-			continue
-		}
-		histSlice = append(histSlice, lab.GemPriceHistory{
-			Name:    gk.Name,
-			Variant: gk.Variant,
-			Points:  h.points,
+	for i, r := range results {
+		out.Results = append(out.Results, JSONResult{
+			Rank:          i + 1,
+			WeightedScore: r.WeightedScore,
+			TopAcc:        r.TopAcc,
+			HighAcc:       r.HighAcc,
+			MidAcc:        r.MidAcc,
+			LowAcc:        r.LowAcc,
+			OverallAcc:    r.OverallAcc,
+			SweetSpot:     r.SweetSpot,
+			Sigma:         r.Sigma,
+			TemporalAcc:   r.TemporalAcc,
 		})
 	}
 
-	// Compute market context from the last snapshot's gems and accumulated history.
-	var snapTime time.Time
-	if len(times) > 0 {
-		snapTime = times[len(times)-1]
-	}
-	mc := lab.ComputeMarketContext(snapTime, lastGems, histSlice)
-
-	return features, lastGems, &mc
-}
-
-// sweep evaluates every config against pre-computed features.
-func sweep(features []precomputed, lastGems []lab.GemPrice, grid []lab.SignalConfig) []SweepResult {
-	// Pre-compute gem average ROIs for top-15 set (config-independent).
-	gemROIs := make(map[gemKey]struct{ sum float64; count int })
-	for _, f := range features {
-		entry := gemROIs[f.gem]
-		entry.sum += f.futurePct
-		entry.count++
-		gemROIs[f.gem] = entry
-	}
-
-	type gemAvgROI struct {
-		key gemKey
-		avg float64
-	}
-	var sorted []gemAvgROI
-	for gk, entry := range gemROIs {
-		sorted = append(sorted, gemAvgROI{gk, entry.sum / float64(entry.count)})
-	}
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i].avg > sorted[j].avg })
-
-	top15Count := 15
-	if top15Count > len(sorted) {
-		top15Count = len(sorted)
-	}
-	top15Set := make(map[gemKey]bool, top15Count)
-	for _, g := range sorted[:top15Count] {
-		top15Set[g.key] = true
-	}
-
-	// Tier boundaries are data-derived (not config parameters), compute once.
-	tb := lab.DetectTierBoundaries(lastGems)
-
-	results := make([]SweepResult, len(grid))
-
-	for i, cfg := range grid {
-		if i%100 == 0 {
-			fmt.Fprintf(os.Stderr, "  Progress: %d/%d\n", i, len(grid))
-		}
-
-		var totalCorrect, totalCount int
-		var topCorrect, topCount int
-		var highCorrect, highCount int
-		var midCorrect, midCount int
-		var lowCorrect, lowCount int
-		var top15Correct, top15Total int
-
-		for _, f := range features {
-			signal := lab.ClassifySignalWithConfig(f.priceVel, f.listingVel, f.cv, f.listings, cfg)
-			predicted := predictedDirection(signal)
-			actual := directionFromChange(f.futurePct)
-			correct := predicted == actual
-
-			tier := lab.ClassifyTier(f.chaos, tb)
-
-			totalCount++
-			if correct {
-				totalCorrect++
-			}
-
-			switch tier {
-			case "TOP":
-				topCount++
-				if correct {
-					topCorrect++
-				}
-			case "HIGH":
-				highCount++
-				if correct {
-					highCorrect++
-				}
-			case "MID":
-				midCount++
-				if correct {
-					midCorrect++
-				}
-			case "LOW":
-				lowCount++
-				if correct {
-					lowCorrect++
-				}
-			}
-
-			if top15Set[f.gem] {
-				top15Total++
-				if correct {
-					top15Correct++
-				}
-			}
-		}
-
-		results[i] = SweepResult{
-			Config:     cfg,
-			OverallAcc: pct(totalCorrect, totalCount),
-			TopAcc:     pct(topCorrect, topCount),
-			HighAcc:    pct(highCorrect, highCount),
-			MidAcc:     pct(midCorrect, midCount),
-			LowAcc:     pct(lowCorrect, lowCount),
-			Top15Acc:   pct(top15Correct, top15Total),
+	if len(results) > 0 {
+		best := results[0]
+		out.BestDetail = &JSONBestDetail{
+			ConfBands:   best.ConfBands,
+			TemporalAcc: best.TemporalAcc,
 		}
 	}
 
-	return results
-}
+	def := lab.DefaultSignalConfig()
+	approxHP, approxHL, approxSP, approxBP := approxSigmaEquivalents(def, mc)
+	out.Defaults = &JSONDefaults{
+		ApproxHERDPriceMult:    approxHP,
+		ApproxHERDListingMult:  approxHL,
+		ApproxStablePriceMult:  approxSP,
+		ApproxBrewingPriceMult: approxBP,
+	}
 
-// generateGrid produces a focused parameter grid for sweeping.
-// Tier boundaries are now data-derived (not parameters), so the grid
-// sweeps only signal thresholds: 5x4x4x4 = 320 combos.
-func generateGrid() []lab.SignalConfig {
-	base := lab.DefaultSignalConfig()
-	var grid []lab.SignalConfig
-
-	for _, herdPV := range []float64{20, 25, 30, 35, 40} {
-		for _, herdLV := range []float64{2, 3, 5, 7} {
-			for _, stablePV := range []float64{1.0, 1.5, 2.0, 2.5} {
-				for _, brewPV := range []float64{1, 2, 3, 5} {
-					cfg := base
-					cfg.PreHERDPriceVel = herdPV
-					cfg.PreHERDListingVel = herdLV
-					cfg.StablePriceVel = stablePV
-					cfg.BrewingMinPVel = brewPV
-					grid = append(grid, cfg)
-				}
-			}
-		}
-	}
-	return grid // 5x4x4x4 = 320 combos
-}
-
-// velocityFromPoints removed — now uses lab.VelocityWindow directly.
-
-// cvFromPoints computes coefficient of variation from price history.
-func cvFromPoints(points []lab.PricePoint) float64 {
-	if len(points) < 2 {
-		return 0
-	}
-	prices := make([]float64, len(points))
-	for i, p := range points {
-		prices[i] = p.Chaos
-	}
-	var sum float64
-	for _, p := range prices {
-		sum += p
-	}
-	mean := sum / float64(len(prices))
-	if mean == 0 {
-		return 0
-	}
-	var variance float64
-	for _, p := range prices {
-		d := p - mean
-		variance += d * d
-	}
-	variance /= float64(len(prices))
-	cv := (math.Sqrt(variance) / math.Abs(mean)) * 100
-	if math.IsNaN(cv) || math.IsInf(cv, 0) {
-		return 0
-	}
-	return cv
-}
-
-// directionFromChange maps a price change % into UP, DOWN, or FLAT.
-func directionFromChange(pctChange float64) string {
-	if pctChange > 2 {
-		return "UP"
-	}
-	if pctChange < -2 {
-		return "DOWN"
-	}
-	return "FLAT"
-}
-
-// predictedDirection maps a signal to an expected price direction.
-func predictedDirection(signal string) string {
-	switch signal {
-	case "HERD", "RISING", "RECOVERY":
-		return "UP"
-	case "DUMPING", "FALLING", "TRAP":
-		return "DOWN"
-	case "STABLE":
-		return "FLAT"
-	default:
-		return "FLAT"
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		fmt.Fprintf(os.Stderr, "JSON encode error: %v\n", err)
+		os.Exit(1)
 	}
 }
 
-// pct returns a percentage, handling division by zero.
-func pct(correct, total int) float64 {
-	if total == 0 {
-		return 0
+// approxSigmaEquivalents computes approximate sigma multipliers for the current
+// default absolute thresholds by dividing by the market context's sigma values.
+// This is a simple division for reference, not an exact inversion.
+func approxSigmaEquivalents(def lab.SignalConfig, mc *lab.MarketContext) (herdP, herdL, stableP, brewP float64) {
+	if mc.VelocitySigma > 0 {
+		herdP = (def.PreHERDPriceVel - mc.VelocityMean) / mc.VelocitySigma
+		stableP = def.StablePriceVel / mc.VelocitySigma
+		brewP = def.BrewingMinPVel / mc.VelocitySigma
+	} else {
+		herdP = math.NaN()
+		stableP = math.NaN()
+		brewP = math.NaN()
 	}
-	return float64(correct) / float64(total) * 100
+	if mc.ListingVelSigma > 0 {
+		herdL = (def.PreHERDListingVel - mc.ListingVelMean) / mc.ListingVelSigma
+	} else {
+		herdL = math.NaN()
+	}
+	return
 }

--- a/internal/lab/optimizer.go
+++ b/internal/lab/optimizer.go
@@ -5,6 +5,290 @@ import (
 	"time"
 )
 
+// SweepResultV2 holds the evaluation metrics for a single σ-multiplier configuration.
+type SweepResultV2 struct {
+	Sigma         SigmaConfig
+	WeightedScore float64 // primary sort key — confidence-weighted directional accuracy
+	TopAcc        float64 // TOP tier accuracy %
+	HighAcc       float64 // HIGH tier accuracy %
+	MidAcc        float64 // MID tier accuracy %
+	LowAcc        float64 // LOW tier accuracy %
+	OverallAcc    float64 // all tiers
+	ConfBands     []ConfidenceBand
+	SweetSpot     int                // min confidence for >=80% accuracy, -1 if not found
+	TemporalAcc   map[string]float64 // "weekday-peak", "weekday-offpeak", "weekend"
+	TotalEvals    int
+	HighConfEvals int // evals with confidence >= 70
+}
+
+// ConfidenceBand groups accuracy metrics within a confidence score range.
+type ConfidenceBand struct {
+	MinConf  int
+	MaxConf  int
+	Accuracy float64
+	Count    int
+}
+
+// predictedDirection maps a signal to an expected price direction.
+// HERD/RISING/RECOVERY → UP, DUMPING/FALLING/TRAP → DOWN, STABLE → FLAT.
+func predictedDirection(signal string) string {
+	switch signal {
+	case "HERD", "RISING", "RECOVERY":
+		return "UP"
+	case "DUMPING", "FALLING", "TRAP":
+		return "DOWN"
+	case "STABLE":
+		return "FLAT"
+	default:
+		return "FLAT"
+	}
+}
+
+// directionFromChange maps a price change % into UP, DOWN, or FLAT.
+// >2% → UP, <-2% → DOWN, else → FLAT.
+func directionFromChange(pctChange float64) string {
+	if pctChange > 2 {
+		return "UP"
+	}
+	if pctChange < -2 {
+		return "DOWN"
+	}
+	return "FLAT"
+}
+
+// tierWeight returns the scoring weight for a gem price tier.
+// TOP gems are weighted more heavily because mispredictions on expensive gems
+// carry higher financial risk.
+func tierWeight(tier string) float64 {
+	switch tier {
+	case "TOP":
+		return 2.0
+	case "HIGH":
+		return 1.5
+	case "MID":
+		return 1.0
+	case "LOW":
+		return 0.5
+	default:
+		return 1.0
+	}
+}
+
+// classifyTemporalPhase categorizes a timestamp into a temporal phase for
+// accuracy analysis: "weekend", "weekday-peak" (14-22 UTC), "weekday-offpeak".
+func classifyTemporalPhase(t time.Time) string {
+	weekday := t.UTC().Weekday()
+	if weekday == time.Saturday || weekday == time.Sunday {
+		return "weekend"
+	}
+	hour := t.UTC().Hour()
+	if hour >= 14 && hour < 22 {
+		return "weekday-peak"
+	}
+	return "weekday-offpeak"
+}
+
+// SweepV2 evaluates each σ-multiplier configuration against the eval points,
+// computing confidence-weighted directional accuracy. Results are sorted by
+// WeightedScore descending (best first).
+//
+// For each SigmaConfig, it converts to absolute thresholds via MarketContext,
+// classifies signals, computes confidence, and compares predicted direction
+// against actual price movement. Scoring is weighted by tier importance and
+// confidence level.
+func SweepV2(evals []EvalPoint, mc MarketContext, grid []SigmaConfig) []SweepResultV2 {
+	results := make([]SweepResultV2, 0, len(grid))
+
+	for _, sigma := range grid {
+		cfg := sigma.ToSignalConfig(mc)
+
+		// Per-tier accumulators.
+		type tierAcc struct {
+			correct int
+			total   int
+		}
+		tiers := map[string]*tierAcc{
+			"TOP":  {},
+			"HIGH": {},
+			"MID":  {},
+			"LOW":  {},
+		}
+
+		// Confidence band accumulators (0-9, 10-19, ..., 90-100).
+		type bandAcc struct {
+			correct int
+			total   int
+		}
+		bands := make([]bandAcc, 10) // index 0 = [0,9], ..., 9 = [90,100]
+
+		// Temporal phase accumulators.
+		phases := map[string]*tierAcc{
+			"weekend":         {},
+			"weekday-peak":    {},
+			"weekday-offpeak": {},
+		}
+
+		var weightedCorrect float64
+		var weightedTotal float64
+		var overallCorrect int
+		highConfEvals := 0
+
+		for _, ep := range evals {
+			signal := classifySignalWithConfig(
+				ep.Feature.VelMedPrice,
+				ep.Feature.VelMedListing,
+				ep.Feature.CV,
+				ep.Feature.Listings,
+				cfg,
+			)
+
+			confidence, _ := computeConfidence(signal, ep.Feature, mc, ep.SnapTime)
+
+			predicted := predictedDirection(signal)
+			actual := directionFromChange(ep.FuturePct)
+			correct := predicted == actual
+
+			// Tier-weighted scoring.
+			tw := tierWeight(ep.Feature.Tier)
+			confWeight := float64(confidence) / 100.0
+			weight := tw * confWeight
+			weightedTotal += weight
+			if correct {
+				weightedCorrect += weight
+				overallCorrect++
+			}
+
+			// Per-tier accuracy.
+			tier := ep.Feature.Tier
+			if tier == "" {
+				tier = "LOW"
+			}
+			ta, ok := tiers[tier]
+			if !ok {
+				ta = &tierAcc{}
+				tiers[tier] = ta
+			}
+			ta.total++
+			if correct {
+				ta.correct++
+			}
+
+			// Confidence band accumulation.
+			bandIdx := confidence / 10
+			if bandIdx > 9 {
+				bandIdx = 9
+			}
+			bands[bandIdx].total++
+			if correct {
+				bands[bandIdx].correct++
+			}
+
+			// Temporal phase.
+			phase := classifyTemporalPhase(ep.SnapTime)
+			pa := phases[phase]
+			pa.total++
+			if correct {
+				pa.correct++
+			}
+
+			// High confidence count.
+			if confidence >= 70 {
+				highConfEvals++
+			}
+		}
+
+		// Compute weighted score.
+		var weightedScore float64
+		if weightedTotal > 0 {
+			weightedScore = weightedCorrect / weightedTotal * 100
+		}
+
+		// Build confidence bands.
+		confBands := make([]ConfidenceBand, 0, 10)
+		for i, b := range bands {
+			if b.total == 0 {
+				continue
+			}
+			confBands = append(confBands, ConfidenceBand{
+				MinConf:  i * 10,
+				MaxConf:  i*10 + 9,
+				Accuracy: float64(b.correct) / float64(b.total) * 100,
+				Count:    b.total,
+			})
+		}
+		// Fix last band max to 100.
+		if len(confBands) > 0 && confBands[len(confBands)-1].MinConf == 90 {
+			confBands[len(confBands)-1].MaxConf = 100
+		}
+
+		// Compute sweet spot: scan from highest confidence band down,
+		// accumulating correct/total. Find the minimum confidence threshold
+		// where cumulative accuracy >= 80%.
+		sweetSpot := -1
+		{
+			cumCorrect := 0
+			cumTotal := 0
+			for i := len(bands) - 1; i >= 0; i-- {
+				cumCorrect += bands[i].correct
+				cumTotal += bands[i].total
+				if cumTotal > 0 {
+					cumAcc := float64(cumCorrect) / float64(cumTotal) * 100
+					if cumAcc >= 80 {
+						sweetSpot = i * 10
+					} else {
+						// Once accuracy drops below 80%, stop scanning down.
+						break
+					}
+				}
+			}
+		}
+
+		// Build temporal accuracy map.
+		temporalAcc := make(map[string]float64, 3)
+		for phase, pa := range phases {
+			if pa.total > 0 {
+				temporalAcc[phase] = float64(pa.correct) / float64(pa.total) * 100
+			}
+		}
+
+		// Per-tier accuracy.
+		accForTier := func(tier string) float64 {
+			ta := tiers[tier]
+			if ta.total == 0 {
+				return 0
+			}
+			return float64(ta.correct) / float64(ta.total) * 100
+		}
+
+		var overallAcc float64
+		if len(evals) > 0 {
+			overallAcc = float64(overallCorrect) / float64(len(evals)) * 100
+		}
+
+		results = append(results, SweepResultV2{
+			Sigma:         sigma,
+			WeightedScore: weightedScore,
+			TopAcc:        accForTier("TOP"),
+			HighAcc:       accForTier("HIGH"),
+			MidAcc:        accForTier("MID"),
+			LowAcc:        accForTier("LOW"),
+			OverallAcc:    overallAcc,
+			ConfBands:     confBands,
+			SweetSpot:     sweetSpot,
+			TemporalAcc:   temporalAcc,
+			TotalEvals:    len(evals),
+			HighConfEvals: highConfEvals,
+		})
+	}
+
+	// Sort by WeightedScore descending.
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].WeightedScore > results[j].WeightedScore
+	})
+
+	return results
+}
+
 // SnapshotPrice is a lightweight price observation for ground truth lookup.
 type SnapshotPrice struct {
 	Time    time.Time

--- a/internal/lab/optimizer.go
+++ b/internal/lab/optimizer.go
@@ -1,0 +1,126 @@
+package lab
+
+import (
+	"sort"
+	"time"
+)
+
+// SnapshotPrice is a lightweight price observation for ground truth lookup.
+type SnapshotPrice struct {
+	Time    time.Time
+	Name    string
+	Variant string
+	Chaos   float64
+}
+
+// EvalPoint pairs a pre-computed feature with its ground truth future price change.
+type EvalPoint struct {
+	Feature   GemFeature
+	FuturePct float64   // actual price change % over horizon
+	SnapTime  time.Time // snapshot time used as price baseline
+}
+
+// BuildEvalPoints pairs features with future snapshot prices.
+// Groups prices by (name, variant) into sorted time slices.
+// For each feature, finds the nearest snapshot price within [horizon-30m, horizon+30m].
+// Uses the snapshot chaos at the feature's time as the price baseline for futurePct
+// (not GemFeature.Chaos, which may differ due to aggregation).
+// Returns eval points and count of dropped features (no valid future price match).
+func BuildEvalPoints(features []GemFeature, prices []SnapshotPrice, horizon time.Duration) ([]EvalPoint, int) {
+	// Build a lookup index: (name, variant) → time-sorted prices.
+	type gemKey struct {
+		Name    string
+		Variant string
+	}
+	priceIndex := make(map[gemKey][]SnapshotPrice)
+	for _, p := range prices {
+		k := gemKey{p.Name, p.Variant}
+		priceIndex[k] = append(priceIndex[k], p)
+	}
+	for k, ps := range priceIndex {
+		sort.Slice(ps, func(i, j int) bool { return ps[i].Time.Before(ps[j].Time) })
+		priceIndex[k] = ps
+	}
+
+	// Build a baseline price index: (name, variant, truncated time) → chaos.
+	// This lets us find the snapshot price at the feature's time for the baseline.
+	type baselineKey struct {
+		Name    string
+		Variant string
+		Time    time.Time
+	}
+	baselineIndex := make(map[baselineKey]float64, len(prices))
+	for _, p := range prices {
+		bk := baselineKey{p.Name, p.Variant, p.Time.Truncate(time.Minute)}
+		baselineIndex[bk] = p.Chaos
+	}
+
+	const tolerance = 30 * time.Minute
+
+	var result []EvalPoint
+	dropped := 0
+
+	for _, f := range features {
+		k := gemKey{f.Name, f.Variant}
+		ps, ok := priceIndex[k]
+		if !ok {
+			dropped++
+			continue
+		}
+
+		targetTime := f.Time.Add(horizon)
+		minTime := targetTime.Add(-tolerance)
+		maxTime := targetTime.Add(tolerance)
+
+		// Binary search for the first price >= minTime.
+		idx := sort.Search(len(ps), func(i int) bool {
+			return !ps[i].Time.Before(minTime)
+		})
+
+		// Find the closest price within [minTime, maxTime].
+		bestIdx := -1
+		bestDist := time.Duration(0)
+		for i := idx; i < len(ps); i++ {
+			if ps[i].Time.After(maxTime) {
+				break
+			}
+			dist := ps[i].Time.Sub(targetTime)
+			if dist < 0 {
+				dist = -dist
+			}
+			if bestIdx == -1 || dist < bestDist {
+				bestIdx = i
+				bestDist = dist
+			}
+		}
+
+		if bestIdx == -1 {
+			dropped++
+			continue
+		}
+
+		// Use the snapshot price at the feature's time as baseline.
+		// Fall back to GemFeature.Chaos if no exact baseline snapshot is found.
+		bk := baselineKey{f.Name, f.Variant, f.Time.Truncate(time.Minute)}
+		baseline, found := baselineIndex[bk]
+		if !found {
+			baseline = f.Chaos
+		}
+
+		if baseline <= 0 {
+			dropped++
+			continue
+		}
+
+		futureChaos := ps[bestIdx].Chaos
+		futurePct := (futureChaos - baseline) / baseline * 100
+
+		result = append(result, EvalPoint{
+			Feature:   f,
+			FuturePct: futurePct,
+			SnapTime:  f.Time,
+		})
+	}
+
+	return result, dropped
+}

--- a/internal/lab/optimizer.go
+++ b/internal/lab/optimizer.go
@@ -156,7 +156,7 @@ func (sc SigmaConfig) ToSignalConfig(mc MarketContext) SignalConfig {
 // Grid: 5×4×4×4 = 320 combos (same size as v1 absolute grid).
 // DumpPriceMult is fixed at 2.0 (not swept).
 func GenerateSigmaGrid() []SigmaConfig {
-	var grid []SigmaConfig
+	grid := make([]SigmaConfig, 0, 320)
 
 	for _, herdP := range []float64{1.5, 2.0, 2.5, 3.0, 3.5} {
 		for _, herdL := range []float64{1.0, 1.5, 2.0, 2.5} {

--- a/internal/lab/optimizer.go
+++ b/internal/lab/optimizer.go
@@ -88,6 +88,13 @@ func classifyTemporalPhase(t time.Time) string {
 	return "weekday-offpeak"
 }
 
+// sweepAcc is a simple correct/total accumulator used for per-tier, per-band,
+// and per-temporal-phase accuracy tracking within SweepV2.
+type sweepAcc struct {
+	correct int
+	total   int
+}
+
 // SweepV2 evaluates each σ-multiplier configuration against the eval points,
 // computing confidence-weighted directional accuracy. Results are sorted by
 // WeightedScore descending (best first).
@@ -103,11 +110,7 @@ func SweepV2(evals []EvalPoint, mc MarketContext, grid []SigmaConfig) []SweepRes
 		cfg := sigma.ToSignalConfig(mc)
 
 		// Per-tier accumulators.
-		type tierAcc struct {
-			correct int
-			total   int
-		}
-		tiers := map[string]*tierAcc{
+		tiers := map[string]*sweepAcc{
 			"TOP":  {},
 			"HIGH": {},
 			"MID":  {},
@@ -115,14 +118,10 @@ func SweepV2(evals []EvalPoint, mc MarketContext, grid []SigmaConfig) []SweepRes
 		}
 
 		// Confidence band accumulators (0-9, 10-19, ..., 90-100).
-		type bandAcc struct {
-			correct int
-			total   int
-		}
-		bands := make([]bandAcc, 10) // index 0 = [0,9], ..., 9 = [90,100]
+		bands := make([]sweepAcc, 10) // index 0 = [0,9], ..., 9 = [90,100]
 
 		// Temporal phase accumulators.
-		phases := map[string]*tierAcc{
+		phases := map[string]*sweepAcc{
 			"weekend":         {},
 			"weekday-peak":    {},
 			"weekday-offpeak": {},
@@ -131,7 +130,7 @@ func SweepV2(evals []EvalPoint, mc MarketContext, grid []SigmaConfig) []SweepRes
 		var weightedCorrect float64
 		var weightedTotal float64
 		var overallCorrect int
-		highConfEvals := 0
+		var highConfEvals int
 
 		for _, ep := range evals {
 			signal := classifySignalWithConfig(
@@ -165,7 +164,7 @@ func SweepV2(evals []EvalPoint, mc MarketContext, grid []SigmaConfig) []SweepRes
 			}
 			ta, ok := tiers[tier]
 			if !ok {
-				ta = &tierAcc{}
+				ta = &sweepAcc{}
 				tiers[tier] = ta
 			}
 			ta.total++
@@ -225,20 +224,18 @@ func SweepV2(evals []EvalPoint, mc MarketContext, grid []SigmaConfig) []SweepRes
 		// accumulating correct/total. Find the minimum confidence threshold
 		// where cumulative accuracy >= 80%.
 		sweetSpot := -1
-		{
-			cumCorrect := 0
-			cumTotal := 0
-			for i := len(bands) - 1; i >= 0; i-- {
-				cumCorrect += bands[i].correct
-				cumTotal += bands[i].total
-				if cumTotal > 0 {
-					cumAcc := float64(cumCorrect) / float64(cumTotal) * 100
-					if cumAcc >= 80 {
-						sweetSpot = i * 10
-					} else {
-						// Once accuracy drops below 80%, stop scanning down.
-						break
-					}
+		cumCorrect := 0
+		cumTotal := 0
+		for i := len(bands) - 1; i >= 0; i-- {
+			cumCorrect += bands[i].correct
+			cumTotal += bands[i].total
+			if cumTotal > 0 {
+				cumAcc := float64(cumCorrect) / float64(cumTotal) * 100
+				if cumAcc >= 80 {
+					sweetSpot = i * 10
+				} else {
+					// Once accuracy drops below 80%, stop scanning down.
+					break
 				}
 			}
 		}

--- a/internal/lab/optimizer.go
+++ b/internal/lab/optimizer.go
@@ -124,3 +124,55 @@ func BuildEvalPoints(features []GemFeature, prices []SnapshotPrice, horizon time
 
 	return result, dropped
 }
+
+// SigmaConfig holds σ-multiplier parameters for optimizer grid sweeping.
+// Each field is a multiplier of the corresponding market-wide sigma value.
+// ToSignalConfig converts these relative multipliers into absolute thresholds
+// using observed market statistics from MarketContext.
+type SigmaConfig struct {
+	HERDPriceMult    float64 // priceVel threshold = VelocityMean + N * VelocitySigma
+	HERDListingMult  float64 // listingVel threshold = ListingVelMean + N * ListingVelSigma
+	StablePriceMult  float64 // max |priceVel| for STABLE = M * VelocitySigma
+	BrewingPriceMult float64 // min priceVel for BREWING = M * VelocitySigma
+	DumpPriceMult    float64 // dump priceVel = -(M * VelocitySigma)
+}
+
+// ToSignalConfig converts σ-multipliers to absolute thresholds using market context.
+// Starts from DefaultSignalConfig and overrides the swept fields. Fields not swept
+// (HERDPriceVel, HERDListingVel, StableListingVel, RecoveryMaxList, TrapCV) keep defaults.
+func (sc SigmaConfig) ToSignalConfig(mc MarketContext) SignalConfig {
+	cfg := DefaultSignalConfig()
+
+	cfg.PreHERDPriceVel = mc.VelocityMean + sc.HERDPriceMult*mc.VelocitySigma
+	cfg.PreHERDListingVel = mc.ListingVelMean + sc.HERDListingMult*mc.ListingVelSigma
+	cfg.StablePriceVel = sc.StablePriceMult * mc.VelocitySigma
+	cfg.BrewingMinPVel = sc.BrewingPriceMult * mc.VelocitySigma
+	cfg.DumpPriceVel = -(sc.DumpPriceMult * mc.VelocitySigma)
+
+	return cfg
+}
+
+// GenerateSigmaGrid produces a focused σ-multiplier grid for sweeping.
+// Grid: 5×4×4×4 = 320 combos (same size as v1 absolute grid).
+// DumpPriceMult is fixed at 2.0 (not swept).
+func GenerateSigmaGrid() []SigmaConfig {
+	var grid []SigmaConfig
+
+	for _, herdP := range []float64{1.5, 2.0, 2.5, 3.0, 3.5} {
+		for _, herdL := range []float64{1.0, 1.5, 2.0, 2.5} {
+			for _, stableP := range []float64{0.3, 0.5, 0.7, 1.0} {
+				for _, brewP := range []float64{0.5, 1.0, 1.5, 2.0} {
+					grid = append(grid, SigmaConfig{
+						HERDPriceMult:    herdP,
+						HERDListingMult:  herdL,
+						StablePriceMult:  stableP,
+						BrewingPriceMult: brewP,
+						DumpPriceMult:    2.0,
+					})
+				}
+			}
+		}
+	}
+
+	return grid
+}

--- a/internal/lab/optimizer_test.go
+++ b/internal/lab/optimizer_test.go
@@ -272,3 +272,124 @@ func TestBuildEvalPoints_DroppedCountDiagnostics(t *testing.T) {
 	}
 }
 
+func TestToSignalConfig(t *testing.T) {
+	mc := MarketContext{
+		VelocityMean:    5,
+		VelocitySigma:   10,
+		ListingVelMean:  2,
+		ListingVelSigma: 4,
+	}
+
+	sc := SigmaConfig{
+		HERDPriceMult:    2.0,
+		HERDListingMult:  1.5,
+		StablePriceMult:  0.5,
+		BrewingPriceMult: 1.0,
+		DumpPriceMult:    2.0,
+	}
+
+	cfg := sc.ToSignalConfig(mc)
+
+	// PreHERDPriceVel = VelocityMean + HERDPriceMult * VelocitySigma = 5 + 2.0 * 10 = 25
+	if got := cfg.PreHERDPriceVel; !approxEqual(got, 25.0, 0.01) {
+		t.Errorf("PreHERDPriceVel: got %.2f, want 25.0", got)
+	}
+
+	// PreHERDListingVel = ListingVelMean + HERDListingMult * ListingVelSigma = 2 + 1.5 * 4 = 8
+	if got := cfg.PreHERDListingVel; !approxEqual(got, 8.0, 0.01) {
+		t.Errorf("PreHERDListingVel: got %.2f, want 8.0", got)
+	}
+
+	// StablePriceVel = StablePriceMult * VelocitySigma = 0.5 * 10 = 5
+	if got := cfg.StablePriceVel; !approxEqual(got, 5.0, 0.01) {
+		t.Errorf("StablePriceVel: got %.2f, want 5.0", got)
+	}
+
+	// BrewingMinPVel = BrewingPriceMult * VelocitySigma = 1.0 * 10 = 10
+	if got := cfg.BrewingMinPVel; !approxEqual(got, 10.0, 0.01) {
+		t.Errorf("BrewingMinPVel: got %.2f, want 10.0", got)
+	}
+
+	// DumpPriceVel = -(DumpPriceMult * VelocitySigma) = -(2.0 * 10) = -20
+	if got := cfg.DumpPriceVel; !approxEqual(got, -20.0, 0.01) {
+		t.Errorf("DumpPriceVel: got %.2f, want -20.0", got)
+	}
+}
+
+func TestToSignalConfig_PreservesDefaults(t *testing.T) {
+	mc := MarketContext{
+		VelocityMean:    5,
+		VelocitySigma:   10,
+		ListingVelMean:  2,
+		ListingVelSigma: 4,
+	}
+
+	sc := SigmaConfig{
+		HERDPriceMult:    2.0,
+		HERDListingMult:  1.5,
+		StablePriceMult:  0.5,
+		BrewingPriceMult: 1.0,
+		DumpPriceMult:    2.0,
+	}
+
+	cfg := sc.ToSignalConfig(mc)
+	defaults := DefaultSignalConfig()
+
+	// Non-swept fields must retain default values.
+	if cfg.HERDPriceVel != defaults.HERDPriceVel {
+		t.Errorf("HERDPriceVel: got %.2f, want default %.2f", cfg.HERDPriceVel, defaults.HERDPriceVel)
+	}
+	if cfg.HERDListingVel != defaults.HERDListingVel {
+		t.Errorf("HERDListingVel: got %.2f, want default %.2f", cfg.HERDListingVel, defaults.HERDListingVel)
+	}
+	if cfg.StableListingVel != defaults.StableListingVel {
+		t.Errorf("StableListingVel: got %.2f, want default %.2f", cfg.StableListingVel, defaults.StableListingVel)
+	}
+	if cfg.RecoveryMaxList != defaults.RecoveryMaxList {
+		t.Errorf("RecoveryMaxList: got %d, want default %d", cfg.RecoveryMaxList, defaults.RecoveryMaxList)
+	}
+	if cfg.TrapCV != defaults.TrapCV {
+		t.Errorf("TrapCV: got %.2f, want default %.2f", cfg.TrapCV, defaults.TrapCV)
+	}
+}
+
+func TestGenerateSigmaGrid(t *testing.T) {
+	grid := GenerateSigmaGrid()
+
+	// Expected size: 5 * 4 * 4 * 4 = 320 combos.
+	if got := len(grid); got != 320 {
+		t.Fatalf("grid size: got %d, want 320", got)
+	}
+
+	// Verify all values are within expected ranges.
+	for i, sc := range grid {
+		if sc.HERDPriceMult < 1.5 || sc.HERDPriceMult > 3.5 {
+			t.Errorf("grid[%d].HERDPriceMult=%.1f out of range [1.5, 3.5]", i, sc.HERDPriceMult)
+		}
+		if sc.HERDListingMult < 1.0 || sc.HERDListingMult > 2.5 {
+			t.Errorf("grid[%d].HERDListingMult=%.1f out of range [1.0, 2.5]", i, sc.HERDListingMult)
+		}
+		if sc.StablePriceMult < 0.3 || sc.StablePriceMult > 1.0 {
+			t.Errorf("grid[%d].StablePriceMult=%.1f out of range [0.3, 1.0]", i, sc.StablePriceMult)
+		}
+		if sc.BrewingPriceMult < 0.5 || sc.BrewingPriceMult > 2.0 {
+			t.Errorf("grid[%d].BrewingPriceMult=%.1f out of range [0.5, 2.0]", i, sc.BrewingPriceMult)
+		}
+		if sc.DumpPriceMult != 2.0 {
+			t.Errorf("grid[%d].DumpPriceMult=%.1f, want fixed 2.0", i, sc.DumpPriceMult)
+		}
+	}
+}
+
+func TestGenerateSigmaGrid_NoDuplicates(t *testing.T) {
+	grid := GenerateSigmaGrid()
+
+	seen := make(map[SigmaConfig]bool, len(grid))
+	for _, sc := range grid {
+		if seen[sc] {
+			t.Errorf("duplicate SigmaConfig: %+v", sc)
+		}
+		seen[sc] = true
+	}
+}
+

--- a/internal/lab/optimizer_test.go
+++ b/internal/lab/optimizer_test.go
@@ -33,11 +33,11 @@ func TestBuildEvalPoints_ExactMatch(t *testing.T) {
 	}
 
 	// Spark: (110-100)/100 * 100 = 10%
-	if got := points[0].FuturePct; !approxEqual(got, 10.0) {
+	if got := points[0].FuturePct; !approxEqual(got, 10.0, 0.01) {
 		t.Errorf("Spark futurePct: got %.2f, want 10.0", got)
 	}
 	// Ice Nova: (180-200)/200 * 100 = -10%
-	if got := points[1].FuturePct; !approxEqual(got, -10.0) {
+	if got := points[1].FuturePct; !approxEqual(got, -10.0, 0.01) {
 		t.Errorf("Ice Nova futurePct: got %.2f, want -10.0", got)
 	}
 }
@@ -112,7 +112,7 @@ func TestBuildEvalPoints_WithinTolerance(t *testing.T) {
 		t.Fatalf("expected 1 eval point, got %d", len(points))
 	}
 	// (115-100)/100 * 100 = 15%
-	if got := points[0].FuturePct; !approxEqual(got, 15.0) {
+	if got := points[0].FuturePct; !approxEqual(got, 15.0, 0.01) {
 		t.Errorf("futurePct: got %.2f, want 15.0", got)
 	}
 }
@@ -142,7 +142,7 @@ func TestBuildEvalPoints_PicksClosestWithinWindow(t *testing.T) {
 	}
 	// Should use the 130 chaos (5min late, closer to target)
 	// (130-100)/100 * 100 = 30%
-	if got := points[0].FuturePct; !approxEqual(got, 30.0) {
+	if got := points[0].FuturePct; !approxEqual(got, 30.0, 0.01) {
 		t.Errorf("futurePct: got %.2f, want 30.0", got)
 	}
 }
@@ -201,7 +201,7 @@ func TestBuildEvalPoints_UsesSnapshotBaseline(t *testing.T) {
 		t.Fatalf("expected 1 eval point, got %d", len(points))
 	}
 	// (120-100)/100 * 100 = 20% (based on snapshot price, not feature Chaos)
-	if got := points[0].FuturePct; !approxEqual(got, 20.0) {
+	if got := points[0].FuturePct; !approxEqual(got, 20.0, 0.01) {
 		t.Errorf("futurePct: got %.2f, want 20.0 (should use snapshot baseline)", got)
 	}
 }
@@ -272,12 +272,3 @@ func TestBuildEvalPoints_DroppedCountDiagnostics(t *testing.T) {
 	}
 }
 
-// approxEqual compares two floats within a small tolerance.
-func approxEqual(a, b float64) bool {
-	const epsilon = 0.01
-	diff := a - b
-	if diff < 0 {
-		diff = -diff
-	}
-	return diff < epsilon
-}

--- a/internal/lab/optimizer_test.go
+++ b/internal/lab/optimizer_test.go
@@ -345,8 +345,32 @@ func TestToSignalConfig_PreservesDefaults(t *testing.T) {
 	if cfg.StableListingVel != defaults.StableListingVel {
 		t.Errorf("StableListingVel: got %.2f, want default %.2f", cfg.StableListingVel, defaults.StableListingVel)
 	}
+	if cfg.DumpListingVel != defaults.DumpListingVel {
+		t.Errorf("DumpListingVel: got %.2f, want default %.2f", cfg.DumpListingVel, defaults.DumpListingVel)
+	}
 	if cfg.RecoveryMaxList != defaults.RecoveryMaxList {
 		t.Errorf("RecoveryMaxList: got %d, want default %d", cfg.RecoveryMaxList, defaults.RecoveryMaxList)
+	}
+	if cfg.OpenMinPVel != defaults.OpenMinPVel {
+		t.Errorf("OpenMinPVel: got %.2f, want default %.2f", cfg.OpenMinPVel, defaults.OpenMinPVel)
+	}
+	if cfg.DrainPct != defaults.DrainPct {
+		t.Errorf("DrainPct: got %.4f, want default %.4f", cfg.DrainPct, defaults.DrainPct)
+	}
+	if cfg.ThinPoolFloor != defaults.ThinPoolFloor {
+		t.Errorf("ThinPoolFloor: got %.2f, want default %.2f", cfg.ThinPoolFloor, defaults.ThinPoolFloor)
+	}
+	if cfg.NormalFloor != defaults.NormalFloor {
+		t.Errorf("NormalFloor: got %.2f, want default %.2f", cfg.NormalFloor, defaults.NormalFloor)
+	}
+	if cfg.BreakoutMaxPrice != defaults.BreakoutMaxPrice {
+		t.Errorf("BreakoutMaxPrice: got %.2f, want default %.2f", cfg.BreakoutMaxPrice, defaults.BreakoutMaxPrice)
+	}
+	if cfg.BreakoutMaxList != defaults.BreakoutMaxList {
+		t.Errorf("BreakoutMaxList: got %d, want default %d", cfg.BreakoutMaxList, defaults.BreakoutMaxList)
+	}
+	if cfg.BreakoutMinLVel != defaults.BreakoutMinLVel {
+		t.Errorf("BreakoutMinLVel: got %.2f, want default %.2f", cfg.BreakoutMinLVel, defaults.BreakoutMinLVel)
 	}
 	if cfg.TrapCV != defaults.TrapCV {
 		t.Errorf("TrapCV: got %.2f, want default %.2f", cfg.TrapCV, defaults.TrapCV)

--- a/internal/lab/optimizer_test.go
+++ b/internal/lab/optimizer_test.go
@@ -1,0 +1,283 @@
+package lab
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBuildEvalPoints_ExactMatch(t *testing.T) {
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	horizon := 2 * time.Hour
+
+	features := []GemFeature{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+		{Time: t0, Name: "Ice Nova", Variant: "1", Chaos: 200},
+	}
+
+	prices := []SnapshotPrice{
+		// Baseline prices at feature time
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+		{Time: t0, Name: "Ice Nova", Variant: "1", Chaos: 200},
+		// Future prices at exactly t0 + 2h
+		{Time: t0.Add(horizon), Name: "Spark", Variant: "1", Chaos: 110},
+		{Time: t0.Add(horizon), Name: "Ice Nova", Variant: "1", Chaos: 180},
+	}
+
+	points, dropped := BuildEvalPoints(features, prices, horizon)
+
+	if dropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", dropped)
+	}
+	if len(points) != 2 {
+		t.Fatalf("expected 2 eval points, got %d", len(points))
+	}
+
+	// Spark: (110-100)/100 * 100 = 10%
+	if got := points[0].FuturePct; !approxEqual(got, 10.0) {
+		t.Errorf("Spark futurePct: got %.2f, want 10.0", got)
+	}
+	// Ice Nova: (180-200)/200 * 100 = -10%
+	if got := points[1].FuturePct; !approxEqual(got, -10.0) {
+		t.Errorf("Ice Nova futurePct: got %.2f, want -10.0", got)
+	}
+}
+
+func TestBuildEvalPoints_NoFuturePrice(t *testing.T) {
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	horizon := 2 * time.Hour
+
+	features := []GemFeature{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+	}
+
+	// No future prices at all
+	prices := []SnapshotPrice{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+	}
+
+	points, dropped := BuildEvalPoints(features, prices, horizon)
+
+	if dropped != 1 {
+		t.Errorf("expected 1 dropped, got %d", dropped)
+	}
+	if len(points) != 0 {
+		t.Errorf("expected 0 eval points, got %d", len(points))
+	}
+}
+
+func TestBuildEvalPoints_EdgeOfRange(t *testing.T) {
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	horizon := 2 * time.Hour
+
+	features := []GemFeature{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+	}
+
+	// Price just beyond the 30min tolerance window (31 minutes late)
+	prices := []SnapshotPrice{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+		{Time: t0.Add(horizon).Add(31 * time.Minute), Name: "Spark", Variant: "1", Chaos: 120},
+	}
+
+	points, dropped := BuildEvalPoints(features, prices, horizon)
+
+	if dropped != 1 {
+		t.Errorf("expected 1 dropped (out of tolerance), got %d", dropped)
+	}
+	if len(points) != 0 {
+		t.Errorf("expected 0 eval points, got %d", len(points))
+	}
+}
+
+func TestBuildEvalPoints_WithinTolerance(t *testing.T) {
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	horizon := 2 * time.Hour
+
+	features := []GemFeature{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+	}
+
+	// Price 20 minutes late (within 30min tolerance)
+	prices := []SnapshotPrice{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+		{Time: t0.Add(horizon).Add(20 * time.Minute), Name: "Spark", Variant: "1", Chaos: 115},
+	}
+
+	points, dropped := BuildEvalPoints(features, prices, horizon)
+
+	if dropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", dropped)
+	}
+	if len(points) != 1 {
+		t.Fatalf("expected 1 eval point, got %d", len(points))
+	}
+	// (115-100)/100 * 100 = 15%
+	if got := points[0].FuturePct; !approxEqual(got, 15.0) {
+		t.Errorf("futurePct: got %.2f, want 15.0", got)
+	}
+}
+
+func TestBuildEvalPoints_PicksClosestWithinWindow(t *testing.T) {
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	horizon := 2 * time.Hour
+
+	features := []GemFeature{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+	}
+
+	// Two prices in window — one 25min early, one 5min late. Should pick the closer one (5min late).
+	prices := []SnapshotPrice{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+		{Time: t0.Add(horizon).Add(-25 * time.Minute), Name: "Spark", Variant: "1", Chaos: 90},
+		{Time: t0.Add(horizon).Add(5 * time.Minute), Name: "Spark", Variant: "1", Chaos: 130},
+	}
+
+	points, dropped := BuildEvalPoints(features, prices, horizon)
+
+	if dropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", dropped)
+	}
+	if len(points) != 1 {
+		t.Fatalf("expected 1 eval point, got %d", len(points))
+	}
+	// Should use the 130 chaos (5min late, closer to target)
+	// (130-100)/100 * 100 = 30%
+	if got := points[0].FuturePct; !approxEqual(got, 30.0) {
+		t.Errorf("futurePct: got %.2f, want 30.0", got)
+	}
+}
+
+func TestBuildEvalPoints_MultipleGemsIndependent(t *testing.T) {
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	horizon := 2 * time.Hour
+
+	features := []GemFeature{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+		{Time: t0, Name: "Ice Nova", Variant: "1", Chaos: 50},
+		{Time: t0, Name: "Arc", Variant: "1", Chaos: 200},
+	}
+
+	prices := []SnapshotPrice{
+		// Baselines
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+		{Time: t0, Name: "Ice Nova", Variant: "1", Chaos: 50},
+		{Time: t0, Name: "Arc", Variant: "1", Chaos: 200},
+		// Futures — Spark has future, Ice Nova does not, Arc has future
+		{Time: t0.Add(horizon), Name: "Spark", Variant: "1", Chaos: 120},
+		{Time: t0.Add(horizon), Name: "Arc", Variant: "1", Chaos: 160},
+	}
+
+	points, dropped := BuildEvalPoints(features, prices, horizon)
+
+	if dropped != 1 {
+		t.Errorf("expected 1 dropped (Ice Nova), got %d", dropped)
+	}
+	if len(points) != 2 {
+		t.Fatalf("expected 2 eval points, got %d", len(points))
+	}
+}
+
+func TestBuildEvalPoints_UsesSnapshotBaseline(t *testing.T) {
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	horizon := 2 * time.Hour
+
+	// Feature Chaos differs from snapshot price at same time.
+	// Should use snapshot price (100) as baseline, not feature Chaos (95).
+	features := []GemFeature{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 95},
+	}
+
+	prices := []SnapshotPrice{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 100},
+		{Time: t0.Add(horizon), Name: "Spark", Variant: "1", Chaos: 120},
+	}
+
+	points, dropped := BuildEvalPoints(features, prices, horizon)
+
+	if dropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", dropped)
+	}
+	if len(points) != 1 {
+		t.Fatalf("expected 1 eval point, got %d", len(points))
+	}
+	// (120-100)/100 * 100 = 20% (based on snapshot price, not feature Chaos)
+	if got := points[0].FuturePct; !approxEqual(got, 20.0) {
+		t.Errorf("futurePct: got %.2f, want 20.0 (should use snapshot baseline)", got)
+	}
+}
+
+func TestBuildEvalPoints_ZeroBaselineDropped(t *testing.T) {
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	horizon := 2 * time.Hour
+
+	// Feature with zero chaos and no snapshot baseline
+	features := []GemFeature{
+		{Time: t0, Name: "Spark", Variant: "1", Chaos: 0},
+	}
+
+	prices := []SnapshotPrice{
+		{Time: t0.Add(horizon), Name: "Spark", Variant: "1", Chaos: 120},
+	}
+
+	points, dropped := BuildEvalPoints(features, prices, horizon)
+
+	if dropped != 1 {
+		t.Errorf("expected 1 dropped (zero baseline), got %d", dropped)
+	}
+	if len(points) != 0 {
+		t.Errorf("expected 0 eval points, got %d", len(points))
+	}
+}
+
+func TestBuildEvalPoints_EmptyInputs(t *testing.T) {
+	horizon := 2 * time.Hour
+
+	points, dropped := BuildEvalPoints(nil, nil, horizon)
+
+	if dropped != 0 {
+		t.Errorf("expected 0 dropped, got %d", dropped)
+	}
+	if len(points) != 0 {
+		t.Errorf("expected 0 eval points, got %d", len(points))
+	}
+}
+
+func TestBuildEvalPoints_DroppedCountDiagnostics(t *testing.T) {
+	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
+	horizon := 2 * time.Hour
+
+	// 5 features, only 2 have matching future prices
+	features := []GemFeature{
+		{Time: t0, Name: "A", Variant: "1", Chaos: 100},
+		{Time: t0, Name: "B", Variant: "1", Chaos: 100},
+		{Time: t0, Name: "C", Variant: "1", Chaos: 100},
+		{Time: t0, Name: "D", Variant: "1", Chaos: 100},
+		{Time: t0, Name: "E", Variant: "1", Chaos: 100},
+	}
+
+	prices := []SnapshotPrice{
+		{Time: t0, Name: "A", Variant: "1", Chaos: 100},
+		{Time: t0, Name: "B", Variant: "1", Chaos: 100},
+		{Time: t0.Add(horizon), Name: "A", Variant: "1", Chaos: 120},
+		{Time: t0.Add(horizon), Name: "B", Variant: "1", Chaos: 80},
+	}
+
+	points, dropped := BuildEvalPoints(features, prices, horizon)
+
+	if dropped != 3 {
+		t.Errorf("expected 3 dropped, got %d", dropped)
+	}
+	if len(points) != 2 {
+		t.Errorf("expected 2 eval points, got %d", len(points))
+	}
+}
+
+// approxEqual compares two floats within a small tolerance.
+func approxEqual(a, b float64) bool {
+	const epsilon = 0.01
+	diff := a - b
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff < epsilon
+}

--- a/internal/lab/optimizer_test.go
+++ b/internal/lab/optimizer_test.go
@@ -5,6 +5,24 @@ import (
 	"time"
 )
 
+// sweepMarketContext returns a MarketContext with custom velocity stats and
+// properly initialized temporal slices (neutral 1.0 biases) for sweep tests.
+func sweepMarketContext(velMean, velSigma, listVelMean, listVelSigma float64) MarketContext {
+	mc := testMarketContext()
+	mc.VelocityMean = velMean
+	mc.VelocitySigma = velSigma
+	mc.ListingVelMean = listVelMean
+	mc.ListingVelSigma = listVelSigma
+	// Set neutral biases (1.0) for predictable confidence scoring.
+	for i := range mc.HourlyBias {
+		mc.HourlyBias[i] = 1.0
+	}
+	for i := range mc.WeekdayBias {
+		mc.WeekdayBias[i] = 1.0
+	}
+	return mc
+}
+
 func TestBuildEvalPoints_ExactMatch(t *testing.T) {
 	t0 := time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC)
 	horizon := 2 * time.Hour
@@ -414,6 +432,397 @@ func TestGenerateSigmaGrid_NoDuplicates(t *testing.T) {
 			t.Errorf("duplicate SigmaConfig: %+v", sc)
 		}
 		seen[sc] = true
+	}
+}
+
+func TestPredictedDirection(t *testing.T) {
+	tests := []struct {
+		signal string
+		want   string
+	}{
+		{"HERD", "UP"},
+		{"RISING", "UP"},
+		{"RECOVERY", "UP"},
+		{"DUMPING", "DOWN"},
+		{"FALLING", "DOWN"},
+		{"TRAP", "DOWN"},
+		{"STABLE", "FLAT"},
+		{"UNKNOWN", "FLAT"},
+		{"", "FLAT"},
+	}
+
+	for _, tt := range tests {
+		got := predictedDirection(tt.signal)
+		if got != tt.want {
+			t.Errorf("predictedDirection(%q) = %q, want %q", tt.signal, got, tt.want)
+		}
+	}
+}
+
+func TestDirectionFromChange(t *testing.T) {
+	tests := []struct {
+		pctChange float64
+		want      string
+	}{
+		{5.0, "UP"},
+		{2.01, "UP"},
+		{2.0, "FLAT"},
+		{0.0, "FLAT"},
+		{-2.0, "FLAT"},
+		{-2.01, "DOWN"},
+		{-10.0, "DOWN"},
+	}
+
+	for _, tt := range tests {
+		got := directionFromChange(tt.pctChange)
+		if got != tt.want {
+			t.Errorf("directionFromChange(%.2f) = %q, want %q", tt.pctChange, got, tt.want)
+		}
+	}
+}
+
+func TestTierWeight(t *testing.T) {
+	tests := []struct {
+		tier string
+		want float64
+	}{
+		{"TOP", 2.0},
+		{"HIGH", 1.5},
+		{"MID", 1.0},
+		{"LOW", 0.5},
+		{"", 1.0},
+		{"UNKNOWN", 1.0},
+	}
+
+	for _, tt := range tests {
+		got := tierWeight(tt.tier)
+		if got != tt.want {
+			t.Errorf("tierWeight(%q) = %.1f, want %.1f", tt.tier, got, tt.want)
+		}
+	}
+}
+
+func TestClassifyTemporalPhase(t *testing.T) {
+	tests := []struct {
+		name string
+		t    time.Time
+		want string
+	}{
+		{
+			name: "Saturday is weekend",
+			t:    time.Date(2026, 3, 14, 16, 0, 0, 0, time.UTC), // Saturday
+			want: "weekend",
+		},
+		{
+			name: "Sunday is weekend",
+			t:    time.Date(2026, 3, 15, 10, 0, 0, 0, time.UTC), // Sunday
+			want: "weekend",
+		},
+		{
+			name: "Monday 16:00 UTC is weekday-peak",
+			t:    time.Date(2026, 3, 16, 16, 0, 0, 0, time.UTC), // Monday
+			want: "weekday-peak",
+		},
+		{
+			name: "Wednesday 14:00 UTC is weekday-peak (boundary)",
+			t:    time.Date(2026, 3, 18, 14, 0, 0, 0, time.UTC), // Wednesday
+			want: "weekday-peak",
+		},
+		{
+			name: "Thursday 21:59 UTC is weekday-peak (end boundary)",
+			t:    time.Date(2026, 3, 19, 21, 59, 0, 0, time.UTC), // Thursday
+			want: "weekday-peak",
+		},
+		{
+			name: "Friday 22:00 UTC is weekday-offpeak (past peak)",
+			t:    time.Date(2026, 3, 20, 22, 0, 0, 0, time.UTC), // Friday
+			want: "weekday-offpeak",
+		},
+		{
+			name: "Tuesday 08:00 UTC is weekday-offpeak",
+			t:    time.Date(2026, 3, 17, 8, 0, 0, 0, time.UTC), // Tuesday
+			want: "weekday-offpeak",
+		},
+		{
+			name: "Monday 00:00 UTC is weekday-offpeak",
+			t:    time.Date(2026, 3, 16, 0, 0, 0, 0, time.UTC), // Monday
+			want: "weekday-offpeak",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyTemporalPhase(tt.t)
+			if got != tt.want {
+				t.Errorf("classifyTemporalPhase(%v) = %q, want %q", tt.t, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSweepV2_SingleCombo(t *testing.T) {
+	// Wednesday 16:00 UTC = weekday-peak
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	// 5 eval points with known outcomes.
+	// Use STABLE-triggering velocities (low abs values) so predictions are FLAT.
+	// FuturePct near 0 = FLAT = correct, large positive/negative = wrong.
+	sigma := SigmaConfig{
+		HERDPriceMult:    2.0,
+		HERDListingMult:  1.5,
+		StablePriceMult:  0.5,
+		BrewingPriceMult: 1.0,
+		DumpPriceMult:    2.0,
+	}
+
+	evals := []EvalPoint{
+		// STABLE signal (low vel), FLAT actual → correct
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.5, VelMedListing: 0.5, CV: 0.1, Listings: 10, Tier: "TOP"}, FuturePct: 0.5, SnapTime: t0},
+		// STABLE signal, FLAT actual → correct
+		{Feature: GemFeature{Time: t0, VelMedPrice: -0.3, VelMedListing: 0.2, CV: 0.1, Listings: 10, Tier: "HIGH"}, FuturePct: -1.0, SnapTime: t0},
+		// STABLE signal, UP actual → wrong
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.2, VelMedListing: -0.1, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 5.0, SnapTime: t0},
+		// STABLE signal, DOWN actual → wrong
+		{Feature: GemFeature{Time: t0, VelMedPrice: -0.4, VelMedListing: 0.3, CV: 0.1, Listings: 10, Tier: "LOW"}, FuturePct: -5.0, SnapTime: t0},
+		// STABLE signal, FLAT actual → correct
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 1.5, SnapTime: t0},
+	}
+
+	results := SweepV2(evals, mc, []SigmaConfig{sigma})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+
+	if r.TotalEvals != 5 {
+		t.Errorf("TotalEvals: got %d, want 5", r.TotalEvals)
+	}
+
+	// Overall: 3 correct out of 5 = 60%
+	if !approxEqual(r.OverallAcc, 60.0, 0.1) {
+		t.Errorf("OverallAcc: got %.2f, want 60.0", r.OverallAcc)
+	}
+
+	// TOP: 1/1 = 100%
+	if !approxEqual(r.TopAcc, 100.0, 0.1) {
+		t.Errorf("TopAcc: got %.2f, want 100.0", r.TopAcc)
+	}
+
+	// HIGH: 1/1 = 100%
+	if !approxEqual(r.HighAcc, 100.0, 0.1) {
+		t.Errorf("HighAcc: got %.2f, want 100.0", r.HighAcc)
+	}
+
+	// MID: 1/2 = 50%
+	if !approxEqual(r.MidAcc, 50.0, 0.1) {
+		t.Errorf("MidAcc: got %.2f, want 50.0", r.MidAcc)
+	}
+
+	// LOW: 0/1 = 0%
+	if !approxEqual(r.LowAcc, 0.0, 0.1) {
+		t.Errorf("LowAcc: got %.2f, want 0.0", r.LowAcc)
+	}
+
+	// WeightedScore should be > 0 (some correct with non-zero confidence).
+	if r.WeightedScore <= 0 {
+		t.Errorf("WeightedScore should be > 0, got %.2f", r.WeightedScore)
+	}
+
+	// All timestamps are weekday-peak.
+	if acc, ok := r.TemporalAcc["weekday-peak"]; !ok {
+		t.Error("missing temporal phase weekday-peak")
+	} else if !approxEqual(acc, 60.0, 0.1) {
+		t.Errorf("weekday-peak accuracy: got %.2f, want 60.0", acc)
+	}
+
+	// Confidence bands should be populated.
+	if len(r.ConfBands) == 0 {
+		t.Error("expected at least one confidence band")
+	}
+}
+
+func TestSweepV2_SweetSpot(t *testing.T) {
+	// Design eval points so high-confidence ones are correct (accuracy >= 80%)
+	// and low-confidence ones are wrong, establishing a sweet spot.
+	// Tuesday 16:00 UTC = weekday-peak
+	t0 := time.Date(2026, 3, 17, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	sigma := SigmaConfig{
+		HERDPriceMult:    2.0,
+		HERDListingMult:  1.5,
+		StablePriceMult:  0.5,
+		BrewingPriceMult: 1.0,
+		DumpPriceMult:    2.0,
+	}
+
+	// STABLE signal with high cross-window agreement (all windows aligned)
+	// should yield higher confidence. Mix correct and incorrect to create
+	// a boundary.
+	var evals []EvalPoint
+
+	// 10 STABLE+high-agreement points (should get higher confidence): 9 correct, 1 wrong
+	for i := 0; i < 9; i++ {
+		evals = append(evals, EvalPoint{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.05,
+				Listings: 15, Tier: "HIGH",
+				VelShortPrice: 0.1, VelLongPrice: 0.1,
+			},
+			FuturePct: 0.5, // FLAT = correct for STABLE
+			SnapTime:  t0,
+		})
+	}
+	evals = append(evals, EvalPoint{
+		Feature: GemFeature{
+			Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.05,
+			Listings: 15, Tier: "HIGH",
+			VelShortPrice: 0.1, VelLongPrice: 0.1,
+		},
+		FuturePct: 5.0, // UP = wrong for STABLE
+		SnapTime:  t0,
+	})
+
+	results := SweepV2(evals, mc, []SigmaConfig{sigma})
+	r := results[0]
+
+	// With all same-confidence evals at 90% accuracy, sweet spot should be found.
+	// (All evals have the same features/confidence, so they land in the same band.)
+	if r.SweetSpot == -1 {
+		t.Error("expected SweetSpot to be found (90% accuracy), got -1")
+	}
+}
+
+func TestSweepV2_NoSweetSpot(t *testing.T) {
+	// All predictions wrong → no sweet spot.
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	sigma := SigmaConfig{
+		HERDPriceMult:    2.0,
+		HERDListingMult:  1.5,
+		StablePriceMult:  0.5,
+		BrewingPriceMult: 1.0,
+		DumpPriceMult:    2.0,
+	}
+
+	// STABLE signals with large actual moves → all wrong.
+	evals := []EvalPoint{
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.05, Listings: 10, Tier: "MID"}, FuturePct: 10.0, SnapTime: t0},
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.2, VelMedListing: 0.1, CV: 0.05, Listings: 10, Tier: "MID"}, FuturePct: -8.0, SnapTime: t0},
+		{Feature: GemFeature{Time: t0, VelMedPrice: -0.1, VelMedListing: 0.2, CV: 0.05, Listings: 10, Tier: "MID"}, FuturePct: 7.0, SnapTime: t0},
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.3, VelMedListing: -0.1, CV: 0.05, Listings: 10, Tier: "MID"}, FuturePct: -6.0, SnapTime: t0},
+		{Feature: GemFeature{Time: t0, VelMedPrice: -0.2, VelMedListing: 0.3, CV: 0.05, Listings: 10, Tier: "MID"}, FuturePct: 9.0, SnapTime: t0},
+	}
+
+	results := SweepV2(evals, mc, []SigmaConfig{sigma})
+	r := results[0]
+
+	if r.SweetSpot != -1 {
+		t.Errorf("expected SweetSpot=-1 (no band >= 80%%), got %d", r.SweetSpot)
+	}
+
+	// Overall accuracy should be 0%.
+	if !approxEqual(r.OverallAcc, 0.0, 0.1) {
+		t.Errorf("OverallAcc: got %.2f, want 0.0", r.OverallAcc)
+	}
+}
+
+func TestSweepV2_SortedByWeightedScore(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	// Two configs with different accuracy profiles.
+	// Config 1: tight stable threshold → more STABLE signals
+	// Config 2: loose stable threshold → fewer STABLE signals
+	grid := []SigmaConfig{
+		{HERDPriceMult: 2.0, HERDListingMult: 1.5, StablePriceMult: 0.3, BrewingPriceMult: 1.0, DumpPriceMult: 2.0},
+		{HERDPriceMult: 2.0, HERDListingMult: 1.5, StablePriceMult: 1.0, BrewingPriceMult: 1.0, DumpPriceMult: 2.0},
+	}
+
+	evals := []EvalPoint{
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.5, VelMedListing: 0.5, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 0.5, SnapTime: t0},
+		{Feature: GemFeature{Time: t0, VelMedPrice: -0.3, VelMedListing: 0.2, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: -1.0, SnapTime: t0},
+	}
+
+	results := SweepV2(evals, mc, grid)
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// Results must be sorted by WeightedScore descending.
+	if results[0].WeightedScore < results[1].WeightedScore {
+		t.Errorf("results not sorted: [0].WeightedScore=%.2f < [1].WeightedScore=%.2f",
+			results[0].WeightedScore, results[1].WeightedScore)
+	}
+}
+
+func TestSweepV2_EmptyEvals(t *testing.T) {
+	mc := sweepMarketContext(0, 10, 0, 5)
+	sigma := SigmaConfig{
+		HERDPriceMult:    2.0,
+		HERDListingMult:  1.5,
+		StablePriceMult:  0.5,
+		BrewingPriceMult: 1.0,
+		DumpPriceMult:    2.0,
+	}
+
+	results := SweepV2(nil, mc, []SigmaConfig{sigma})
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+
+	if r.TotalEvals != 0 {
+		t.Errorf("TotalEvals: got %d, want 0", r.TotalEvals)
+	}
+	if r.WeightedScore != 0 {
+		t.Errorf("WeightedScore: got %.2f, want 0", r.WeightedScore)
+	}
+	if r.OverallAcc != 0 {
+		t.Errorf("OverallAcc: got %.2f, want 0", r.OverallAcc)
+	}
+	if r.SweetSpot != -1 {
+		t.Errorf("SweetSpot: got %d, want -1", r.SweetSpot)
+	}
+}
+
+func TestSweepV2_EmptyTierDefaultsToLOW(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+	sigma := SigmaConfig{
+		HERDPriceMult:    2.0,
+		HERDListingMult:  1.5,
+		StablePriceMult:  0.5,
+		BrewingPriceMult: 1.0,
+		DumpPriceMult:    2.0,
+	}
+
+	// Feature with empty tier should be counted as LOW.
+	evals := []EvalPoint{
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.05, Listings: 10, Tier: ""}, FuturePct: 0.5, SnapTime: t0},
+	}
+
+	results := SweepV2(evals, mc, []SigmaConfig{sigma})
+	r := results[0]
+
+	// LOW tier should have 1 entry (the empty-tier feature).
+	if !approxEqual(r.LowAcc, 100.0, 0.1) {
+		t.Errorf("LowAcc: got %.2f, want 100.0 (empty tier defaults to LOW)", r.LowAcc)
+	}
+	// TOP/HIGH/MID should be 0.
+	if r.TopAcc != 0 {
+		t.Errorf("TopAcc: got %.2f, want 0", r.TopAcc)
+	}
+	if r.HighAcc != 0 {
+		t.Errorf("HighAcc: got %.2f, want 0", r.HighAcc)
+	}
+	if r.MidAcc != 0 {
+		t.Errorf("MidAcc: got %.2f, want 0", r.MidAcc)
 	}
 }
 

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -1082,3 +1082,76 @@ func (r *Repository) LatestGemSignals(ctx context.Context, variant, tier string,
 
 	return results, nil
 }
+
+// AllGemFeaturesInRange returns all gem feature rows within the given time range (hours ago to now).
+// No variant/tier filters, no limit. Ordered by time, name, variant.
+func (r *Repository) AllGemFeaturesInRange(ctx context.Context, hours int) ([]GemFeature, error) {
+	query := `
+		SELECT time, name, variant, chaos, listings, tier,
+		       vel_short_price, vel_short_listing, vel_med_price, vel_med_listing,
+		       vel_long_price, vel_long_listing,
+		       cv, hist_position, high_7d, low_7d,
+		       flood_count, crash_count, listing_elasticity,
+		       relative_price, relative_listings
+		FROM gem_features
+		WHERE time > NOW() - make_interval(hours => $1)
+		ORDER BY time, name, variant`
+
+	rows, err := r.pool.Query(ctx, query, hours)
+	if err != nil {
+		return nil, fmt.Errorf("lab repo: query all gem features in range: %w", err)
+	}
+	defer rows.Close()
+
+	var results []GemFeature
+	for rows.Next() {
+		var f GemFeature
+		if err := rows.Scan(&f.Time, &f.Name, &f.Variant, &f.Chaos, &f.Listings, &f.Tier,
+			&f.VelShortPrice, &f.VelShortListing, &f.VelMedPrice, &f.VelMedListing,
+			&f.VelLongPrice, &f.VelLongListing,
+			&f.CV, &f.HistPosition, &f.High7d, &f.Low7d,
+			&f.FloodCount, &f.CrashCount, &f.ListingElasticity,
+			&f.RelativePrice, &f.RelativeListings); err != nil {
+			return nil, fmt.Errorf("lab repo: scan gem feature in range: %w", err)
+		}
+		results = append(results, f)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("lab repo: gem features in range rows iteration: %w", err)
+	}
+
+	return results, nil
+}
+
+// SnapshotPricesInRange returns lightweight price observations for transfigured,
+// non-corrupted gems with chaos > 5, within the given time range (hours ago to now).
+func (r *Repository) SnapshotPricesInRange(ctx context.Context, hours int) ([]SnapshotPrice, error) {
+	query := `
+		SELECT time, name, variant, COALESCE(chaos, 0)
+		FROM gem_snapshots
+		WHERE time > NOW() - make_interval(hours => $1)
+		  AND is_transfigured = true
+		  AND is_corrupted = false
+		  AND chaos > 5
+		ORDER BY time, name, variant`
+
+	rows, err := r.pool.Query(ctx, query, hours)
+	if err != nil {
+		return nil, fmt.Errorf("lab repo: query snapshot prices in range: %w", err)
+	}
+	defer rows.Close()
+
+	var results []SnapshotPrice
+	for rows.Next() {
+		var p SnapshotPrice
+		if err := rows.Scan(&p.Time, &p.Name, &p.Variant, &p.Chaos); err != nil {
+			return nil, fmt.Errorf("lab repo: scan snapshot price: %w", err)
+		}
+		results = append(results, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("lab repo: snapshot prices rows iteration: %w", err)
+	}
+
+	return results, nil
+}


### PR DESCRIPTION
## Summary
- Rewrite signal parameter optimizer from absolute thresholds to σ-multiplier sweep (market-relative)
- Add confidence-weighted scoring with tier weights (TOP=2.0, HIGH=1.5, MID=1.0, LOW=0.5)
- Multi-dimensional accuracy reporting: per-tier, per-confidence-band (10-point buckets), per-temporal-phase
- Sweet spot detection: finds minimum confidence threshold where accuracy >= 80%
- New repository methods: `AllGemFeaturesInRange`, `SnapshotPricesInRange` for backtest data loading
- CLI flags: `--top`, `--hours`, `--horizon`, `--json` for flexible analysis

## Tracker
https://softsolution.youtrack.cloud/issue/POE-47

## Test Plan
- [x] All tests pass (644 tests, 0 failures)
- [ ] Manual testing: `go run ./cmd/optimize --top 5`
- [ ] JSON output: `go run ./cmd/optimize --json --top 3`

Generated with [Claude Code](https://claude.com/claude-code)