### PR TITLE
feat(frontend): add risk-adjusted display — sell confidence, quick-sell, 7d floor

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,6 +26,7 @@ export interface GemPlay {
 	color: 'RED' | 'GREEN' | 'BLUE';
 	roi: number;
 	roiPercent: number;
+	weightedRoi: number;
 	signal: string;
 	cv: number;
 	windowSignal: string;
@@ -46,6 +47,10 @@ export interface GemPlay {
 	sellReason: string;
 	sellability: number;
 	sellabilityLabel: SellabilityLabel;
+	low7d: number;
+	high7d: number;
+	histPosition: number;
+	sellConfidence: string;
 }
 
 export interface SignalTransition {
@@ -120,12 +125,15 @@ export interface CompareGem {
 	color: 'RED' | 'GREEN' | 'BLUE';
 	roi: number;
 	roiPercent: number;
+	weightedRoi: number;
 	signal: string;
 	cv: number;
 	transListings: number;
 	transVelocity: number;
 	baseListings: number;
 	baseVelocity: number;
+	basePrice: number;
+	transPrice: number;
 	liquidityTier: string;
 	windowSignal: string;
 	sparkline: number[];
@@ -137,6 +145,12 @@ export interface CompareGem {
 	sellReason: string;
 	sellability: number;
 	sellabilityLabel: SellabilityLabel;
+	low7d: number;
+	high7d: number;
+	histPosition: number;
+	sellConfidence: string;
+	sellConfidenceReason: string;
+	quickSellPrice: number;
 }
 
 // --- API helpers ---
@@ -167,6 +181,7 @@ function mapCollectiveRow(r: any): GemPlay {
 		color: r.gemColor || '',
 		roi: Math.round(r.roi || 0),
 		roiPercent: Math.round(r.roiPct || 0),
+		weightedRoi: Math.round(r.weightedRoi || 0),
 		signal: r.signal || '',
 		cv: Math.round(r.cv || 0),
 		windowSignal: r.windowSignal || '',
@@ -187,6 +202,10 @@ function mapCollectiveRow(r: any): GemPlay {
 		sellReason: r.sellReason || '',
 		sellability: r.sellability || 0,
 		sellabilityLabel: (r.sellabilityLabel || '') as SellabilityLabel,
+		low7d: Math.round(r.low7d || 0),
+		high7d: Math.round(r.high7d || 0),
+		histPosition: Math.round(r.histPosition || 0),
+		sellConfidence: r.sellConfidence || '',
 	};
 }
 
@@ -201,12 +220,15 @@ function mapCompareRow(r: any): CompareGem {
 		color: r.gemColor || '',
 		roi: Math.round(r.roi || 0),
 		roiPercent: Math.round(r.roiPct || 0),
+		weightedRoi: Math.round(r.weightedRoi || 0),
 		signal: r.signal || '',
 		cv: Math.round(r.cv || 0),
 		transListings: r.transListings || r.transfiguredListings || 0,
 		transVelocity: Math.round(r.priceVelocity || 0),
 		baseListings: r.baseListings || 0,
 		baseVelocity: Math.round(r.listingVelocity || 0),
+		basePrice: Math.round(r.basePrice || 0),
+		transPrice: Math.round(r.transfiguredPrice || 0),
 		liquidityTier: r.liquidityTier || '',
 		windowSignal: r.windowSignal || '',
 		sparkline,
@@ -218,6 +240,12 @@ function mapCompareRow(r: any): CompareGem {
 		sellReason: r.sellReason || '',
 		sellability: r.sellability || 0,
 		sellabilityLabel: (r.sellabilityLabel || '') as SellabilityLabel,
+		low7d: Math.round(r.low7d || 0),
+		high7d: Math.round(r.high7d || 0),
+		histPosition: Math.round(r.histPosition || 0),
+		sellConfidence: r.sellConfidence || '',
+		sellConfidenceReason: r.sellConfidenceReason || '',
+		quickSellPrice: Math.round(r.quickSellPrice || 0),
 	};
 }
 

--- a/frontend/src/lib/tooltips.ts
+++ b/frontend/src/lib/tooltips.ts
@@ -53,6 +53,12 @@ export const METRIC_TOOLTIPS: Record<string, string> = {
 	'\u039412h': 'Change over the last 12 hours. Shows recent momentum. \u2191 = increasing, \u2193 = decreasing.',
 };
 
+export const SELL_CONFIDENCE_TOOLTIPS: Record<string, string> = {
+	GREEN: 'Liquid market, stable price \u2014 will sell near listed price',
+	YELLOW: 'Moderate risk \u2014 may need patience or small undercut',
+	RED: 'Thin market or volatile \u2014 significant gap between listed and realizable price',
+};
+
 export const LIQUIDITY_TOOLTIPS: Record<string, string> = {
 	HIGH: 'High liquidity \u2014 herd gets absorbed, safe to farm. Base listings \u226580% of market average.',
 	MED: 'Medium liquidity \u2014 windows open and close. Base listings 30-80% of market average.',

--- a/frontend/src/routes/lab/components/BestPlays.svelte
+++ b/frontend/src/routes/lab/components/BestPlays.svelte
@@ -7,7 +7,8 @@
 	import Select from '$lib/components/Select.svelte';
 
 	const SORT_OPTIONS = [
-		{ value: 'roi', label: 'ROI' },
+		{ value: 'riskAdjusted', label: 'Risk-Adj ROI' },
+		{ value: 'roi', label: 'Raw ROI' },
 		{ value: 'roiPercent', label: 'ROI%' },
 	];
 
@@ -23,7 +24,7 @@
 		league?: string;
 	} = $props();
 
-	let sortBy = $state<'roi' | 'roiPercent'>('roi');
+	let sortBy = $state<'riskAdjusted' | 'roi' | 'roiPercent'>('riskAdjusted');
 	let budget = $state('');
 	let expandedRow = $state<number | null>(null);
 
@@ -65,6 +66,9 @@
 		if (b > 0) {
 			filtered = filtered.filter((p) => p.basePrice <= b);
 			if (b <= 50) sortBy = 'roiPercent';
+		}
+		if (sortBy === 'riskAdjusted') {
+			return filtered.sort((a, b) => b.weightedRoi - a.weightedRoi);
 		}
 		return filtered.sort((a, b) =>
 			sortBy === 'roi' ? b.roi - a.roi : b.roiPercent - a.roiPercent
@@ -127,7 +131,7 @@
 			<th class="col-name" title="Transfigured gem name">Gem</th>
 			{#if showVariantColumn}<th class="col-var" title="Gem variant: level/quality (e.g. 20/20 = level 20, 20% quality)">Var</th>{/if}
 			<th class="col-tier" title="Price tier — TOP (high value), MID (moderate), LOW (budget). Auto-scales with league economy.">Tier</th>
-			<th class="col-num" title={METRIC_TOOLTIPS.ROI}>ROI</th>
+			<th class="col-num" title={sortBy === 'riskAdjusted' ? 'Risk-adjusted ROI: raw ROI weighted by sellability and market stability' : METRIC_TOOLTIPS.ROI}>{sortBy === 'riskAdjusted' ? 'Adj ROI' : 'ROI'}</th>
 			<th class="col-signal" title="Primary signal: STABLE, UNCERTAIN, DUMPING, HERD, RECOVERY, TRAP. Based on price velocity, listing changes, and historical position.">Signal</th>
 			<th class="col-sell" title="Sellability score 0-100. How quickly you can sell this gem. Based on listings, demand velocity, and price tier.">Sell</th>
 			<th class="col-signals" title="Window: CLOSED, BREWING, OPENING, OPEN, CLOSING, EXHAUSTED. Advanced: BREAKOUT, COMEBACK, POTENTIAL, PRICE_MANIPULATION.">Signals</th>
@@ -150,8 +154,13 @@
 				<td class="col-tier">
 					<span class="tier-badge tier-{gem.priceTier.toLowerCase()}">{gem.priceTier}</span>
 				</td>
-				<td class="col-num roi-val">{gem.roi}c</td>
-				<td class="col-signal"><SignalBadge signal={gem.signal} /></td>
+				<td class="col-num roi-val">{sortBy === 'riskAdjusted' ? gem.weightedRoi : gem.roi}c</td>
+				<td class="col-signal">
+					<SignalBadge signal={gem.signal} />
+					{#if gem.sellConfidence}
+						<SignalBadge signal={gem.sellConfidence} type="confidence" />
+					{/if}
+				</td>
 				<td class="col-sell">
 					<span class="sell-score sell-{gem.sellabilityLabel.toLowerCase().replace(' ', '-')}" title="{gem.sellabilityLabel} ({gem.sellability})">{gem.sellability}</span>
 				</td>
@@ -335,8 +344,11 @@
 		white-space: nowrap;
 	}
 	.col-signal {
-		width: 110px;
+		width: 180px;
 		white-space: nowrap;
+	}
+	.col-signal :global(.signal-badge + .signal-badge) {
+		margin-left: 4px;
 	}
 	.col-signals {
 		width: 180px;

--- a/frontend/src/routes/lab/components/Comparator.svelte
+++ b/frontend/src/routes/lab/components/Comparator.svelte
@@ -370,6 +370,11 @@
 					<div class="card-row">
 						<span class="roi" title={METRIC_TOOLTIPS.ROI}>{gem.roi}c</span>
 						<SignalBadge signal={gem.signal} />
+						{#if gem.sellConfidence}
+							<span title={gem.sellConfidenceReason || ''}>
+								<SignalBadge signal={gem.sellConfidence} type="confidence" />
+							</span>
+						{/if}
 						<span class="cv" title={METRIC_TOOLTIPS.CV}>CV: {gem.cv}%</span>
 					</div>
 					<div class="card-row small">
@@ -377,6 +382,29 @@
 						<span class="velocity-inline" title="Price change over last 12 hours">({gem.transVelocity > 0 ? '+' : ''}{gem.transVelocity * 12}c /12h)</span>
 						<span class="liq" title="Liquidity tier">{gem.liquidityTier}</span>
 					</div>
+					<div class="price-context">
+						<div class="price-row">
+							<span>Listed: {gem.transPrice}c</span>
+							{#if gem.quickSellPrice > 0}
+								<span class="quick-sell">Quick-sell: ~{gem.quickSellPrice}c</span>
+							{/if}
+						</div>
+						{#if gem.low7d > 0 || gem.high7d > 0}
+							<div class="range-context">
+								<span class="range-label">7d floor: {gem.low7d}c</span>
+								<span class="range-sep">&middot;</span>
+								<span class="range-label">7d high: {gem.high7d}c</span>
+								<div class="range-bar">
+									<div class="range-fill" style="width: {gem.histPosition}%"></div>
+								</div>
+							</div>
+						{/if}
+					</div>
+					{#if gem.signal === 'DUMPING' || gem.signal === 'TRAP'}
+						<div class="listing-warning">
+							{gem.signal === 'DUMPING' ? 'Listings rising — price may drop' : 'Price trap — avoid'}
+						</div>
+					{/if}
 
 					<div class="urgency-slot">
 						{#if gem.sellUrgency}
@@ -1067,5 +1095,56 @@
 		color: var(--color-lab-text-secondary);
 		font-size: 0.7rem;
 		margin-left: 4px;
+	}
+
+	/* Price context section */
+	.price-context {
+		margin: 8px 0;
+		font-size: 0.875rem;
+	}
+	.price-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		color: var(--color-lab-text-secondary);
+	}
+	.quick-sell {
+		color: var(--color-lab-text-secondary);
+		opacity: 0.7;
+	}
+	.range-context {
+		margin-top: 6px;
+		color: var(--color-lab-text-secondary);
+		font-size: 0.8125rem;
+	}
+	.range-label {
+		color: var(--color-lab-text-secondary);
+	}
+	.range-sep {
+		margin: 0 4px;
+		opacity: 0.5;
+	}
+	.range-bar {
+		width: 100%;
+		height: 4px;
+		background: rgba(42, 45, 55, 0.8);
+		border-radius: 2px;
+		margin-top: 4px;
+		overflow: hidden;
+	}
+	.range-fill {
+		height: 100%;
+		background: #60a5fa;
+		border-radius: 2px;
+		transition: width 0.3s ease;
+	}
+	.listing-warning {
+		color: var(--color-lab-red);
+		font-size: 0.875rem;
+		font-weight: 600;
+		margin-top: 8px;
+		padding: 6px 10px;
+		background: rgba(239, 68, 68, 0.08);
+		border-left: 3px solid var(--color-lab-red);
 	}
 </style>

--- a/frontend/src/routes/lab/components/Comparator.svelte
+++ b/frontend/src/routes/lab/components/Comparator.svelte
@@ -395,7 +395,7 @@
 								<span class="range-sep">&middot;</span>
 								<span class="range-label">7d high: {gem.high7d}c</span>
 								<div class="range-bar">
-									<div class="range-fill" style="width: {gem.histPosition}%"></div>
+									<div class="range-fill" style="width: {Math.min(100, Math.max(0, gem.histPosition))}%"></div>
 								</div>
 							</div>
 						{/if}

--- a/frontend/src/routes/lab/components/SignalBadge.svelte
+++ b/frontend/src/routes/lab/components/SignalBadge.svelte
@@ -3,9 +3,10 @@
 		SIGNAL_TOOLTIPS,
 		WINDOW_TOOLTIPS,
 		ADVANCED_TOOLTIPS,
+		SELL_CONFIDENCE_TOOLTIPS,
 	} from '$lib/tooltips';
 
-	let { signal, type = 'signal' }: { signal: string; type?: 'signal' | 'window' | 'advanced' } =
+	let { signal, type = 'signal' }: { signal: string; type?: 'signal' | 'window' | 'advanced' | 'confidence' } =
 		$props();
 
 	const SIGNAL_STYLES: Record<string, { prefix: string; cssClass: string }> = {
@@ -33,16 +34,25 @@
 		BREAKOUT: { prefix: '🚀', cssClass: 'badge-green' },
 	};
 
+	const CONFIDENCE_STYLES: Record<string, { prefix: string; cssClass: string }> = {
+		GREEN:  { prefix: '\u2713', cssClass: 'badge-green' },
+		YELLOW: { prefix: '\u26A0', cssClass: 'badge-yellow' },
+		RED:    { prefix: '\u2717', cssClass: 'badge-red' },
+	};
+
 	function getStyle() {
 		if (type === 'window') return WINDOW_STYLES[signal] || { prefix: '', cssClass: 'badge-muted' };
 		if (type === 'advanced')
 			return ADVANCED_STYLES[signal] || { prefix: '', cssClass: 'badge-muted' };
+		if (type === 'confidence')
+			return CONFIDENCE_STYLES[signal] || { prefix: '', cssClass: 'badge-muted' };
 		return SIGNAL_STYLES[signal] || { prefix: '', cssClass: 'badge-muted' };
 	}
 
 	function getTooltip() {
 		if (type === 'window') return WINDOW_TOOLTIPS[signal] || '';
 		if (type === 'advanced') return ADVANCED_TOOLTIPS[signal] || '';
+		if (type === 'confidence') return SELL_CONFIDENCE_TOOLTIPS[signal] || '';
 		return SIGNAL_TOOLTIPS[signal] || '';
 	}
 

--- a/internal/lab/collective.go
+++ b/internal/lab/collective.go
@@ -1,6 +1,9 @@
 package lab
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+)
 
 // CollectiveResult is a cross-analyzer "what to farm now" entry combining
 // transfigure ROI with trend signals.
@@ -33,6 +36,10 @@ type CollectiveResult struct {
 	SellReason       string `json:"sellReason"`
 	Sellability      int    `json:"sellability"`
 	SellabilityLabel string `json:"sellabilityLabel"`
+	// From features/signals (risk-adjusted display)
+	Low7d          float64 `json:"low7d"`
+	High7d         float64 `json:"high7d"`
+	SellConfidence string  `json:"sellConfidence"`
 }
 
 // CompareResult is a side-by-side gem comparison entry with sparkline data.
@@ -63,6 +70,13 @@ type CompareResult struct {
 	BaseListings         int              `json:"baseListings"`
 	LiquidityTier        string           `json:"liquidityTier"`
 	TransListings        int              `json:"transListings"`
+	// Risk-adjusted display fields (from features/signals)
+	WeightedROI        float64 `json:"weightedRoi"`
+	Low7d              float64 `json:"low7d"`
+	High7d             float64 `json:"high7d"`
+	SellConfidence     string  `json:"sellConfidence"`
+	SellConfidenceReason string `json:"sellConfidenceReason"`
+	QuickSellPrice     float64 `json:"quickSellPrice"`
 }
 
 // SparklinePoint is a single data point for sparkline charts.
@@ -165,6 +179,9 @@ func RankCollective(transfigure []TransfigureResult, trends []TrendResult, budge
 			cr.SellReason = t.SellReason
 			cr.Sellability = t.Sellability
 			cr.SellabilityLabel = t.SellabilityLabel
+			cr.Low7d = t.PriceLow7d
+			cr.High7d = t.PriceHigh7d
+			cr.SellConfidence = deriveSellConfidence(t.CurrentListings, t.CV, t.Signal)
 		}
 
 		// Exclude TRAP gems entirely — no actionable signal.
@@ -282,6 +299,11 @@ func BuildCompareResults(
 			cr.BaseListings = t.BaseListings
 			cr.LiquidityTier = t.LiquidityTier
 			cr.TransListings = t.CurrentListings
+			cr.Low7d = t.PriceLow7d
+			cr.High7d = t.PriceHigh7d
+			cr.SellConfidence = deriveSellConfidence(t.CurrentListings, t.CV, t.Signal)
+			cr.SellConfidenceReason = deriveSellConfidenceReason(t.CurrentListings, t.CV, t.Signal)
+			cr.QuickSellPrice = deriveQuickSellPrice(t.CurrentPrice, t.CurrentListings, t.CV)
 		}
 
 		// Attach sparkline.
@@ -308,7 +330,9 @@ func BuildCompareResults(
 			if sell == 0 {
 				sell = 50 // default if no trend data
 			}
-			ranks[i] = ranked{idx: i, score: cr.ROI * w * (sell / 100)}
+			score := cr.ROI * w * (sell / 100)
+			ranks[i] = ranked{idx: i, score: score}
+			results[i].WeightedROI = score
 		}
 		sort.Slice(ranks, func(i, j int) bool {
 			return ranks[i].score > ranks[j].score
@@ -329,4 +353,56 @@ func BuildCompareResults(
 	}
 
 	return results
+}
+
+// deriveSellConfidence returns GREEN/YELLOW/RED based on market conditions.
+// GREEN = liquid + stable, YELLOW = moderate risk, RED = thin/volatile.
+func deriveSellConfidence(listings int, cv float64, signal string) string {
+	if signal == "TRAP" || signal == "DUMPING" {
+		return "RED"
+	}
+	if listings >= 15 && cv < 30 {
+		return "GREEN"
+	}
+	if listings >= 5 && cv < 60 {
+		return "YELLOW"
+	}
+	return "RED"
+}
+
+// deriveSellConfidenceReason returns a human-readable explanation of sell confidence.
+func deriveSellConfidenceReason(listings int, cv float64, signal string) string {
+	if signal == "TRAP" {
+		return "extreme volatility — price unpredictable"
+	}
+	if signal == "DUMPING" {
+		return "price dropping — sellers undercutting"
+	}
+	conf := deriveSellConfidence(listings, cv, signal)
+	switch conf {
+	case "GREEN":
+		return fmt.Sprintf("%d listings — liquid, stable", listings)
+	case "YELLOW":
+		return fmt.Sprintf("%d listings — moderate liquidity", listings)
+	default:
+		if listings < 5 {
+			return fmt.Sprintf("%d listings — thin market", listings)
+		}
+		return fmt.Sprintf("CV %.0f%% — volatile pricing", cv)
+	}
+}
+
+// deriveQuickSellPrice estimates an aggressive undercut price.
+// Thin markets need larger undercuts; stable markets need minimal.
+func deriveQuickSellPrice(currentPrice float64, listings int, cv float64) float64 {
+	discount := 0.05 // 5% default undercut
+	if listings < 5 {
+		discount = 0.15
+	} else if listings < 15 {
+		discount = 0.10
+	}
+	if cv > 50 {
+		discount += 0.05
+	}
+	return currentPrice * (1.0 - discount)
 }

--- a/internal/server/handlers/collective.go
+++ b/internal/server/handlers/collective.go
@@ -152,6 +152,9 @@ func CollectiveAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc
 			Sellability          int     `json:"sellability"`
 			SellabilityLabel     string              `json:"sellabilityLabel"`
 			Sparkline            []lab.SparklinePoint `json:"sparkline"`
+			Low7d                float64 `json:"low7d"`
+			High7d               float64 `json:"high7d"`
+			SellConfidence       string  `json:"sellConfidence"`
 		}
 
 		rows := make([]row, 0, len(results))
@@ -185,6 +188,9 @@ func CollectiveAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc
 				Sellability:          cr.Sellability,
 				SellabilityLabel:     cr.SellabilityLabel,
 				Sparkline:           sparklines[cr.TransfiguredName],
+				Low7d:               cr.Low7d,
+				High7d:              cr.High7d,
+				SellConfidence:      cr.SellConfidence,
 			})
 			if rows[len(rows)-1].Sparkline == nil {
 				rows[len(rows)-1].Sparkline = []lab.SparklinePoint{}
@@ -285,63 +291,77 @@ func CompareAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc {
 		results := lab.BuildCompareResults(names, transfigure, trends, sparklines)
 
 		type row struct {
-			TransfiguredName  string              `json:"transfiguredName"`
-			BaseName          string              `json:"baseName"`
-			Variant           string              `json:"variant"`
-			GemColor          string              `json:"gemColor"`
-			ROI               float64             `json:"roi"`
-			ROIPct            float64             `json:"roiPct"`
-			BasePrice         float64             `json:"basePrice"`
-			TransfiguredPrice float64             `json:"transfiguredPrice"`
-			Confidence        string              `json:"confidence"`
-			Signal            string              `json:"signal"`
-			CV                float64             `json:"cv"`
-			PriceVelocity     float64             `json:"priceVelocity"`
-			ListingVelocity   float64             `json:"listingVelocity"`
-			HistPosition      float64             `json:"histPosition"`
-			Sparkline         []lab.SparklinePoint `json:"sparkline"`
-			Recommendation    string              `json:"recommendation"`
-			SellUrgency       string              `json:"sellUrgency"`
-			SellReason        string              `json:"sellReason"`
-			Sellability       int                 `json:"sellability"`
-			SellabilityLabel  string              `json:"sellabilityLabel"`
-			PriceTier         string              `json:"priceTier"`
-			TierAction        string              `json:"tierAction"`
-			WindowSignal      string              `json:"windowSignal"`
-			BaseListings      int                 `json:"baseListings"`
-			LiquidityTier     string              `json:"liquidityTier"`
-			TransListings     int                 `json:"transListings"`
+			TransfiguredName     string              `json:"transfiguredName"`
+			BaseName             string              `json:"baseName"`
+			Variant              string              `json:"variant"`
+			GemColor             string              `json:"gemColor"`
+			ROI                  float64             `json:"roi"`
+			ROIPct               float64             `json:"roiPct"`
+			BasePrice            float64             `json:"basePrice"`
+			TransfiguredPrice    float64             `json:"transfiguredPrice"`
+			Confidence           string              `json:"confidence"`
+			Signal               string              `json:"signal"`
+			CV                   float64             `json:"cv"`
+			PriceVelocity        float64             `json:"priceVelocity"`
+			ListingVelocity      float64             `json:"listingVelocity"`
+			HistPosition         float64             `json:"histPosition"`
+			Sparkline            []lab.SparklinePoint `json:"sparkline"`
+			Recommendation       string              `json:"recommendation"`
+			SellUrgency          string              `json:"sellUrgency"`
+			SellReason           string              `json:"sellReason"`
+			Sellability          int                 `json:"sellability"`
+			SellabilityLabel     string              `json:"sellabilityLabel"`
+			PriceTier            string              `json:"priceTier"`
+			TierAction           string              `json:"tierAction"`
+			WindowSignal         string              `json:"windowSignal"`
+			BaseListings         int                 `json:"baseListings"`
+			LiquidityTier        string              `json:"liquidityTier"`
+			TransListings        int                 `json:"transListings"`
+			TransfiguredListings int                 `json:"transfiguredListings"`
+			WeightedROI          float64             `json:"weightedRoi"`
+			Low7d                float64             `json:"low7d"`
+			High7d               float64             `json:"high7d"`
+			SellConfidence       string              `json:"sellConfidence"`
+			SellConfidenceReason string              `json:"sellConfidenceReason"`
+			QuickSellPrice       float64             `json:"quickSellPrice"`
 		}
 
 		rows := make([]row, 0, len(results))
 		for _, cr := range results {
 			rows = append(rows, row{
-				TransfiguredName:  cr.TransfiguredName,
-				BaseName:          cr.BaseName,
-				Variant:           cr.Variant,
-				GemColor:          cr.GemColor,
-				ROI:               cr.ROI,
-				ROIPct:            cr.ROIPct,
-				BasePrice:         cr.BasePrice,
-				TransfiguredPrice: cr.TransfiguredPrice,
-				Confidence:        cr.Confidence,
-				Signal:            cr.Signal,
-				CV:                cr.CV,
-				PriceVelocity:     cr.PriceVelocity,
-				ListingVelocity:   cr.ListingVelocity,
-				HistPosition:      cr.HistPosition,
-				Sparkline:         cr.Sparkline,
-				Recommendation:    cr.Recommendation,
-				SellUrgency:      cr.SellUrgency,
-				SellReason:       cr.SellReason,
-				Sellability:      cr.Sellability,
-				SellabilityLabel: cr.SellabilityLabel,
-				PriceTier:        cr.PriceTier,
-				TierAction:       cr.TierAction,
-				WindowSignal:     cr.WindowSignal,
-				BaseListings:     cr.BaseListings,
-				LiquidityTier:    cr.LiquidityTier,
-				TransListings:    cr.TransListings,
+				TransfiguredName:     cr.TransfiguredName,
+				BaseName:             cr.BaseName,
+				Variant:              cr.Variant,
+				GemColor:             cr.GemColor,
+				ROI:                  cr.ROI,
+				ROIPct:               cr.ROIPct,
+				BasePrice:            cr.BasePrice,
+				TransfiguredPrice:    cr.TransfiguredPrice,
+				Confidence:           cr.Confidence,
+				Signal:               cr.Signal,
+				CV:                   cr.CV,
+				PriceVelocity:        cr.PriceVelocity,
+				ListingVelocity:      cr.ListingVelocity,
+				HistPosition:         cr.HistPosition,
+				Sparkline:            cr.Sparkline,
+				Recommendation:       cr.Recommendation,
+				SellUrgency:          cr.SellUrgency,
+				SellReason:           cr.SellReason,
+				Sellability:          cr.Sellability,
+				SellabilityLabel:     cr.SellabilityLabel,
+				PriceTier:            cr.PriceTier,
+				TierAction:           cr.TierAction,
+				WindowSignal:         cr.WindowSignal,
+				BaseListings:         cr.BaseListings,
+				LiquidityTier:        cr.LiquidityTier,
+				TransListings:        cr.TransListings,
+				TransfiguredListings: cr.TransListings,
+				WeightedROI:          cr.WeightedROI,
+				Low7d:                cr.Low7d,
+				High7d:               cr.High7d,
+				SellConfidence:       cr.SellConfidence,
+				SellConfidenceReason: cr.SellConfidenceReason,
+				QuickSellPrice:       cr.QuickSellPrice,
 			})
 		}
 


### PR DESCRIPTION
## Summary

Frontend display layer for risk-adjusted scoring (POE-69). Makes the scoring visible to farmers.

### BestPlays
- New default sort: **Risk-Adj ROI** (uses `weightedRoi` from collective)
- Sell confidence badge (GREEN/YELLOW/RED) next to signal badge
- ROI column dynamically shows adjusted or raw value

### Comparator
- **Sell confidence badge** with reason tooltip (e.g., "42 listings — liquid, stable")
- **Quick-sell price** alongside listed price
- **7-day floor/ceiling** with visual position bar
- **Listing trend warning** for DUMPING/TRAP signals

### SignalBadge
- New `confidence` type with GREEN/YELLOW/RED styles (zero new CSS — reuses existing badge classes)

### Backend (handler wiring)
- `CollectiveResult`: added Low7d, High7d, SellConfidence (from trend data)
- `CompareResult`: added WeightedROI, Low7d, High7d, SellConfidence, SellConfidenceReason, QuickSellPrice
- `collective.go`: added `deriveSellConfidence`, `deriveSellConfidenceReason`, `deriveQuickSellPrice` helpers
- Handlers updated to serialize new fields

### 7 files, 292 additions

## Test plan

- [x] Go tests pass
- [x] `go vet` clean
- [ ] Visual review: sell confidence badges render correctly
- [ ] Visual review: quick-sell price and 7d floor display in Comparator
- [ ] Visual review: BestPlays default sort is risk-adjusted

Closes POE-71

🤖 Generated with [Claude Code](https://claude.com/claude-code)