### PR TITLE
POE-45: Add --validate mode to optimizer CLI

### DIFF
--- a/cmd/optimize/main.go
+++ b/cmd/optimize/main.go
@@ -13,12 +13,25 @@ import (
 	"profitofexile/internal/lab"
 )
 
-// JSONOutput is the structured output for --json mode.
+// JSONOutput is the structured output for --json mode (sweep).
 type JSONOutput struct {
 	Context    JSONContext        `json:"context"`
 	Results    []JSONResult       `json:"results"`
 	BestDetail *JSONBestDetail   `json:"best_detail,omitempty"`
 	Defaults   *JSONDefaults      `json:"defaults,omitempty"`
+}
+
+// JSONValidateOutput is the structured output for --validate --json mode.
+type JSONValidateOutput struct {
+	Context         JSONContext                        `json:"context"`
+	PerSignal       map[string]lab.SignalAccuracy      `json:"per_signal"`
+	ConfusionMatrix map[string]map[string]int          `json:"confusion_matrix"`
+	ConfBands       []lab.ConfidenceBand               `json:"confidence_bands"`
+	PerTier         map[string]float64                 `json:"per_tier"`
+	PerPhase        map[string]float64                 `json:"per_phase"`
+	SweetSpot       int                                `json:"sweet_spot"`
+	TotalEvals      int                                `json:"total_evals"`
+	OverallAcc      float64                            `json:"overall_acc"`
 }
 
 // JSONContext holds metadata about the optimization run.
