### PR TITLE
feat(frontend): add Font EV Safe/Jackpot mode toggle

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -69,6 +69,9 @@ export interface FontColor {
 	pWin: number;
 	profit: number;
 	evDelta2h: number;
+	thinPoolGems?: number;
+	liquidityRisk?: string;
+	mode?: string;
 }
 
 export interface FontEVData {
@@ -76,6 +79,13 @@ export interface FontEVData {
 	qualityAvgRoi: number;
 	bestColor: string;
 	bestAdvantage: number;
+}
+
+export interface FontEVResponse {
+	safe: FontColor[];
+	jackpot: FontColor[];
+	bestColorSafe: string;
+	bestColorJackpot: string;
 }
 
 export interface WindowAlert {
@@ -295,33 +305,37 @@ export async function fetchVariantPlays(variant: string): Promise<GemPlay[]> {
 	return fetchBestPlays(variant);
 }
 
-export async function fetchFontEV(variant: string): Promise<FontEVData> {
-	const params: Record<string, string> = {};
-	if (variant) params.variant = variant;
-
-	const resp = await get<{ count: number; data: any[] }>('/analysis/font', params);
-	const rows = resp.data || [];
-
-	const colors: FontColor[] = rows.map((r: any) => ({
+function mapFontRows(rows: any[]): FontColor[] {
+	return rows.map((r: any) => ({
 		color: r.color || '',
 		ev: Math.round(r.ev || 0),
 		pool: r.pool || 0,
 		winners: r.winners || 0,
 		pWin: Math.round((r.pWin || 0) * 10000) / 100,
 		profit: Math.round(r.profit || 0),
-		evDelta2h: 0, // not in backend yet
+		evDelta2h: 0,
+		thinPoolGems: r.thinPoolGems || 0,
+		liquidityRisk: r.liquidityRisk || 'LOW',
+		mode: r.mode || '',
 	}));
+}
 
-	// Compute best color
-	const sorted = [...colors].sort((a, b) => b.ev - a.ev);
-	const best = sorted[0];
-	const second = sorted[1];
+export async function fetchFontEV(variant: string): Promise<FontEVResponse> {
+	const params: Record<string, string> = {};
+	if (variant) params.variant = variant;
+
+	const resp = await get<{
+		safe: any[];
+		jackpot: any[];
+		bestColorSafe: string;
+		bestColorJackpot: string;
+	}>('/analysis/font', params);
 
 	return {
-		colors,
-		qualityAvgRoi: 0, // needs quality data cross-reference
-		bestColor: best?.color || '',
-		bestAdvantage: best && second ? Math.round(best.ev - second.ev) : 0,
+		safe: mapFontRows(resp.safe || []),
+		jackpot: mapFontRows(resp.jackpot || []),
+		bestColorSafe: resp.bestColorSafe || '',
+		bestColorJackpot: resp.bestColorJackpot || '',
 	};
 }
 

--- a/frontend/src/routes/lab/components/ByVariant.svelte
+++ b/frontend/src/routes/lab/components/ByVariant.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fetchVariantPlays, fetchFontEV, type GemPlay, type FontEVData } from '$lib/api';
+	import { fetchVariantPlays, fetchFontEV, type GemPlay, type FontEVResponse } from '$lib/api';
 	import BestPlays from './BestPlays.svelte';
 	import FontEV from './FontEV.svelte';
 
@@ -12,7 +12,7 @@
 
 	interface VariantData {
 		plays: GemPlay[];
-		fontEV: FontEVData;
+		fontEV: FontEVResponse;
 	}
 
 	let variantData = $state<Record<string, VariantData>>({});

--- a/frontend/src/routes/lab/components/FontEV.svelte
+++ b/frontend/src/routes/lab/components/FontEV.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
-	import type { FontEVData } from '$lib/api';
+	import type { FontEVResponse, FontColor } from '$lib/api';
 	import { METRIC_TOOLTIPS } from '$lib/tooltips';
 
-	let { data }: { data: FontEVData } = $props();
+	let { data }: { data: FontEVResponse } = $props();
+
+	let mode = $state<'safe' | 'jackpot'>('safe');
 
 	const COLOR_LABELS: Record<string, { icon: string; cssClass: string; colorClass: string }> = {
 		RED: { icon: '●', cssClass: 'font-red', colorClass: 'icon-red' },
@@ -10,38 +12,68 @@
 		BLUE: { icon: '●', cssClass: 'font-blue', colorClass: 'icon-blue' },
 	};
 
+	let activeColors = $derived(mode === 'safe' ? data.safe : data.jackpot);
+	let bestColor = $derived(mode === 'safe' ? data.bestColorSafe : data.bestColorJackpot);
+
 	function deltaStr(v: number): string {
 		if (v > 0) return `+${v}c`;
 		if (v < 0) return `${v}c`;
 		return '0c';
 	}
+
+	function liquidityBadge(fc: FontColor): string | null {
+		if (!fc.liquidityRisk || fc.liquidityRisk === 'LOW') return null;
+		return `${fc.liquidityRisk} -- ${fc.thinPoolGems || 0} of ${fc.winners} winners have <5 listings`;
+	}
 </script>
 
 <div class="font-ev">
-	<h4 class="font-title">Font EV</h4>
-	<div class="color-cards">
-		{#each data.colors as fc}
-			{@const cl = COLOR_LABELS[fc.color]}
-			<div class="color-card {cl.cssClass}">
-				<div class="color-header">
-					<span class="color-icon {cl.colorClass}">{cl.icon}</span>
-					<span class="color-name">{fc.color}</span>
-				</div>
-				<div class="color-stats">
-					<span class="stat" title={METRIC_TOOLTIPS.EV}>EV: <strong>{fc.ev}c</strong></span>
-					<span class="stat" title={METRIC_TOOLTIPS.Pool}>Pool: {fc.pool}</span>
-					<span class="stat">Winners: {fc.winners}</span>
-					<span class="stat" title={METRIC_TOOLTIPS.pWin}>pWin: {fc.pWin}%</span>
-					<span class="stat">Profit: {fc.profit}c</span>
-					<span class="stat delta" title={METRIC_TOOLTIPS['\u039412h']}>
-						Δ12h: EV {deltaStr(fc.evDelta2h)}
-					</span>
-				</div>
-			</div>
-		{/each}
+	<div class="font-header">
+		<h4 class="font-title">Font EV</h4>
+		<div class="mode-toggle">
+			<button
+				class="toggle-btn"
+				class:active={mode === 'safe'}
+				onclick={() => mode = 'safe'}
+			>Safe</button>
+			<button
+				class="toggle-btn"
+				class:active={mode === 'jackpot'}
+				onclick={() => mode = 'jackpot'}
+			>Jackpot</button>
+		</div>
 	</div>
-	<div class="quality-compare">
-		vs Quality avg ROI: {data.qualityAvgRoi}c → Font {data.bestColor} wins by {data.bestAdvantage}c
+	<div class="color-cards">
+		{#each activeColors as fc}
+			{@const cl = COLOR_LABELS[fc.color]}
+			{@const badge = liquidityBadge(fc)}
+			{#if cl}
+				<div class="color-card {cl.cssClass}" class:best-card={fc.color === bestColor}>
+					<div class="color-header">
+						<span class="color-icon {cl.colorClass}">{cl.icon}</span>
+						<span class="color-name">{fc.color}</span>
+						{#if fc.color === bestColor}
+							<span class="best-badge">BEST</span>
+						{/if}
+					</div>
+					<div class="color-stats">
+						<span class="stat" title={METRIC_TOOLTIPS.EV}>EV: <strong>{fc.ev}c</strong></span>
+						<span class="stat" title={METRIC_TOOLTIPS.Pool}>Pool: {fc.pool}</span>
+						<span class="stat">Winners: {fc.winners}</span>
+						<span class="stat" title={METRIC_TOOLTIPS.pWin}>pWin: {fc.pWin}%</span>
+						<span class="stat">Profit: {fc.profit}c</span>
+						<span class="stat delta" title={METRIC_TOOLTIPS['\u039412h']}>
+							Δ12h: EV {deltaStr(fc.evDelta2h)}
+						</span>
+					</div>
+					{#if badge}
+						<div class="liquidity-badge risk-{fc.liquidityRisk?.toLowerCase()}">
+							{badge}
+						</div>
+					{/if}
+				</div>
+			{/if}
+		{/each}
 	</div>
 </div>
 
@@ -51,11 +83,44 @@
 		border-top: 1px solid var(--color-lab-border);
 		padding-top: 18px;
 	}
+	.font-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 12px;
+	}
 	.font-title {
 		font-size: 1rem;
 		font-weight: 700;
 		color: var(--color-lab-text);
-		margin: 0 0 12px 0;
+		margin: 0;
+	}
+	.mode-toggle {
+		display: flex;
+		gap: 0;
+	}
+	.toggle-btn {
+		background: transparent;
+		border: 1px solid var(--color-lab-border);
+		color: var(--color-lab-text-secondary);
+		padding: 4px 14px;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		cursor: pointer;
+		font-family: inherit;
+		transition: all 0.15s ease;
+	}
+	.toggle-btn:first-child {
+		border-right: none;
+	}
+	.toggle-btn:hover {
+		color: var(--color-lab-text);
+		border-color: var(--color-lab-text-secondary);
+	}
+	.toggle-btn.active {
+		color: var(--color-lab-text);
+		border-color: var(--color-lab-blue);
+		background: rgba(59, 130, 246, 0.15);
 	}
 	.color-cards {
 		display: flex;
@@ -66,6 +131,10 @@
 		border: 1px solid var(--color-lab-border);
 		padding: 16px 18px;
 		background: var(--color-lab-bg);
+	}
+	.color-card.best-card {
+		border-color: var(--color-lab-green);
+		background: rgba(34, 197, 94, 0.04);
 	}
 	.color-header {
 		display: flex;
@@ -86,6 +155,14 @@
 	.font-red .color-name { color: var(--color-lab-red); }
 	.font-green .color-name { color: var(--color-lab-green); }
 	.font-blue .color-name { color: var(--color-lab-blue); }
+	.best-badge {
+		font-size: 0.625rem;
+		font-weight: 700;
+		color: var(--color-lab-green);
+		border: 1px solid var(--color-lab-green);
+		padding: 1px 6px;
+		letter-spacing: 0.05em;
+	}
 	.color-stats {
 		display: flex;
 		flex-wrap: wrap;
@@ -102,9 +179,20 @@
 	.delta {
 		color: var(--color-lab-text-secondary);
 	}
-	.quality-compare {
-		margin-top: 12px;
-		font-size: 0.875rem;
-		color: var(--color-lab-text-secondary);
+	.liquidity-badge {
+		margin-top: 10px;
+		font-size: 0.8125rem;
+		padding: 4px 10px;
+		border: 1px solid;
+	}
+	.risk-medium {
+		color: var(--color-lab-yellow, #eab308);
+		border-color: rgba(234, 179, 8, 0.3);
+		background: rgba(234, 179, 8, 0.06);
+	}
+	.risk-high {
+		color: var(--color-lab-red);
+		border-color: rgba(239, 68, 68, 0.3);
+		background: rgba(239, 68, 68, 0.06);
 	}
 </style>

--- a/frontend/src/routes/lab/components/FontEVCompare.svelte
+++ b/frontend/src/routes/lab/components/FontEVCompare.svelte
@@ -1,13 +1,14 @@
 <script lang="ts">
-	import { fetchFontEV, type FontEVData, type FontColor } from '$lib/api';
+	import { fetchFontEV, type FontEVResponse, type FontColor } from '$lib/api';
 
 	let { refreshKey = 0 }: { refreshKey?: number } = $props();
 
 	const VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
 	const COLORS = ['RED', 'GREEN', 'BLUE'] as const;
 
-	let data = $state<Record<string, FontEVData>>({});
+	let data = $state<Record<string, FontEVResponse>>({});
 	let loading = $state(true);
+	let mode = $state<'safe' | 'jackpot'>('safe');
 
 	async function loadAll() {
 		loading = true;
@@ -26,7 +27,8 @@
 	function getEV(variant: string, color: string): FontColor | null {
 		const vd = data[variant];
 		if (!vd) return null;
-		return vd.colors.find((c) => c.color === color) || null;
+		const colors = mode === 'safe' ? vd.safe : vd.jackpot;
+		return colors.find((c) => c.color === color) || null;
 	}
 
 	function winner(): { variant: string; color: string; ev: number } {
@@ -42,11 +44,30 @@
 		return best;
 	}
 
+	function liquidityNote(fc: FontColor): string | null {
+		if (!fc.liquidityRisk || fc.liquidityRisk === 'LOW') return null;
+		return `${fc.thinPoolGems || 0} thin`;
+	}
+
 	$effect(() => { refreshKey; loadAll(); });
 </script>
 
 <section class="section">
-	<h2 class="section-title">Font EV</h2>
+	<div class="section-header">
+		<h2 class="section-title">Font EV</h2>
+		<div class="mode-toggle">
+			<button
+				class="toggle-btn"
+				class:active={mode === 'safe'}
+				onclick={() => mode = 'safe'}
+			>Safe</button>
+			<button
+				class="toggle-btn"
+				class:active={mode === 'jackpot'}
+				onclick={() => mode = 'jackpot'}
+			>Jackpot</button>
+		</div>
+	</div>
 
 	{#if loading}
 		<span class="loading">Loading...</span>
@@ -72,6 +93,10 @@
 								{#if cd && cd.ev > 0}
 									<span class="ev" class:best={isW}>{cd.ev}c</span>
 									<span class="det">pool {cd.pool} · {cd.pWin}%</span>
+									{#if cd.liquidityRisk && cd.liquidityRisk !== 'LOW'}
+										{@const note = liquidityNote(cd)}
+										<span class="liq-warn liq-{cd.liquidityRisk.toLowerCase()}">{note}</span>
+									{/if}
 								{:else}
 									<span class="nil">—</span>
 								{/if}
@@ -91,11 +116,44 @@
 		padding: 20px 28px;
 		margin-bottom: 32px;
 	}
+	.section-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 14px;
+	}
 	.section-title {
 		font-size: 1.0625rem;
 		font-weight: 700;
 		color: var(--color-lab-text);
-		margin: 0 0 14px 0;
+		margin: 0;
+	}
+	.mode-toggle {
+		display: flex;
+		gap: 0;
+	}
+	.toggle-btn {
+		background: transparent;
+		border: 1px solid var(--color-lab-border);
+		color: var(--color-lab-text-secondary);
+		padding: 5px 16px;
+		font-size: 0.8125rem;
+		font-weight: 600;
+		cursor: pointer;
+		font-family: inherit;
+		transition: all 0.15s ease;
+	}
+	.toggle-btn:first-child {
+		border-right: none;
+	}
+	.toggle-btn:hover {
+		color: var(--color-lab-text);
+		border-color: var(--color-lab-text-secondary);
+	}
+	.toggle-btn.active {
+		color: var(--color-lab-text);
+		border-color: var(--color-lab-blue);
+		background: rgba(59, 130, 246, 0.15);
 	}
 	.loading { color: var(--color-lab-text-secondary); font-size: 0.875rem; }
 
@@ -141,4 +199,16 @@
 	.c-red { color: var(--color-lab-red); }
 	.c-green { color: var(--color-lab-green); }
 	.c-blue { color: var(--color-lab-blue); }
+
+	.liq-warn {
+		display: block;
+		font-size: 0.75rem;
+		margin-top: 4px;
+	}
+	.liq-medium {
+		color: var(--color-lab-yellow, #eab308);
+	}
+	.liq-high {
+		color: var(--color-lab-red);
+	}
 </style>


### PR DESCRIPTION
## Summary

Adds Safe/Jackpot toggle buttons to Font EV and Font EV Compare components. Each mode shows independently computed EV, winners, pWin, and bestColor from the tier-based backend (POE-70).

### FontEV.svelte
- Two toggle buttons (Safe/Jackpot) in section header top-right
- Mode-specific bestColor highlight with "BEST" badge
- Liquidity risk badges (MEDIUM/HIGH) with thin-pool gem count
- `$state` for mode, `$derived` for active data

### FontEVCompare.svelte
- Same toggle buttons in the 4×3 matrix header
- Best-cell highlight shifts per mode
- Liquidity risk annotations in matrix cells

### api.ts
- New `FontEVResponse` interface (`{safe, jackpot, bestColorSafe, bestColorJackpot}`)
- Updated `fetchFontEV` to parse new backend response
- Added `thinPoolGems`, `liquidityRisk`, `mode` to `FontColor`

### 4 files, 223 additions

## Test plan

- [ ] Visual: toggle buttons render in top-right of Font EV section
- [ ] Visual: switching modes changes EV values, winners, pWin
- [ ] Visual: bestColor highlight changes per mode
- [ ] Visual: liquidity risk badge shows for MEDIUM/HIGH

Closes POE-72

🤖 Generated with [Claude Code](https://claude.com/claude-code)