### PR TITLE
feat(lab): add Font EV tier-based modes — Safe (MID+) and Jackpot (HIGH+)

### DIFF
--- a/internal/db/migrations/20260320150114_font_tier_modes.down.sql
+++ b/internal/db/migrations/20260320150114_font_tier_modes.down.sql
@@ -1,0 +1,10 @@
+-- Revert tier-based mode columns, restore threshold.
+ALTER TABLE font_snapshots DROP CONSTRAINT IF EXISTS font_snapshots_pkey;
+
+ALTER TABLE font_snapshots
+    DROP COLUMN IF EXISTS mode,
+    DROP COLUMN IF EXISTS thin_pool_gems,
+    DROP COLUMN IF EXISTS liquidity_risk,
+    ADD COLUMN IF NOT EXISTS threshold NUMERIC(10,2) NOT NULL DEFAULT 0;
+
+ALTER TABLE font_snapshots ADD PRIMARY KEY (time, color, variant);

--- a/internal/db/migrations/20260320150114_font_tier_modes.up.sql
+++ b/internal/db/migrations/20260320150114_font_tier_modes.up.sql
@@ -1,0 +1,10 @@
+-- Add tier-based mode columns and remove hardcoded threshold from font_snapshots.
+ALTER TABLE font_snapshots
+    DROP COLUMN IF EXISTS threshold,
+    ADD COLUMN IF NOT EXISTS mode           TEXT         NOT NULL DEFAULT 'safe',
+    ADD COLUMN IF NOT EXISTS thin_pool_gems INTEGER      NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS liquidity_risk TEXT         NOT NULL DEFAULT 'LOW';
+
+-- Drop and recreate PK to include mode (time, color, variant, mode).
+ALTER TABLE font_snapshots DROP CONSTRAINT IF EXISTS font_snapshots_pkey;
+ALTER TABLE font_snapshots ADD PRIMARY KEY (time, color, variant, mode);

--- a/internal/lab/analyzer.go
+++ b/internal/lab/analyzer.go
@@ -70,6 +70,8 @@ func (a *Analyzer) RunTransfigure(ctx context.Context) error {
 }
 
 // RunFont fetches the latest gem snapshot and computes Font of Divine Skill EV.