@@ -69,6 +82,7 @@ func main() {
 	hours := flag.Int("hours", 168, "Backtest time range in hours")
 	horizon := flag.String("horizon", "2h", "Ground truth forward horizon (e.g. 2h, 90m)")
 	jsonMode := flag.Bool("json", false, "Output JSON instead of console table")
+	validate := flag.Bool("validate", false, "Validate current defaults (skip grid sweep)")
 	flag.Parse()
 
 	horizonDur, err := time.ParseDuration(*horizon)
@@ -134,8 +148,23 @@ func main() {
 	}
 
 	if len(evals) == 0 {
-		fmt.Fprintln(os.Stderr, "No eval points — cannot sweep. Check time range and data freshness.")
+		fmt.Fprintln(os.Stderr, "No eval points — cannot run. Check time range and data freshness.")
 		os.Exit(1)
+	}
+
+	if *validate {
+		// Validate current defaults — skip grid sweep.
+		fmt.Fprintf(os.Stderr, "Validating defaults over %d eval points...\n", len(evals))
+		t2 := time.Now()
+		report := lab.ValidateDefaults(evals, *mc)
+		fmt.Fprintf(os.Stderr, "Validation complete in %s\n", time.Since(t2).Round(time.Millisecond))
+
+		if *jsonMode {
+			printValidateJSON(report, mc, len(evals), dropped, *hours, *horizon)
+		} else {
+			printValidateConsole(report, mc, len(evals), dropped, *hours, *horizon)
+		}
+		return
 	}
 
 	// Generate grid and sweep.
@@ -282,6 +311,155 @@ func printJSON(results []lab.SweepResultV2, mc *lab.MarketContext, evalCount, dr
 		ApproxHERDListingMult:  approxHL,
 		ApproxStablePriceMult:  approxSP,
 		ApproxBrewingPriceMult: approxBP,
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		fmt.Fprintf(os.Stderr, "JSON encode error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// printValidateConsole outputs the multi-section human-readable validation report.
+func printValidateConsole(report lab.ValidationReport, mc *lab.MarketContext, evalCount, droppedCount, hours int, horizon string) {
+	// Section 1: Context
+	fmt.Println()
+	fmt.Println("=== SIGNAL VALIDATION — CURRENT DEFAULTS ===")
+	fmt.Printf("  Market time:       %s\n", mc.Time.Format(time.RFC3339))
+	fmt.Printf("  Total gems:        %d\n", mc.TotalGems)
+	fmt.Printf("  Velocity:          mean=%.2f sigma=%.2f\n", mc.VelocityMean, mc.VelocitySigma)
+	fmt.Printf("  Listing velocity:  mean=%.2f sigma=%.2f\n", mc.ListingVelMean, mc.ListingVelSigma)
+	fmt.Printf("  Eval points:       %d (dropped %d)\n", evalCount, droppedCount)
+	fmt.Printf("  Time range:        %dh, horizon=%s\n", hours, horizon)
+	fmt.Printf("  Overall accuracy:  %.1f%%\n", report.OverallAcc)
+	sweetStr := fmt.Sprintf("%d", report.SweetSpot)
+	if report.SweetSpot < 0 {
+		sweetStr = "none"
+	}
+	fmt.Printf("  Sweet spot:        %s\n", sweetStr)
+	fmt.Println()
+
+	// Section 2: Per-signal accuracy scorecard
+	fmt.Println("=== PER-SIGNAL ACCURACY ===")
+	fmt.Println()
+	fmt.Printf("  %-12s %-10s %-8s %-8s %-10s %-10s\n",
+		"Signal", "Predicts", "Count", "Correct", "Accuracy", "AvgConf")
+	fmt.Printf("  %s\n", strings.Repeat("-", 62))
+
+	// Sort signals for deterministic output.
+	signalOrder := []string{"HERD", "DUMPING", "RISING", "FALLING", "RECOVERY", "STABLE", "TRAP"}
+	for _, sig := range signalOrder {
+		sa, ok := report.PerSignal[sig]
+		if !ok {
+			continue
+		}
+		fmt.Printf("  %-12s %-10s %-8d %-8d %-10.1f %-10.1f\n",
+			sa.Signal, sa.Predicted, sa.Count, sa.Correct, sa.Accuracy, sa.AvgConfidence)
+	}
+	// Print any signals not in the standard order.
+	for sig, sa := range report.PerSignal {
+		found := false
+		for _, s := range signalOrder {
+			if s == sig {
+				found = true
+				break
+			}
+		}
+		if !found {
+			fmt.Printf("  %-12s %-10s %-8d %-8d %-10.1f %-10.1f\n",
+				sa.Signal, sa.Predicted, sa.Count, sa.Correct, sa.Accuracy, sa.AvgConfidence)
+		}
+	}
+	fmt.Println()
+
+	// Section 3: Confusion matrix
+	fmt.Println("=== CONFUSION MATRIX (predicted vs actual) ===")
+	fmt.Println()
+	dirs := []string{"UP", "DOWN", "FLAT"}
+	fmt.Printf("  %-12s", "Predicted\\Actual")
+	for _, d := range dirs {
+		fmt.Printf(" %-8s", d)
+	}
+	fmt.Println()
+	fmt.Printf("  %s\n", strings.Repeat("-", 38))
+	for _, predicted := range dirs {
+		fmt.Printf("  %-12s", predicted)
+		row, ok := report.ConfusionMatrix[predicted]
+		for _, actual := range dirs {
+			count := 0
+			if ok {
+				count = row[actual]
+			}
+			fmt.Printf(" %-8d", count)
+		}
+		fmt.Println()
+	}
+	fmt.Println()
+
+	// Section 4: Confidence bands
+	fmt.Println("=== CONFIDENCE BANDS ===")
+	fmt.Println()
+	fmt.Printf("  %-12s %-10s %-8s\n", "Conf Range", "Accuracy", "Count")
+	fmt.Printf("  %s\n", strings.Repeat("-", 32))
+	for _, b := range report.ConfBands {
+		fmt.Printf("  %-12s %-10.1f %-8d\n",
+			fmt.Sprintf("%d-%d", b.MinConf, b.MaxConf), b.Accuracy, b.Count)
+	}
+	fmt.Println()
+
+	// Section 5: Per-tier accuracy
+	fmt.Println("=== PER-TIER ACCURACY ===")
+	fmt.Println()
+	tierOrder := []string{"TOP", "HIGH", "MID", "LOW"}
+	for _, tier := range tierOrder {
+		acc, ok := report.PerTier[tier]
+		if ok {
+			fmt.Printf("  %-12s %.1f%%\n", tier, acc)
+		} else {
+			fmt.Printf("  %-12s (no data)\n", tier)
+		}
+	}
+	fmt.Println()
+
+	// Section 6: Temporal accuracy
+	fmt.Println("=== TEMPORAL ACCURACY ===")
+	fmt.Println()
+	phases := []string{"weekday-peak", "weekday-offpeak", "weekend"}
+	for _, phase := range phases {
+		acc, ok := report.PerPhase[phase]
+		if ok {
+			fmt.Printf("  %-20s %.1f%%\n", phase, acc)
+		} else {
+			fmt.Printf("  %-20s (no data)\n", phase)
+		}
+	}
+	fmt.Println()
+}
+
+// printValidateJSON outputs the structured JSON validation report.
+func printValidateJSON(report lab.ValidationReport, mc *lab.MarketContext, evalCount, droppedCount, hours int, horizon string) {
+	out := JSONValidateOutput{
+		Context: JSONContext{
+			MarketTime:      mc.Time,
+			TotalGems:       mc.TotalGems,
+			VelocityMean:    mc.VelocityMean,
+			VelocitySigma:   mc.VelocitySigma,
+			ListingVelMean:  mc.ListingVelMean,
+			ListingVelSigma: mc.ListingVelSigma,
+			EvalPoints:      evalCount,
+			DroppedPoints:   droppedCount,
+			Hours:           hours,
+			Horizon:         horizon,
+		},
+		PerSignal:       report.PerSignal,
+		ConfusionMatrix: report.ConfusionMatrix,
+		ConfBands:       report.ConfBands,
+		PerTier:         report.PerTier,
+		PerPhase:        report.PerPhase,
+		SweetSpot:       report.SweetSpot,
+		TotalEvals:      report.TotalEvals,
+		OverallAcc:      report.OverallAcc,
 	}
 
 	enc := json.NewEncoder(os.Stdout)

--- a/internal/lab/optimizer.go
+++ b/internal/lab/optimizer.go
@@ -457,3 +457,222 @@ func GenerateSigmaGrid() []SigmaConfig {
 
 	return grid
 }
+
+// SignalAccuracy holds per-signal accuracy metrics for validation reporting.
+type SignalAccuracy struct {
+	Signal        string  // signal name (e.g. HERD, DUMPING, STABLE)
+	Predicted     string  // predicted direction (UP, DOWN, FLAT)
+	Count         int     // total times this signal fired
+	Correct       int     // how many times the prediction was correct
+	Accuracy      float64 // Correct/Count * 100
+	AvgConfidence float64 // average confidence score when this signal fires
+}
+
+// ValidationReport holds the full output of ValidateDefaults.
+type ValidationReport struct {
+	PerSignal       map[string]SignalAccuracy   // keyed by signal name
+	ConfusionMatrix map[string]map[string]int   // [predicted_direction][actual_direction] = count
+	ConfBands       []ConfidenceBand
+	PerTier         map[string]float64
+	PerPhase        map[string]float64
+	SweetSpot       int
+	TotalEvals      int
+	OverallAcc      float64
+}
+
+// ValidateDefaults evaluates the current default signal configuration against
+// the provided eval points, producing a detailed accuracy breakdown by signal,
+// confusion matrix, confidence bands, tier, and temporal phase.
+func ValidateDefaults(evals []EvalPoint, mc MarketContext) ValidationReport {
+	report := ValidationReport{
+		PerSignal:       make(map[string]SignalAccuracy),
+		ConfusionMatrix: make(map[string]map[string]int),
+		PerTier:         make(map[string]float64),
+		PerPhase:        make(map[string]float64),
+		SweetSpot:       -1,
+	}
+
+	if len(evals) == 0 {
+		return report
+	}
+
+	cfg := DefaultSignalConfig()
+
+	// Per-tier accumulators.
+	tiers := map[string]*sweepAcc{
+		"TOP":  {},
+		"HIGH": {},
+		"MID":  {},
+		"LOW":  {},
+	}
+
+	// Confidence band accumulators (0-9, 10-19, ..., 90-100).
+	bands := make([]sweepAcc, 10)
+
+	// Temporal phase accumulators.
+	phases := map[string]*sweepAcc{
+		"weekend":         {},
+		"weekday-peak":    {},
+		"weekday-offpeak": {},
+	}
+
+	// Per-signal accumulators.
+	type signalAcc struct {
+		count      int
+		correct    int
+		confSum    float64
+		predicted  string
+	}
+	signalAccs := make(map[string]*signalAcc)
+
+	// Initialize confusion matrix directions.
+	for _, dir := range []string{"UP", "DOWN", "FLAT"} {
+		report.ConfusionMatrix[dir] = make(map[string]int)
+	}
+
+	var overallCorrect int
+
+	for _, ep := range evals {
+		signal := classifySignalWithConfig(
+			ep.Feature.VelMedPrice,
+			ep.Feature.VelMedListing,
+			ep.Feature.CV,
+			ep.Feature.Listings,
+			cfg,
+		)
+
+		confidence, _ := computeConfidence(signal, ep.Feature, mc, ep.SnapTime)
+
+		predicted := predictedDirection(signal)
+		actual := directionFromChange(ep.FuturePct)
+		correct := predicted == actual
+
+		if correct {
+			overallCorrect++
+		}
+
+		// Per-signal accumulation.
+		sa, ok := signalAccs[signal]
+		if !ok {
+			sa = &signalAcc{predicted: predicted}
+			signalAccs[signal] = sa
+		}
+		sa.count++
+		if correct {
+			sa.correct++
+		}
+		sa.confSum += float64(confidence)
+
+		// Confusion matrix.
+		if _, ok := report.ConfusionMatrix[predicted]; !ok {
+			report.ConfusionMatrix[predicted] = make(map[string]int)
+		}
+		report.ConfusionMatrix[predicted][actual]++
+
+		// Per-tier accuracy.
+		tier := ep.Feature.Tier
+		if tier == "" {
+			tier = "LOW"
+		}
+		ta, ok := tiers[tier]
+		if !ok {
+			ta = &sweepAcc{}
+			tiers[tier] = ta
+		}
+		ta.total++
+		if correct {
+			ta.correct++
+		}
+
+		// Confidence band accumulation.
+		bandIdx := confidence / 10
+		if bandIdx > 9 {
+			bandIdx = 9
+		}
+		bands[bandIdx].total++
+		if correct {
+			bands[bandIdx].correct++
+		}
+
+		// Temporal phase.
+		phase := classifyTemporalPhase(ep.SnapTime)
+		pa := phases[phase]
+		pa.total++
+		if correct {
+			pa.correct++
+		}
+	}
+
+	// Build per-signal map.
+	for sig, sa := range signalAccs {
+		var acc float64
+		if sa.count > 0 {
+			acc = float64(sa.correct) / float64(sa.count) * 100
+		}
+		var avgConf float64
+		if sa.count > 0 {
+			avgConf = sa.confSum / float64(sa.count)
+		}
+		report.PerSignal[sig] = SignalAccuracy{
+			Signal:        sig,
+			Predicted:     sa.predicted,
+			Count:         sa.count,
+			Correct:       sa.correct,
+			Accuracy:      acc,
+			AvgConfidence: avgConf,
+		}
+	}
+
+	// Build confidence bands.
+	confBands := make([]ConfidenceBand, 0, 10)
+	for i, b := range bands {
+		if b.total == 0 {
+			continue
+		}
+		confBands = append(confBands, ConfidenceBand{
+			MinConf:  i * 10,
+			MaxConf:  i*10 + 9,
+			Accuracy: float64(b.correct) / float64(b.total) * 100,
+			Count:    b.total,
+		})
+	}
+	if len(confBands) > 0 && confBands[len(confBands)-1].MinConf == 90 {
+		confBands[len(confBands)-1].MaxConf = 100
+	}
+	report.ConfBands = confBands
+
+	// Compute sweet spot.
+	cumCorrect := 0
+	cumTotal := 0
+	for i := len(bands) - 1; i >= 0; i-- {
+		cumCorrect += bands[i].correct
+		cumTotal += bands[i].total
+		if cumTotal > 0 {
+			cumAcc := float64(cumCorrect) / float64(cumTotal) * 100
+			if cumAcc >= 80 {
+				report.SweetSpot = i * 10
+			} else {
+				break
+			}
+		}
+	}
+
+	// Build per-tier map.
+	for tier, ta := range tiers {
+		if ta.total > 0 {
+			report.PerTier[tier] = float64(ta.correct) / float64(ta.total) * 100
+		}
+	}
+
+	// Build per-phase map.
+	for phase, pa := range phases {
+		if pa.total > 0 {
+			report.PerPhase[phase] = float64(pa.correct) / float64(pa.total) * 100
+		}
+	}
+
+	report.TotalEvals = len(evals)
+	report.OverallAcc = float64(overallCorrect) / float64(len(evals)) * 100
+
+	return report
+}

--- a/internal/lab/optimizer_test.go
+++ b/internal/lab/optimizer_test.go
@@ -826,3 +826,264 @@ func TestSweepV2_EmptyTierDefaultsToLOW(t *testing.T) {
 	}
 }
 
+// --- ValidateDefaults tests ---
+
+func TestValidateDefaults_PerSignalAccuracy(t *testing.T) {
+	// Wednesday 16:00 UTC = weekday-peak
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	// Use DefaultSignalConfig to compute STABLE threshold:
+	// StablePriceVel=2, StableListingVel=3
+	// STABLE fires when |priceVel|<2 and |listingVel|<3.
+
+	evals := []EvalPoint{
+		// STABLE signal (low vel), FLAT actual -> correct
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.5, VelMedListing: 0.5, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 0.5, SnapTime: t0},
+		// STABLE signal, FLAT actual -> correct
+		{Feature: GemFeature{Time: t0, VelMedPrice: -0.3, VelMedListing: 0.2, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: -1.0, SnapTime: t0},
+		// STABLE signal, UP actual -> wrong
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.2, VelMedListing: -0.1, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 5.0, SnapTime: t0},
+	}
+
+	report := ValidateDefaults(evals, mc)
+
+	if report.TotalEvals != 3 {
+		t.Errorf("TotalEvals: got %d, want 3", report.TotalEvals)
+	}
+
+	// All should classify as STABLE.
+	sa, ok := report.PerSignal["STABLE"]
+	if !ok {
+		t.Fatal("expected STABLE signal in PerSignal")
+	}
+	if sa.Count != 3 {
+		t.Errorf("STABLE count: got %d, want 3", sa.Count)
+	}
+	if sa.Correct != 2 {
+		t.Errorf("STABLE correct: got %d, want 2", sa.Correct)
+	}
+	if !approxEqual(sa.Accuracy, 66.67, 0.1) {
+		t.Errorf("STABLE accuracy: got %.2f, want ~66.67", sa.Accuracy)
+	}
+	if sa.Predicted != "FLAT" {
+		t.Errorf("STABLE predicted: got %q, want FLAT", sa.Predicted)
+	}
+	if sa.AvgConfidence <= 0 {
+		t.Error("STABLE AvgConfidence should be > 0")
+	}
+}
+
+func TestValidateDefaults_ConfusionMatrix(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	// STABLE predicts FLAT. Create outcomes: 3 FLAT, 1 UP, 1 DOWN.
+	evals := []EvalPoint{
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 0.5, SnapTime: t0},   // FLAT
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.2, VelMedListing: 0.2, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 1.0, SnapTime: t0},   // FLAT
+		{Feature: GemFeature{Time: t0, VelMedPrice: -0.1, VelMedListing: 0.1, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: -0.5, SnapTime: t0}, // FLAT
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.3, VelMedListing: -0.2, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 5.0, SnapTime: t0},  // UP
+		{Feature: GemFeature{Time: t0, VelMedPrice: -0.4, VelMedListing: 0.3, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: -5.0, SnapTime: t0}, // DOWN
+	}
+
+	report := ValidateDefaults(evals, mc)
+
+	// All signals are STABLE => predicted FLAT.
+	flatRow, ok := report.ConfusionMatrix["FLAT"]
+	if !ok {
+		t.Fatal("expected FLAT row in confusion matrix")
+	}
+	if flatRow["FLAT"] != 3 {
+		t.Errorf("ConfusionMatrix[FLAT][FLAT]: got %d, want 3", flatRow["FLAT"])
+	}
+	if flatRow["UP"] != 1 {
+		t.Errorf("ConfusionMatrix[FLAT][UP]: got %d, want 1", flatRow["UP"])
+	}
+	if flatRow["DOWN"] != 1 {
+		t.Errorf("ConfusionMatrix[FLAT][DOWN]: got %d, want 1", flatRow["DOWN"])
+	}
+}
+
+func TestValidateDefaults_SweetSpot(t *testing.T) {
+	t0 := time.Date(2026, 3, 17, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	// 10 STABLE points with high agreement: 9 correct, 1 wrong -> 90% accuracy.
+	// All land in the same confidence band, so sweet spot should be found.
+	var evals []EvalPoint
+	for i := 0; i < 9; i++ {
+		evals = append(evals, EvalPoint{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.05,
+				Listings: 15, Tier: "HIGH",
+				VelShortPrice: 0.1, VelLongPrice: 0.1,
+			},
+			FuturePct: 0.5,
+			SnapTime:  t0,
+		})
+	}
+	evals = append(evals, EvalPoint{
+		Feature: GemFeature{
+			Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.05,
+			Listings: 15, Tier: "HIGH",
+			VelShortPrice: 0.1, VelLongPrice: 0.1,
+		},
+		FuturePct: 5.0, // UP = wrong for STABLE
+		SnapTime:  t0,
+	})
+
+	report := ValidateDefaults(evals, mc)
+
+	if report.SweetSpot == -1 {
+		t.Error("expected SweetSpot to be found (90% accuracy), got -1")
+	}
+}
+
+func TestValidateDefaults_EmptyEvals(t *testing.T) {
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	report := ValidateDefaults(nil, mc)
+
+	if report.TotalEvals != 0 {
+		t.Errorf("TotalEvals: got %d, want 0", report.TotalEvals)
+	}
+	if report.OverallAcc != 0 {
+		t.Errorf("OverallAcc: got %.2f, want 0", report.OverallAcc)
+	}
+	if report.SweetSpot != -1 {
+		t.Errorf("SweetSpot: got %d, want -1", report.SweetSpot)
+	}
+	if len(report.PerSignal) != 0 {
+		t.Errorf("PerSignal: expected empty, got %d entries", len(report.PerSignal))
+	}
+	if len(report.ConfBands) != 0 {
+		t.Errorf("ConfBands: expected empty, got %d entries", len(report.ConfBands))
+	}
+}
+
+func TestValidateDefaults_PerTier(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	evals := []EvalPoint{
+		// TOP: STABLE -> FLAT, actual FLAT -> correct
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.1, Listings: 10, Tier: "TOP"}, FuturePct: 0.5, SnapTime: t0},
+		// HIGH: STABLE -> FLAT, actual UP -> wrong
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.2, VelMedListing: 0.1, CV: 0.1, Listings: 10, Tier: "HIGH"}, FuturePct: 5.0, SnapTime: t0},
+		// MID: STABLE -> FLAT, actual FLAT -> correct
+		{Feature: GemFeature{Time: t0, VelMedPrice: -0.1, VelMedListing: 0.2, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 1.0, SnapTime: t0},
+		// LOW: STABLE -> FLAT, actual DOWN -> wrong
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.3, VelMedListing: -0.1, CV: 0.1, Listings: 10, Tier: "LOW"}, FuturePct: -5.0, SnapTime: t0},
+	}
+
+	report := ValidateDefaults(evals, mc)
+
+	if !approxEqual(report.PerTier["TOP"], 100.0, 0.1) {
+		t.Errorf("PerTier[TOP]: got %.2f, want 100.0", report.PerTier["TOP"])
+	}
+	if !approxEqual(report.PerTier["HIGH"], 0.0, 0.1) {
+		t.Errorf("PerTier[HIGH]: got %.2f, want 0.0", report.PerTier["HIGH"])
+	}
+	if !approxEqual(report.PerTier["MID"], 100.0, 0.1) {
+		t.Errorf("PerTier[MID]: got %.2f, want 100.0", report.PerTier["MID"])
+	}
+	if !approxEqual(report.PerTier["LOW"], 0.0, 0.1) {
+		t.Errorf("PerTier[LOW]: got %.2f, want 0.0", report.PerTier["LOW"])
+	}
+}
+
+func TestValidateDefaults_PerPhase(t *testing.T) {
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	// Saturday = weekend, Wednesday 16:00 = weekday-peak, Monday 08:00 = weekday-offpeak
+	weekend := time.Date(2026, 3, 14, 16, 0, 0, 0, time.UTC)   // Saturday
+	peak := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)      // Wednesday
+	offpeak := time.Date(2026, 3, 16, 8, 0, 0, 0, time.UTC)    // Monday
+
+	evals := []EvalPoint{
+		// Weekend: correct
+		{Feature: GemFeature{Time: weekend, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 0.5, SnapTime: weekend},
+		// Weekday-peak: wrong
+		{Feature: GemFeature{Time: peak, VelMedPrice: 0.2, VelMedListing: 0.2, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 5.0, SnapTime: peak},
+		// Weekday-offpeak: correct
+		{Feature: GemFeature{Time: offpeak, VelMedPrice: -0.1, VelMedListing: 0.1, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 1.0, SnapTime: offpeak},
+	}
+
+	report := ValidateDefaults(evals, mc)
+
+	if !approxEqual(report.PerPhase["weekend"], 100.0, 0.1) {
+		t.Errorf("PerPhase[weekend]: got %.2f, want 100.0", report.PerPhase["weekend"])
+	}
+	if !approxEqual(report.PerPhase["weekday-peak"], 0.0, 0.1) {
+		t.Errorf("PerPhase[weekday-peak]: got %.2f, want 0.0", report.PerPhase["weekday-peak"])
+	}
+	if !approxEqual(report.PerPhase["weekday-offpeak"], 100.0, 0.1) {
+		t.Errorf("PerPhase[weekday-offpeak]: got %.2f, want 100.0", report.PerPhase["weekday-offpeak"])
+	}
+}
+
+func TestValidateDefaults_OverallAccuracy(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	// 5 eval points, 3 correct (STABLE->FLAT), 2 wrong
+	evals := []EvalPoint{
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 0.5, SnapTime: t0},
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.2, VelMedListing: 0.2, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: -1.0, SnapTime: t0},
+		{Feature: GemFeature{Time: t0, VelMedPrice: -0.1, VelMedListing: 0.1, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 0.0, SnapTime: t0},
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.3, VelMedListing: -0.1, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 8.0, SnapTime: t0},
+		{Feature: GemFeature{Time: t0, VelMedPrice: -0.2, VelMedListing: 0.3, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: -8.0, SnapTime: t0},
+	}
+
+	report := ValidateDefaults(evals, mc)
+
+	if !approxEqual(report.OverallAcc, 60.0, 0.1) {
+		t.Errorf("OverallAcc: got %.2f, want 60.0", report.OverallAcc)
+	}
+}
+
+func TestValidateDefaults_MultipleSignalTypes(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	// DefaultSignalConfig: DumpPriceVel=-5, DumpListingVel=5
+	// DUMPING: priceVel < -5 && listingVel > 5
+	// RISING: priceVel > 0 (after other checks fail)
+	// STABLE: |priceVel| < 2 && |listingVel| < 3
+
+	evals := []EvalPoint{
+		// STABLE: predicts FLAT, actual FLAT -> correct
+		{Feature: GemFeature{Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 0.5, SnapTime: t0},
+		// DUMPING: priceVel=-10 < -5, listingVel=10 > 5 -> predicts DOWN, actual DOWN -> correct
+		{Feature: GemFeature{Time: t0, VelMedPrice: -10, VelMedListing: 10, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: -8.0, SnapTime: t0},
+		// RISING: priceVel=3 > 0 (not STABLE: |3|>2), predicts UP, actual UP -> correct
+		{Feature: GemFeature{Time: t0, VelMedPrice: 3, VelMedListing: 5, CV: 0.1, Listings: 10, Tier: "MID"}, FuturePct: 5.0, SnapTime: t0},
+	}
+
+	report := ValidateDefaults(evals, mc)
+
+	if len(report.PerSignal) < 2 {
+		t.Errorf("expected at least 2 signal types, got %d", len(report.PerSignal))
+	}
+
+	// Check STABLE exists.
+	if _, ok := report.PerSignal["STABLE"]; !ok {
+		t.Error("expected STABLE signal in PerSignal")
+	}
+
+	// Check DUMPING exists.
+	if sa, ok := report.PerSignal["DUMPING"]; ok {
+		if sa.Predicted != "DOWN" {
+			t.Errorf("DUMPING predicted: got %q, want DOWN", sa.Predicted)
+		}
+	} else {
+		t.Error("expected DUMPING signal in PerSignal")
+	}
+
+	// Overall: all 3 correct = 100%.
+	if !approxEqual(report.OverallAcc, 100.0, 0.1) {
+		t.Errorf("OverallAcc: got %.2f, want 100.0", report.OverallAcc)
+	}
+}
+


### PR DESCRIPTION
## Summary
- Add ValidateDefaults() function with per-signal accuracy scorecard and confusion matrix
- Add --validate flag to optimizer CLI (skips grid sweep, evaluates current defaults)
- Per-signal breakdown: HERD, DUMPING, RISING, FALLING, STABLE, TRAP, RECOVERY accuracy + avg confidence
- Confusion matrix: predicted direction vs actual outcome
- Reuses existing optimizer infrastructure (EvalPoint, BuildEvalPoints, confidence scoring)
- Console + JSON output modes

## Tracker
https://softsolution.youtrack.cloud/issue/POE-45

## Test Plan
- [x] All 652 tests pass (go test ./...)
- [x] ValidateDefaults unit tests (per-signal accuracy, confusion matrix, sweet spot)
- [x] Build clean

Generated with [Claude Code](https://claude.com/claude-code)