+// It requires GemFeature data for tier-based winner classification.
+// Features are loaded from cache first, then DB fallback.
 // It is safe to call from multiple goroutines; concurrent runs are serialized.
 func (a *Analyzer) RunFont(ctx context.Context) error {
 	a.muFont.Lock()
@@ -85,21 +87,44 @@ func (a *Analyzer) RunFont(ctx context.Context) error {
 		return nil
 	}
 
-	results := AnalyzeFont(snapTime, gems)
+	// Load gem features: try cache first, fall back to DB.
+	var features []GemFeature
+	if a.cache != nil {
+		features = a.cache.GemFeatures()
+	}
+	if len(features) == 0 {
+		features, err = a.repo.LatestGemFeatures(ctx, "", "", 50000)
+		if err != nil {
+			a.logger.Error("font: failed to load gem features", "error", err)
+			return err
+		}
+	}
+	if len(features) == 0 {
+		a.logger.Info("font: no gem features available yet, skipping (run v2 pipeline first)")
+		return nil
+	}
 
-	inserted, err := a.repo.SaveFontResults(ctx, results)
+	analysis := AnalyzeFont(snapTime, gems, features)
+
+	// Combine both modes for DB persistence.
+	allResults := make([]FontResult, 0, len(analysis.Safe)+len(analysis.Jackpot))
+	allResults = append(allResults, analysis.Safe...)
+	allResults = append(allResults, analysis.Jackpot...)
+
+	inserted, err := a.repo.SaveFontResults(ctx, allResults)
 	if err != nil {
 		a.logger.Error("font: failed to save results", "error", err)
 		return err
 	}
 
 	if a.cache != nil {
-		a.cache.SetFont(results)
+		a.cache.SetFont(analysis)
 	}
 
 	a.logger.Info("font analysis complete",
 		"snapTime", snapTime,
-		"results", len(results),
+		"safe", len(analysis.Safe),
+		"jackpot", len(analysis.Jackpot),
 		"inserted", inserted,
 	)
 	a.throttler.Signal()

--- a/internal/lab/cache.go
+++ b/internal/lab/cache.go
@@ -13,9 +13,10 @@ import (
 // immutable once stored.
 type Cache struct {
 	mu          sync.RWMutex
-	transfigure []TransfigureResult
-	font        []FontResult
-	quality     []QualityResult
+	transfigure  []TransfigureResult
+	fontSafe     []FontResult
+	fontJackpot  []FontResult
+	quality      []QualityResult
 	trends      []TrendResult
 	gemNames    []string // unique transfigured gem names, sorted
 	lastUpdated time.Time
@@ -55,11 +56,12 @@ func (c *Cache) SetTransfigure(results []TransfigureResult) {
 	c.lastUpdated = time.Now()
 }
 
-// SetFont replaces the cached font results.
-func (c *Cache) SetFont(results []FontResult) {
+// SetFont replaces the cached font results for both modes.
+func (c *Cache) SetFont(analysis FontAnalysis) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.font = results
+	c.fontSafe = analysis.Safe
+	c.fontJackpot = analysis.Jackpot
 	c.lastUpdated = time.Now()
 }
 
@@ -86,11 +88,25 @@ func (c *Cache) Transfigure() []TransfigureResult {
 	return c.transfigure
 }
 
-// Font returns the cached font results (nil if empty).
-func (c *Cache) Font() []FontResult {
+// Font returns the cached font analysis with both modes (nil slices if empty).
+func (c *Cache) Font() FontAnalysis {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.font
+	return FontAnalysis{Safe: c.fontSafe, Jackpot: c.fontJackpot}
+}
+
+// FontSafe returns the cached safe mode font results (nil if empty).
+func (c *Cache) FontSafe() []FontResult {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.fontSafe
+}
+
+// FontJackpot returns the cached jackpot mode font results (nil if empty).
+func (c *Cache) FontJackpot() []FontResult {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.fontJackpot
 }
 
 // Quality returns the cached quality results (nil if empty).

--- a/internal/lab/font.go
+++ b/internal/lab/font.go
@@ -1,24 +1,31 @@
 package lab
 
 import (
-	"math"
 	"strings"
 	"time"
 )
 
 // FontResult holds the computed EV for a single (color, variant) Font of Divine Skill analysis.
 type FontResult struct {
-	Time      time.Time
-	Color     string  // RED, GREEN, BLUE
-	Variant   string  // "1", "1/20", "20", "20/20"
-	Pool      int     // total unique transfigured gem names of that color
-	Winners   int
-	PWin      float64
-	AvgWin    float64
-	EV        float64
-	InputCost float64
-	Profit    float64
-	Threshold float64
+	Time          time.Time
+	Color         string  // RED, GREEN, BLUE
+	Variant       string  // "1", "1/20", "20", "20/20"
+	Pool          int     // total unique transfigured gem names of that color
+	Winners       int
+	PWin          float64
+	AvgWin        float64
+	EV            float64
+	InputCost     float64
+	Profit        float64
+	Mode          string // "safe" or "jackpot"
+	ThinPoolGems  int    // count of winners with < 5 listings
+	LiquidityRisk string // "LOW", "MEDIUM", "HIGH"
+}
+
+// FontAnalysis holds the results of both Safe and Jackpot font analysis modes.
+type FontAnalysis struct {
+	Safe    []FontResult
+	Jackpot []FontResult
 }
 
 // InputCostForVariant returns the estimated input cost in chaos for a gem variant.
@@ -52,10 +59,44 @@ func pWin3Picks(winners, total int) float64 {
 		(float64(losers-2)/float64(total-2))
 }
 
-// AnalyzeFont computes Font of Divine Skill EV per (color, variant).
+// isSafeTierWinner returns true if the tier qualifies as a winner in Safe mode (MID+).
+func isSafeTierWinner(tier string) bool {
+	return tier == "MID" || tier == "HIGH" || tier == "TOP"
+}
+
+// isJackpotTierWinner returns true if the tier qualifies as a winner in Jackpot mode (HIGH+).
+func isJackpotTierWinner(tier string) bool {
+	return tier == "HIGH" || tier == "TOP"
+}
+
+// computeLiquidityRisk classifies liquidity risk based on the ratio of thin-market winners.
+func computeLiquidityRisk(thinCount, winnerCount int) string {
+	if winnerCount == 0 {
+		return "LOW"
+	}
+	ratio := float64(thinCount) / float64(winnerCount)
+	if ratio > 0.5 {
+		return "HIGH"
+	}
+	if ratio > 0.2 {
+		return "MEDIUM"
+	}
+	return "LOW"
+}
+
+// AnalyzeFont computes Font of Divine Skill EV per (color, variant) in two modes:
+// Safe (MID+ tier winners) and Jackpot (HIGH+ tier winners).
+// Winner contributions are risk-adjusted using SellProbabilityFactor and StabilityDiscount.
 // Pool size = count of distinct transfigured gem NAMES per color (across all variants).
-// Winners and EV use variant-specific prices.
-func AnalyzeFont(snapTime time.Time, gems []GemPrice) []FontResult {
+func AnalyzeFont(snapTime time.Time, gems []GemPrice, features []GemFeature) FontAnalysis {
+	// Build feature lookup: "name|variant" -> *GemFeature
+	type featureKey struct{ name, variant string }
+	featureLookup := make(map[featureKey]*GemFeature, len(features))
+	for i := range features {
+		f := &features[i]
+		featureLookup[featureKey{f.Name, f.Variant}] = f
+	}
+
 	// Step 1: Build pool sizes — unique transfigured gem names per color (all variants).
 	poolNames := map[string]map[string]struct{}{
 		"RED":   {},
@@ -63,13 +104,14 @@ func AnalyzeFont(snapTime time.Time, gems []GemPrice) []FontResult {
 		"BLUE":  {},
 	}
 
-	// Also index variant-specific prices for winner calculation.
-	type priceEntry struct {
+	// Also index variant-specific gem entries for winner evaluation.
+	type gemEntry struct {
+		name     string
 		chaos    float64
 		listings int
 	}
-	// variantGems[color][variant] = []priceEntry
-	type colorVariantGems map[string][]priceEntry
+	// byColor[color][variant] = []gemEntry
+	type colorVariantGems map[string][]gemEntry
 	byColor := map[string]colorVariantGems{
 		"RED":   {},
 		"GREEN": {},
@@ -93,7 +135,8 @@ func AnalyzeFont(snapTime time.Time, gems []GemPrice) []FontResult {
 
 		poolNames[color][g.Name] = struct{}{}
 
-		byColor[color][g.Variant] = append(byColor[color][g.Variant], priceEntry{
+		byColor[color][g.Variant] = append(byColor[color][g.Variant], gemEntry{
+			name:     g.Name,
 			chaos:    g.Chaos,
 			listings: g.Listings,
 		})
@@ -101,7 +144,8 @@ func AnalyzeFont(snapTime time.Time, gems []GemPrice) []FontResult {
 
 	variants := []string{"1", "1/20", "20", "20/20"}
 	colors := []string{"RED", "GREEN", "BLUE"}
-	var results []FontResult
+
+	var analysis FontAnalysis
 
 	for _, color := range colors {
 		pool := len(poolNames[color])
@@ -111,42 +155,103 @@ func AnalyzeFont(snapTime time.Time, gems []GemPrice) []FontResult {
 
 		for _, variant := range variants {
 			inputCost := InputCostForVariant(variant)
-			threshold := math.Max(math.Ceil(inputCost*3), 5)
-
 			entries := byColor[color][variant]
-			var winnerCount int
-			var winnerSum float64
+
+			// Accumulators for Safe mode (MID+)
+			var safeWinnerCount int
+			var safeWinnerSum float64
+			var safeThinCount int
+
+			// Accumulators for Jackpot mode (HIGH+)
+			var jackpotWinnerCount int
+			var jackpotWinnerSum float64
+			var jackpotThinCount int
+
 			for _, e := range entries {
-				if e.chaos >= threshold && e.listings >= 5 {
-					winnerCount++
-					winnerSum += e.chaos
+				feat := featureLookup[featureKey{e.name, variant}]
+
+				// Determine tier: use feature tier if available, skip otherwise.
+				var tier string
+				var sellProb, stabDisc float64
+				if feat != nil {
+					tier = feat.Tier
+					sellProb = feat.SellProbabilityFactor
+					stabDisc = feat.StabilityDiscount
+				} else {
+					// No feature data for this gem — skip for tier-based classification.
+					continue
+				}
+
+				adjustedPrice := e.chaos * sellProb * stabDisc
+				isThin := e.listings < 5
+
+				if isSafeTierWinner(tier) {
+					safeWinnerCount++
+					safeWinnerSum += adjustedPrice
+					if isThin {
+						safeThinCount++
+					}
+				}
+				if isJackpotTierWinner(tier) {
+					jackpotWinnerCount++
+					jackpotWinnerSum += adjustedPrice
+					if isThin {
+						jackpotThinCount++
+					}
 				}
 			}
 
-			var avgWin float64
-			if winnerCount > 0 {
-				avgWin = winnerSum / float64(winnerCount)
+			// Safe mode result
+			var safeAvgWin float64
+			if safeWinnerCount > 0 {
+				safeAvgWin = safeWinnerSum / float64(safeWinnerCount)
 			}
+			safePWin := pWin3Picks(safeWinnerCount, pool)
+			safeEV := safePWin * safeAvgWin
+			safeProfit := safeEV - inputCost
 
-			pWin := pWin3Picks(winnerCount, pool)
-			ev := pWin * avgWin
-			profit := ev - inputCost
+			analysis.Safe = append(analysis.Safe, FontResult{
+				Time:          snapTime,
+				Color:         color,
+				Variant:       variant,
+				Pool:          pool,
+				Winners:       safeWinnerCount,
+				PWin:          safePWin,
+				AvgWin:        safeAvgWin,
+				EV:            safeEV,
+				InputCost:     inputCost,
+				Profit:        safeProfit,
+				Mode:          "safe",
+				ThinPoolGems:  safeThinCount,
+				LiquidityRisk: computeLiquidityRisk(safeThinCount, safeWinnerCount),
+			})
 
-			results = append(results, FontResult{
-				Time:      snapTime,
-				Color:     color,
-				Variant:   variant,
-				Pool:      pool,
-				Winners:   winnerCount,
-				PWin:      pWin,
-				AvgWin:    avgWin,
-				EV:        ev,
-				InputCost: inputCost,
-				Profit:    profit,
-				Threshold: threshold,
+			// Jackpot mode result
+			var jackpotAvgWin float64
+			if jackpotWinnerCount > 0 {
+				jackpotAvgWin = jackpotWinnerSum / float64(jackpotWinnerCount)
+			}
+			jackpotPWin := pWin3Picks(jackpotWinnerCount, pool)
+			jackpotEV := jackpotPWin * jackpotAvgWin
+			jackpotProfit := jackpotEV - inputCost
+
+			analysis.Jackpot = append(analysis.Jackpot, FontResult{
+				Time:          snapTime,
+				Color:         color,
+				Variant:       variant,
+				Pool:          pool,
+				Winners:       jackpotWinnerCount,
+				PWin:          jackpotPWin,
+				AvgWin:        jackpotAvgWin,
+				EV:            jackpotEV,
+				InputCost:     inputCost,
+				Profit:        jackpotProfit,
+				Mode:          "jackpot",
+				ThinPoolGems:  jackpotThinCount,
+				LiquidityRisk: computeLiquidityRisk(jackpotThinCount, jackpotWinnerCount),
 			})
 		}
 	}
 
-	return results
+	return analysis
 }

--- a/internal/lab/font_test.go
+++ b/internal/lab/font_test.go
@@ -67,40 +67,239 @@ func TestPWin3Picks_WinnersExceedTotal(t *testing.T) {
 	}
 }
 
-func TestAnalyzeFont_BasicEV(t *testing.T) {
+// makeTierBoundaries creates tier boundaries where:
+// TOP >= 200, HIGH >= 100, MID >= 30
+func makeTierBoundaries() TierBoundaries {
+	return TierBoundaries{Top: 200, High: 100, Mid: 30}
+}
+
+// makeFeature creates a GemFeature with the given parameters for testing.
+func makeFeature(name, variant string, chaos float64, listings int, tier string, sellProb, stabDisc float64) GemFeature {
+	return GemFeature{
+		Time:                  time.Now(),
+		Name:                  name,
+		Variant:               variant,
+		Chaos:                 chaos,
+		Listings:              listings,
+		Tier:                  tier,
+		SellProbabilityFactor: sellProb,
+		StabilityDiscount:     stabDisc,
+	}
+}
+
+func TestAnalyzeFont_SafeMode_MIDPlusWinners(t *testing.T) {
 	now := time.Now()
 	gems := []GemPrice{
-		// RED transfigured gems (3 unique names)
-		{Name: "Cleave of Rage", Variant: "20/20", Chaos: 100, Listings: 10, IsTransfigured: true, GemColor: "RED"},
-		{Name: "Slam of Force", Variant: "20/20", Chaos: 50, Listings: 10, IsTransfigured: true, GemColor: "RED"},
-		{Name: "Strike of Fear", Variant: "20/20", Chaos: 2, Listings: 10, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Cleave of Rage", Variant: "20/20", Chaos: 250, Listings: 15, IsTransfigured: true, GemColor: "RED"},  // TOP
+		{Name: "Slam of Force", Variant: "20/20", Chaos: 120, Listings: 10, IsTransfigured: true, GemColor: "RED"},   // HIGH
+		{Name: "Strike of Fear", Variant: "20/20", Chaos: 50, Listings: 8, IsTransfigured: true, GemColor: "RED"},    // MID
+		{Name: "Bash of Nothing", Variant: "20/20", Chaos: 10, Listings: 20, IsTransfigured: true, GemColor: "RED"},  // LOW
 	}
 
-	results := AnalyzeFont(now, gems)
+	features := []GemFeature{
+		makeFeature("Cleave of Rage", "20/20", 250, 15, "TOP", 0.9, 0.95),
+		makeFeature("Slam of Force", "20/20", 120, 10, "HIGH", 0.8, 0.9),
+		makeFeature("Strike of Fear", "20/20", 50, 8, "MID", 0.7, 0.85),
+		makeFeature("Bash of Nothing", "20/20", 10, 20, "LOW", 0.6, 0.8),
+	}
 
-	// Should have results for RED color across all 4 variants
+	analysis := AnalyzeFont(now, gems, features)
+
 	var found *FontResult
-	for i := range results {
-		if results[i].Color == "RED" && results[i].Variant == "20/20" {
-			found = &results[i]
+	for i := range analysis.Safe {
+		if analysis.Safe[i].Color == "RED" && analysis.Safe[i].Variant == "20/20" {
+			found = &analysis.Safe[i]
 			break
 		}
 	}
 	if found == nil {
-		t.Fatal("expected RED/20/20 result")
+		t.Fatal("expected RED/20/20 safe result")
 	}
 
-	if found.Pool != 3 {
-		t.Errorf("Pool = %d, want 3", found.Pool)
+	// Safe mode: MID, HIGH, TOP are winners = 3
+	if found.Winners != 3 {
+		t.Errorf("Safe Winners = %d, want 3 (MID+HIGH+TOP)", found.Winners)
 	}
-	// threshold for 20/20 = max(ceil(3.5*3), 5) = max(11, 5) = 11
-	// winners: 100c and 50c are >= 11, so 2 winners
+	// LOW gem (Bash of Nothing) should NOT be a winner
+	if found.Pool != 4 {
+		t.Errorf("Pool = %d, want 4", found.Pool)
+	}
+	if found.Mode != "safe" {
+		t.Errorf("Mode = %q, want %q", found.Mode, "safe")
+	}
+}
+
+func TestAnalyzeFont_JackpotMode_HIGHPlusWinners(t *testing.T) {
+	now := time.Now()
+	gems := []GemPrice{
+		{Name: "Cleave of Rage", Variant: "20/20", Chaos: 250, Listings: 15, IsTransfigured: true, GemColor: "RED"},  // TOP
+		{Name: "Slam of Force", Variant: "20/20", Chaos: 120, Listings: 10, IsTransfigured: true, GemColor: "RED"},   // HIGH
+		{Name: "Strike of Fear", Variant: "20/20", Chaos: 50, Listings: 8, IsTransfigured: true, GemColor: "RED"},    // MID
+		{Name: "Bash of Nothing", Variant: "20/20", Chaos: 10, Listings: 20, IsTransfigured: true, GemColor: "RED"},  // LOW
+	}
+
+	features := []GemFeature{
+		makeFeature("Cleave of Rage", "20/20", 250, 15, "TOP", 0.9, 0.95),
+		makeFeature("Slam of Force", "20/20", 120, 10, "HIGH", 0.8, 0.9),
+		makeFeature("Strike of Fear", "20/20", 50, 8, "MID", 0.7, 0.85),
+		makeFeature("Bash of Nothing", "20/20", 10, 20, "LOW", 0.6, 0.8),
+	}
+
+	analysis := AnalyzeFont(now, gems, features)
+
+	var found *FontResult
+	for i := range analysis.Jackpot {
+		if analysis.Jackpot[i].Color == "RED" && analysis.Jackpot[i].Variant == "20/20" {
+			found = &analysis.Jackpot[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected RED/20/20 jackpot result")
+	}
+
+	// Jackpot mode: only HIGH and TOP are winners = 2
 	if found.Winners != 2 {
-		t.Errorf("Winners = %d, want 2", found.Winners)
+		t.Errorf("Jackpot Winners = %d, want 2 (HIGH+TOP)", found.Winners)
 	}
-	// avgWin = (100+50)/2 = 75
-	if math.Abs(found.AvgWin-75) > 0.01 {
-		t.Errorf("AvgWin = %f, want 75", found.AvgWin)
+	if found.Mode != "jackpot" {
+		t.Errorf("Mode = %q, want %q", found.Mode, "jackpot")
+	}
+}
+
+func TestAnalyzeFont_RiskAdjustedAvgWin(t *testing.T) {
+	now := time.Now()
+	// Two gems: A is expensive but thin market (low sell prob), B is cheaper but liquid
+	gems := []GemPrice{
+		{Name: "Gem A", Variant: "20/20", Chaos: 300, Listings: 2, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Gem B", Variant: "20/20", Chaos: 200, Listings: 30, IsTransfigured: true, GemColor: "RED"},
+	}
+
+	features := []GemFeature{
+		makeFeature("Gem A", "20/20", 300, 2, "TOP", 0.3, 0.6),  // risk-adjusted: 300*0.3*0.6 = 54
+		makeFeature("Gem B", "20/20", 200, 30, "TOP", 0.9, 0.95), // risk-adjusted: 200*0.9*0.95 = 171
+	}
+
+	analysis := AnalyzeFont(now, gems, features)
+
+	var found *FontResult
+	for i := range analysis.Safe {
+		if analysis.Safe[i].Color == "RED" && analysis.Safe[i].Variant == "20/20" {
+			found = &analysis.Safe[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected RED/20/20 safe result")
+	}
+
+	// avgWin = (54 + 171) / 2 = 112.5
+	expectedAvg := (300*0.3*0.6 + 200*0.9*0.95) / 2.0
+	if math.Abs(found.AvgWin-expectedAvg) > 0.01 {
+		t.Errorf("AvgWin = %f, want %f (risk-adjusted)", found.AvgWin, expectedAvg)
+	}
+
+	// The 200c/30-listing gem (B) contributes more than the 300c/2-listing gem (A)
+	adjustedA := 300 * 0.3 * 0.6
+	adjustedB := 200 * 0.9 * 0.95
+	if adjustedB <= adjustedA {
+		t.Errorf("Expected gem B adjusted price (%f) > gem A adjusted price (%f)", adjustedB, adjustedA)
+	}
+}
+
+func TestAnalyzeFont_LiquidityRiskClassification(t *testing.T) {
+	tests := []struct {
+		name     string
+		thin     int
+		total    int
+		wantRisk string
+	}{
+		{"no winners", 0, 0, "LOW"},
+		{"no thin", 0, 5, "LOW"},
+		{"20% exact is LOW (> not >=)", 1, 5, "LOW"},  // 0.2 exactly -> LOW (uses > 0.2)
+		{"above 20%", 2, 5, "MEDIUM"},                 // 0.4 -> MEDIUM
+		{"above 50%", 3, 5, "HIGH"},                   // 0.6 -> HIGH
+		{"all thin", 5, 5, "HIGH"},
+		{"50% exact is MEDIUM (> not >=)", 1, 2, "MEDIUM"}, // 0.5 exactly -> not > 0.5 -> MEDIUM
+		{"just below 20%", 1, 6, "LOW"},                // 0.166 -> LOW
+		{"just above 20%", 2, 9, "MEDIUM"},             // 0.222 -> MEDIUM
+		{"above 50% boundary", 4, 7, "HIGH"},           // 0.571 -> HIGH
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := computeLiquidityRisk(tt.thin, tt.total)
+			if got != tt.wantRisk {
+				t.Errorf("computeLiquidityRisk(%d, %d) = %q, want %q", tt.thin, tt.total, got, tt.wantRisk)
+			}
+		})
+	}
+}
+
+func TestAnalyzeFont_BothModesProduceIndependentResults(t *testing.T) {
+	now := time.Now()
+	// RED: 3 MID gems, 0 HIGH gems
+	// BLUE: 0 MID gems, 1 HIGH gem
+	// Safe mode (MID+): RED has 3 winners, BLUE has 1 winner
+	// Jackpot mode (HIGH+): RED has 0 winners, BLUE has 1 winner
+	gems := []GemPrice{
+		// RED: 3 MID gems + 1 LOW
+		{Name: "Red Gem 1", Variant: "20/20", Chaos: 50, Listings: 10, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Red Gem 2", Variant: "20/20", Chaos: 40, Listings: 10, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Red Gem 3", Variant: "20/20", Chaos: 45, Listings: 10, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Red Low", Variant: "20/20", Chaos: 5, Listings: 10, IsTransfigured: true, GemColor: "RED"},
+		// BLUE: 1 HIGH gem + 2 LOW
+		{Name: "Blue Gem 1", Variant: "20/20", Chaos: 150, Listings: 10, IsTransfigured: true, GemColor: "BLUE"},
+		{Name: "Blue Low 1", Variant: "20/20", Chaos: 5, Listings: 10, IsTransfigured: true, GemColor: "BLUE"},
+		{Name: "Blue Low 2", Variant: "20/20", Chaos: 5, Listings: 10, IsTransfigured: true, GemColor: "BLUE"},
+	}
+
+	features := []GemFeature{
+		makeFeature("Red Gem 1", "20/20", 50, 10, "MID", 0.8, 0.9),
+		makeFeature("Red Gem 2", "20/20", 40, 10, "MID", 0.8, 0.9),
+		makeFeature("Red Gem 3", "20/20", 45, 10, "MID", 0.8, 0.9),
+		makeFeature("Red Low", "20/20", 5, 10, "LOW", 0.6, 0.8),
+		makeFeature("Blue Gem 1", "20/20", 150, 10, "HIGH", 0.85, 0.95),
+		makeFeature("Blue Low 1", "20/20", 5, 10, "LOW", 0.6, 0.8),
+		makeFeature("Blue Low 2", "20/20", 5, 10, "LOW", 0.6, 0.8),
+	}
+
+	analysis := AnalyzeFont(now, gems, features)
+
+	// Verify safe mode: RED has 3 MID winners, BLUE has 1 HIGH winner
+	var redSafeWinners, blueSafeWinners int
+	for _, r := range analysis.Safe {
+		if r.Variant == "20/20" {
+			if r.Color == "RED" {
+				redSafeWinners = r.Winners
+			} else if r.Color == "BLUE" {
+				blueSafeWinners = r.Winners
+			}
+		}
+	}
+	if redSafeWinners != 3 {
+		t.Errorf("RED safe winners = %d, want 3", redSafeWinners)
+	}
+	if blueSafeWinners != 1 {
+		t.Errorf("BLUE safe winners = %d, want 1", blueSafeWinners)
+	}
+
+	// Verify jackpot mode: RED has 0 HIGH+ winners, BLUE has 1 HIGH winner
+	var redJackpotWinners, blueJackpotWinners int
+	for _, r := range analysis.Jackpot {
+		if r.Variant == "20/20" {
+			if r.Color == "RED" {
+				redJackpotWinners = r.Winners
+			} else if r.Color == "BLUE" {
+				blueJackpotWinners = r.Winners
+			}
+		}
+	}
+	if redJackpotWinners != 0 {
+		t.Errorf("RED jackpot winners = %d, want 0", redJackpotWinners)
+	}
+	if blueJackpotWinners != 1 {
+		t.Errorf("BLUE jackpot winners = %d, want 1", blueJackpotWinners)
 	}
 }
 
@@ -112,10 +311,16 @@ func TestAnalyzeFont_PoolIsUniqueNamesAcrossVariants(t *testing.T) {
 		{Name: "Slam of Force", Variant: "20/20", Chaos: 50, Listings: 10, IsTransfigured: true, GemColor: "RED"},
 	}
 
-	results := AnalyzeFont(now, gems)
+	features := []GemFeature{
+		makeFeature("Cleave of Rage", "1", 10, 10, "LOW", 0.5, 0.8),
+		makeFeature("Cleave of Rage", "20/20", 100, 10, "HIGH", 0.8, 0.9),
+		makeFeature("Slam of Force", "20/20", 50, 10, "MID", 0.7, 0.85),
+	}
+
+	analysis := AnalyzeFont(now, gems, features)
 
 	// Pool should be 2 unique names (Cleave of Rage + Slam of Force), not 3 rows
-	for _, r := range results {
+	for _, r := range analysis.Safe {
 		if r.Color == "RED" {
 			if r.Pool != 2 {
 				t.Errorf("Pool = %d, want 2 (unique names across variants)", r.Pool)
@@ -133,8 +338,12 @@ func TestAnalyzeFont_ExcludesCorruptedAndTrarthus(t *testing.T) {
 		{Name: "Wave of Conviction of Trarthus", Variant: "20/20", Chaos: 500, Listings: 10, IsTransfigured: true, GemColor: "RED"},
 	}
 
-	results := AnalyzeFont(now, gems)
-	for _, r := range results {
+	features := []GemFeature{
+		makeFeature("Cleave of Rage", "20/20", 100, 10, "HIGH", 0.8, 0.9),
+	}
+
+	analysis := AnalyzeFont(now, gems, features)
+	for _, r := range analysis.Safe {
 		if r.Color == "RED" && r.Variant == "20/20" {
 			if r.Pool != 1 {
 				t.Errorf("Pool = %d, want 1 (corrupted and Trarthus excluded)", r.Pool)
@@ -145,14 +354,20 @@ func TestAnalyzeFont_ExcludesCorruptedAndTrarthus(t *testing.T) {
 }
 
 func TestAnalyzeFont_EmptyInput(t *testing.T) {
-	results := AnalyzeFont(time.Now(), nil)
-	if len(results) != 0 {
-		t.Errorf("got %d results, want 0", len(results))
+	analysis := AnalyzeFont(time.Now(), nil, nil)
+	if len(analysis.Safe) != 0 {
+		t.Errorf("got %d safe results, want 0", len(analysis.Safe))
+	}
+	if len(analysis.Jackpot) != 0 {
+		t.Errorf("got %d jackpot results, want 0", len(analysis.Jackpot))
 	}
 
-	results = AnalyzeFont(time.Now(), []GemPrice{})
-	if len(results) != 0 {
-		t.Errorf("got %d results, want 0", len(results))
+	analysis = AnalyzeFont(time.Now(), []GemPrice{}, []GemFeature{})
+	if len(analysis.Safe) != 0 {
+		t.Errorf("got %d safe results, want 0", len(analysis.Safe))
+	}
+	if len(analysis.Jackpot) != 0 {
+		t.Errorf("got %d jackpot results, want 0", len(analysis.Jackpot))
 	}
 }
 
@@ -165,8 +380,15 @@ func TestAnalyzeFont_PartialVariantCoverage(t *testing.T) {
 		{Name: "Gem C", Variant: "1", Chaos: 5, Listings: 10, IsTransfigured: true, GemColor: "RED"},
 		// Gem C has no "20/20" variant
 	}
-	results := AnalyzeFont(now, gems)
-	for _, r := range results {
+
+	features := []GemFeature{
+		makeFeature("Gem A", "20/20", 100, 10, "HIGH", 0.8, 0.9),
+		makeFeature("Gem B", "20/20", 50, 10, "MID", 0.7, 0.85),
+		makeFeature("Gem C", "1", 5, 10, "LOW", 0.5, 0.8),
+	}
+
+	analysis := AnalyzeFont(now, gems, features)
+	for _, r := range analysis.Safe {
 		if r.Color == "RED" && r.Variant == "20/20" {
 			// Pool should be 3 (all unique names), even though only 2 have 20/20 entries
 			if r.Pool != 3 {
@@ -182,21 +404,97 @@ func TestAnalyzeFont_PartialVariantCoverage(t *testing.T) {
 	t.Error("expected RED/20/20 result")
 }
 
-func TestAnalyzeFont_LowListingsNotWinners(t *testing.T) {
+func TestAnalyzeFont_ThinPoolGems(t *testing.T) {
 	now := time.Now()
 	gems := []GemPrice{
-		{Name: "Cleave of Rage", Variant: "20/20", Chaos: 100, Listings: 2, IsTransfigured: true, GemColor: "RED"},
-		{Name: "Slam of Force", Variant: "20/20", Chaos: 50, Listings: 10, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Gem A", Variant: "20/20", Chaos: 100, Listings: 2, IsTransfigured: true, GemColor: "RED"},  // thin
+		{Name: "Gem B", Variant: "20/20", Chaos: 120, Listings: 3, IsTransfigured: true, GemColor: "RED"},  // thin
+		{Name: "Gem C", Variant: "20/20", Chaos: 80, Listings: 15, IsTransfigured: true, GemColor: "RED"},  // not thin
 	}
 
-	results := AnalyzeFont(now, gems)
-	for _, r := range results {
+	features := []GemFeature{
+		makeFeature("Gem A", "20/20", 100, 2, "HIGH", 0.4, 0.7),
+		makeFeature("Gem B", "20/20", 120, 3, "HIGH", 0.4, 0.7),
+		makeFeature("Gem C", "20/20", 80, 15, "MID", 0.8, 0.9),
+	}
+
+	analysis := AnalyzeFont(now, gems, features)
+	for _, r := range analysis.Safe {
 		if r.Color == "RED" && r.Variant == "20/20" {
-			// Cleave has < 5 listings, so not a winner
-			if r.Winners != 1 {
-				t.Errorf("Winners = %d, want 1 (low listings excluded)", r.Winners)
+			// All 3 are MID+ winners in safe mode, 2 have < 5 listings
+			if r.ThinPoolGems != 2 {
+				t.Errorf("ThinPoolGems = %d, want 2", r.ThinPoolGems)
+			}
+			if r.LiquidityRisk != "HIGH" {
+				t.Errorf("LiquidityRisk = %q, want HIGH (2/3 = 66%% thin)", r.LiquidityRisk)
 			}
 			return
 		}
 	}
+	t.Error("expected RED/20/20 safe result")
+}
+
+func TestAnalyzeFont_GemsWithoutFeaturesSkipped(t *testing.T) {
+	now := time.Now()
+	gems := []GemPrice{
+		{Name: "Gem A", Variant: "20/20", Chaos: 100, Listings: 10, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Gem B", Variant: "20/20", Chaos: 200, Listings: 15, IsTransfigured: true, GemColor: "RED"},
+	}
+
+	// Only provide feature for Gem A, not Gem B
+	features := []GemFeature{
+		makeFeature("Gem A", "20/20", 100, 10, "HIGH", 0.8, 0.9),
+	}
+
+	analysis := AnalyzeFont(now, gems, features)
+	for _, r := range analysis.Jackpot {
+		if r.Color == "RED" && r.Variant == "20/20" {
+			// Only Gem A has features and is HIGH, so 1 winner
+			if r.Winners != 1 {
+				t.Errorf("Winners = %d, want 1 (Gem B has no features)", r.Winners)
+			}
+			return
+		}
+	}
+	t.Error("expected RED/20/20 jackpot result")
+}
+
+func TestAnalyzeFont_PWin3PicksStillWorksWithTierBasedCounts(t *testing.T) {
+	now := time.Now()
+	// Create pool of 10 gems, 3 are MID+ winners
+	gems := make([]GemPrice, 10)
+	features := make([]GemFeature, 10)
+	for i := 0; i < 10; i++ {
+		name := "Gem " + string(rune('A'+i))
+		var chaos float64
+		var tier string
+		if i < 3 {
+			chaos = 100
+			tier = "HIGH"
+		} else {
+			chaos = 5
+			tier = "LOW"
+		}
+		gems[i] = GemPrice{Name: name, Variant: "20/20", Chaos: chaos, Listings: 10, IsTransfigured: true, GemColor: "RED"}
+		features[i] = makeFeature(name, "20/20", chaos, 10, tier, 0.8, 0.9)
+	}
+
+	analysis := AnalyzeFont(now, gems, features)
+	for _, r := range analysis.Safe {
+		if r.Color == "RED" && r.Variant == "20/20" {
+			if r.Pool != 10 {
+				t.Errorf("Pool = %d, want 10", r.Pool)
+			}
+			if r.Winners != 3 {
+				t.Errorf("Winners = %d, want 3", r.Winners)
+			}
+			// pWin(3, 10) should match direct calculation
+			expected := pWin3Picks(3, 10)
+			if math.Abs(r.PWin-expected) > 0.0001 {
+				t.Errorf("PWin = %f, want %f", r.PWin, expected)
+			}
+			return
+		}
+	}
+	t.Error("expected RED/20/20 safe result")
 }

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -140,11 +140,13 @@ func (r *Repository) SaveFontResults(ctx context.Context, results []FontResult) 
 	for _, r := range results {
 		batch.Queue(
 			`INSERT INTO font_snapshots
-			 (time, color, variant, pool, winners, p_win, avg_win, ev, input_cost, profit, threshold)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+			 (time, color, variant, pool, winners, p_win, avg_win, ev, input_cost, profit,
+			  mode, thin_pool_gems, liquidity_risk)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 			 ON CONFLICT DO NOTHING`,
 			r.Time, r.Color, r.Variant, r.Pool, r.Winners,
-			r.PWin, r.AvgWin, r.EV, r.InputCost, r.Profit, r.Threshold,
+			r.PWin, r.AvgWin, r.EV, r.InputCost, r.Profit,
+			r.Mode, r.ThinPoolGems, r.LiquidityRisk,
 		)
 	}
 
@@ -216,21 +218,29 @@ func (r *Repository) SaveQualityResults(ctx context.Context, results []QualityRe
 	return inserted, nil
 }
 
-// LatestFontResults returns the most recent Font analysis results, optionally filtered by variant.
-func (r *Repository) LatestFontResults(ctx context.Context, variant string, limit int) ([]FontResult, error) {
+// LatestFontResults returns the most recent Font analysis results, optionally filtered by variant and/or mode.
+func (r *Repository) LatestFontResults(ctx context.Context, variant, mode string, limit int) ([]FontResult, error) {
 	query := `
-		SELECT time, color, variant, pool, winners, p_win, avg_win, ev, input_cost, profit, threshold
+		SELECT time, color, variant, pool, winners, p_win, avg_win, ev, input_cost, profit,
+		       COALESCE(mode, 'safe'), COALESCE(thin_pool_gems, 0), COALESCE(liquidity_risk, 'LOW')
 		FROM font_snapshots
 		WHERE time = (SELECT MAX(time) FROM font_snapshots)`
 	args := []any{}
+	argIdx := 1
 
 	if variant != "" {
-		query += ` AND variant = $1 ORDER BY profit DESC LIMIT $2`
-		args = append(args, variant, limit)
-	} else {
-		query += ` ORDER BY profit DESC LIMIT $1`
-		args = append(args, limit)
+		query += fmt.Sprintf(` AND variant = $%d`, argIdx)
+		args = append(args, variant)
+		argIdx++
 	}
+	if mode != "" {
+		query += fmt.Sprintf(` AND mode = $%d`, argIdx)
+		args = append(args, mode)
+		argIdx++
+	}
+
+	query += fmt.Sprintf(` ORDER BY profit DESC LIMIT $%d`, argIdx)
+	args = append(args, limit)
 
 	rows, err := r.pool.Query(ctx, query, args...)
 	if err != nil {
@@ -242,7 +252,8 @@ func (r *Repository) LatestFontResults(ctx context.Context, variant string, limi
 	for rows.Next() {
 		var fr FontResult
 		if err := rows.Scan(&fr.Time, &fr.Color, &fr.Variant, &fr.Pool, &fr.Winners,
-			&fr.PWin, &fr.AvgWin, &fr.EV, &fr.InputCost, &fr.Profit, &fr.Threshold); err != nil {
+			&fr.PWin, &fr.AvgWin, &fr.EV, &fr.InputCost, &fr.Profit,
+			&fr.Mode, &fr.ThinPoolGems, &fr.LiquidityRisk); err != nil {
 			return nil, fmt.Errorf("lab repo: scan font result: %w", err)
 		}
 		results = append(results, fr)

--- a/internal/server/handlers/analysis.go
+++ b/internal/server/handlers/analysis.go
@@ -164,7 +164,8 @@ func filterTransfigure(all []lab.TransfigureResult, variant string, limit int) [
 	return filtered
 }
 
-// FontAnalysis returns the latest Font of Divine Skill EV results.
+// FontAnalysis returns the latest Font of Divine Skill EV results in two modes:
+// Safe (MID+ tier winners) and Jackpot (HIGH+ tier winners).
 // Query params: variant (optional, e.g. "20/20"), limit (default 50, max 500).
 // Uses in-memory cache when available, falls back to DB query.
 func FontAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc {
@@ -176,65 +177,102 @@ func FontAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc {
 			return
 		}
 
-		var results []lab.FontResult
+		var safeResults, jackpotResults []lab.FontResult
+		cacheHit := false
 
 		// Fast path: serve from cache.
 		if cache != nil {
-			if cached := cache.Font(); len(cached) > 0 {
-				results = filterFont(cached, variant, limit)
+			analysis := cache.Font()
+			if len(analysis.Safe) > 0 || len(analysis.Jackpot) > 0 {
+				safeResults = filterFont(analysis.Safe, variant, limit)
+				jackpotResults = filterFont(analysis.Jackpot, variant, limit)
+				cacheHit = true
 			}
 		}
 
 		// Slow path: fall back to DB query.
-		if results == nil {
+		if !cacheHit {
 			var err error
-			results, err = repo.LatestFontResults(r.Context(), variant, limit)
+			safeResults, err = repo.LatestFontResults(r.Context(), variant, "safe", limit)
 			if err != nil {
-				slog.Error("font analysis: query failed", "error", err, "variant", variant)
+				slog.Error("font analysis: query safe failed", "error", err, "variant", variant)
+				http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+				return
+			}
+			jackpotResults, err = repo.LatestFontResults(r.Context(), variant, "jackpot", limit)
+			if err != nil {
+				slog.Error("font analysis: query jackpot failed", "error", err, "variant", variant)
 				http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
 				return
 			}
 		}
 
 		type row struct {
-			Time      string  `json:"time"`
-			Color     string  `json:"color"`
-			Variant   string  `json:"variant"`
-			Pool      int     `json:"pool"`
-			Winners   int     `json:"winners"`
-			PWin      float64 `json:"pWin"`
-			AvgWin    float64 `json:"avgWin"`
-			EV        float64 `json:"ev"`
-			InputCost float64 `json:"inputCost"`
-			Profit    float64 `json:"profit"`
-			Threshold float64 `json:"threshold"`
+			Time          string  `json:"time"`
+			Color         string  `json:"color"`
+			Variant       string  `json:"variant"`
+			Pool          int     `json:"pool"`
+			Winners       int     `json:"winners"`
+			PWin          float64 `json:"pWin"`
+			AvgWin        float64 `json:"avgWin"`
+			EV            float64 `json:"ev"`
+			InputCost     float64 `json:"inputCost"`
+			Profit        float64 `json:"profit"`
+			ThinPoolGems  int     `json:"thinPoolGems"`
+			LiquidityRisk string  `json:"liquidityRisk"`
 		}
 
-		rows := make([]row, 0, len(results))
-		for _, r := range results {
-			rows = append(rows, row{
-				Time:      r.Time.UTC().Format(time.RFC3339),
-				Color:     r.Color,
-				Variant:   r.Variant,
-				Pool:      r.Pool,
-				Winners:   r.Winners,
-				PWin:      r.PWin,
-				AvgWin:    r.AvgWin,
-				EV:        r.EV,
-				InputCost: r.InputCost,
-				Profit:    r.Profit,
-				Threshold: r.Threshold,
-			})
+		toRows := func(results []lab.FontResult) []row {
+			rows := make([]row, 0, len(results))
+			for _, r := range results {
+				rows = append(rows, row{
+					Time:          r.Time.UTC().Format(time.RFC3339),
+					Color:         r.Color,
+					Variant:       r.Variant,
+					Pool:          r.Pool,
+					Winners:       r.Winners,
+					PWin:          r.PWin,
+					AvgWin:        r.AvgWin,
+					EV:            r.EV,
+					InputCost:     r.InputCost,
+					Profit:        r.Profit,
+					ThinPoolGems:  r.ThinPoolGems,
+					LiquidityRisk: r.LiquidityRisk,
+				})
+			}
+			return rows
 		}
+
+		safeRows := toRows(safeResults)
+		jackpotRows := toRows(jackpotResults)
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]any{
-			"count": len(rows),
-			"data":  rows,
+			"safe":             safeRows,
+			"jackpot":          jackpotRows,
+			"bestColorSafe":    bestColor(safeResults),
+			"bestColorJackpot": bestColor(jackpotResults),
 		}); err != nil {
 			slog.Error("font analysis: encode response", "error", err)
 		}
 	}
+}
+
+// bestColor returns the color with the highest EV among the given font results.
+func bestColor(results []lab.FontResult) string {
+	evByColor := make(map[string]float64)
+	for _, r := range results {
+		evByColor[r.Color] += r.EV
+	}
+	var best string
+	var bestEV float64
+	for color, ev := range evByColor {
+		if best == "" || ev > bestEV {
+			best = color
+			bestEV = ev
+		}
+	}
+	return best
 }
 
 // filterFont filters and limits cached font results.
@@ -624,7 +662,8 @@ func AnalysisStatus(cache *lab.Cache, pool *pgxpool.Pool, league string) http.Ha
 			if err := json.NewEncoder(w).Encode(map[string]any{
 				"cached":      false,
 				"transfigure": 0,
-				"font":        0,
+				"fontSafe":    0,
+				"fontJackpot": 0,
 				"quality":     0,
 				"trends":      0,
 			}); err != nil {
@@ -636,11 +675,13 @@ func AnalysisStatus(cache *lab.Cache, pool *pgxpool.Pool, league string) http.Ha
 		lastUpdated := cache.LastUpdated()
 		cached := !lastUpdated.IsZero()
 
+		fontAnalysis := cache.Font()
 		resp := map[string]any{
 			"cached":      cached,
 			"league":      league,
 			"transfigure": len(cache.Transfigure()),
-			"font":        len(cache.Font()),
+			"fontSafe":    len(fontAnalysis.Safe),
+			"fontJackpot": len(fontAnalysis.Jackpot),
 			"quality":     len(cache.Quality()),
 			"trends":      len(cache.Trends()),
 		}


### PR DESCRIPTION
## Summary

Replaces hardcoded 5c winner threshold in Font EV with adaptive tier-based classification. Two modes with independent EV calculations:

- **Safe (MID+)**: gems classified MID, HIGH, or TOP are winners. Higher P(win), consistent income.
- **Jackpot (HIGH+)**: only HIGH and TOP are winners. Lower P(win), dramatically higher avgWin.

### Key changes

- **Removed** hardcoded `math.Max(math.Ceil(inputCost*3), 5)` threshold
- **Removed** `listings >= 5` hard gate (listing impact now via risk-adjusted avgWin)
- **Risk-adjusted avgWin**: each winner weighted by `SellProbabilityFactor × StabilityDiscount`
- **Per-mode liquidity risk**: HIGH/MEDIUM/LOW based on % of thin-market winners
- **Independent bestColor per mode**: Safe might favor BLUE, Jackpot might favor RED

### API response

```json
{
  "safe": [...FontResult per color/variant],
  "jackpot": [...FontResult per color/variant],
  "bestColorSafe": "BLUE",
  "bestColorJackpot": "RED"
}
```

### Migration

Drops `threshold` column, adds `mode`, `thin_pool_gems`, `liquidity_risk`. Updates PK to include mode.

### 8 files, 665 additions

## Test plan

- [x] Safe mode: MID+ gems are winners
- [x] Jackpot mode: HIGH+ only
- [x] Risk-adjusted avgWin: liquid gem contributes more than illiquid
- [x] Liquidity risk classification
- [x] Independent mode results (different bestColor possible)
- [x] pWin3Picks preserved correctly
- [x] All lab tests pass, `go vet` clean
- [ ] Visual review: API returns both modes
- [ ] Backfill with updated AnalyzeFont

Closes POE-70

🤖 Generated with [Claude Code](https://claude.com/claude-code)