### PR TITLE
feat(lab): add --validate-sellability mode for value-capture validation

### DIFF
--- a/cmd/optimize/main.go
+++ b/cmd/optimize/main.go
@@ -34,6 +34,16 @@ type JSONValidateOutput struct {
 	OverallAcc      float64                            `json:"overall_acc"`
 }
 
+// JSONSellabilityOutput is the structured output for --validate-sellability --json mode.
+type JSONSellabilityOutput struct {
+	Context               JSONContext                           `json:"context"`
+	PerSignalCapture      map[string]lab.ValueCapture           `json:"per_signal_capture"`
+	FloorHoldRate         map[string]lab.FloorHoldResult        `json:"floor_hold_rate"`
+	ConfidenceCalibration map[string]lab.ConfidenceCalResult    `json:"confidence_calibration"`
+	PerTierCapture        map[string]lab.ValueCapture           `json:"per_tier_capture"`
+	TotalEvals            int                                   `json:"total_evals"`
+}
+
 // JSONContext holds metadata about the optimization run.
 type JSONContext struct {
 	MarketTime      time.Time `json:"market_time"`
@@ -83,6 +93,7 @@ func main() {
 	horizon := flag.String("horizon", "2h", "Ground truth forward horizon (e.g. 2h, 90m)")
 	jsonMode := flag.Bool("json", false, "Output JSON instead of console table")
 	validate := flag.Bool("validate", false, "Validate current defaults (skip grid sweep)")
+	validateSellability := flag.Bool("validate-sellability", false, "Validate risk-adjusted value scoring")
 	flag.Parse()
 
 	horizonDur, err := time.ParseDuration(*horizon)
@@ -163,6 +174,21 @@ func main() {
 			printValidateJSON(report, mc, len(evals), dropped, *hours, *horizon)
 		} else {
 			printValidateConsole(report, mc, len(evals), dropped, *hours, *horizon)
+		}
+		return
+	}
+
+	if *validateSellability {
+		// Validate risk-adjusted value scoring — skip grid sweep.
+		fmt.Fprintf(os.Stderr, "Validating sellability over %d eval points...\n", len(evals))
+		t2 := time.Now()
+		report := lab.ValidateSellability(evals, *mc)
+		fmt.Fprintf(os.Stderr, "Sellability validation complete in %s\n", time.Since(t2).Round(time.Millisecond))
+
+		if *jsonMode {
+			printSellabilityJSON(report, mc, len(evals), dropped, *hours, *horizon)
+		} else {
+			printSellabilityConsole(report, mc, len(evals), dropped, *hours, *horizon)
 		}
 		return
 	}
@@ -460,6 +486,111 @@ func printValidateJSON(report lab.ValidationReport, mc *lab.MarketContext, evalC
 		SweetSpot:       report.SweetSpot,
 		TotalEvals:      report.TotalEvals,
 		OverallAcc:      report.OverallAcc,
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(out); err != nil {
+		fmt.Fprintf(os.Stderr, "JSON encode error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// printSellabilityConsole outputs the human-readable sellability validation report.
+func printSellabilityConsole(report lab.SellabilityReport, mc *lab.MarketContext, evalCount, droppedCount, hours int, horizon string) {
+	// Section 1: Context
+	fmt.Println()
+	fmt.Println("=== Sellability Validation ===")
+	fmt.Printf("  Market time:       %s\n", mc.Time.Format(time.RFC3339))
+	fmt.Printf("  Total gems:        %d\n", mc.TotalGems)
+	fmt.Printf("  Velocity:          mean=%.2f sigma=%.2f\n", mc.VelocityMean, mc.VelocitySigma)
+	fmt.Printf("  Listing velocity:  mean=%.2f sigma=%.2f\n", mc.ListingVelMean, mc.ListingVelSigma)
+	fmt.Printf("  Eval points:       %d (dropped %d)\n", evalCount, droppedCount)
+	fmt.Printf("  Time range:        %dh, horizon=%s\n", hours, horizon)
+	fmt.Printf("  Scored evals:      %d\n", report.TotalEvals)
+	fmt.Println()
+
+	// Section 2: Per-signal value capture
+	fmt.Println("Per-Signal Value Capture (actual / risk-adjusted):")
+	signalOrder := []string{"HERD", "STABLE", "DUMPING", "UNCERTAIN", "RECOVERY", "TRAP"}
+	printedSignals := make(map[string]bool)
+	for _, sig := range signalOrder {
+		vc, ok := report.PerSignalCapture[sig]
+		if !ok {
+			continue
+		}
+		printedSignals[sig] = true
+		fmt.Printf("  %-12s avg %.2f  median %.2f  [p25: %.2f  p75: %.2f]  (n=%d)\n",
+			sig+":", vc.AvgCapture, vc.MedianCapture, vc.P25Capture, vc.P75Capture, vc.Count)
+	}
+	// Print any signals not in the standard order.
+	for sig, vc := range report.PerSignalCapture {
+		if printedSignals[sig] {
+			continue
+		}
+		fmt.Printf("  %-12s avg %.2f  median %.2f  [p25: %.2f  p75: %.2f]  (n=%d)\n",
+			sig+":", vc.AvgCapture, vc.MedianCapture, vc.P25Capture, vc.P75Capture, vc.Count)
+	}
+	fmt.Println()
+
+	// Section 3: Floor hold rate
+	fmt.Println("Floor Hold Rate (price stayed above 7d floor):")
+	tierOrder := []string{"TOP", "HIGH", "MID", "LOW"}
+	for _, tier := range tierOrder {
+		fh, ok := report.FloorHoldRate[tier]
+		if !ok {
+			continue
+		}
+		fmt.Printf("  %-6s %.1f%%  (n=%d)\n", tier+":", fh.HeldRate, fh.Count)
+	}
+	fmt.Println()
+
+	// Section 4: Sell confidence calibration
+	fmt.Println("Sell Confidence Calibration:")
+	confOrder := []string{"GREEN", "YELLOW", "RED"}
+	for _, conf := range confOrder {
+		cal, ok := report.ConfidenceCalibration[conf]
+		if !ok {
+			continue
+		}
+		fmt.Printf("  %-8s price held %.1f%% of time  avg change %.1f%%  (n=%d)\n",
+			conf+":", cal.HeldRate, cal.AvgChange, cal.Count)
+	}
+	fmt.Println()
+
+	// Section 5: Per-tier value capture
+	fmt.Println("Per-Tier Value Capture:")
+	for _, tier := range tierOrder {
+		vc, ok := report.PerTierCapture[tier]
+		if !ok {
+			continue
+		}
+		fmt.Printf("  %-6s avg %.2f  median %.2f  [p25: %.2f  p75: %.2f]  (n=%d)\n",
+			tier+":", vc.AvgCapture, vc.MedianCapture, vc.P25Capture, vc.P75Capture, vc.Count)
+	}
+	fmt.Println()
+}
+
+// printSellabilityJSON outputs the structured JSON sellability validation report.
+func printSellabilityJSON(report lab.SellabilityReport, mc *lab.MarketContext, evalCount, droppedCount, hours int, horizon string) {
+	out := JSONSellabilityOutput{
+		Context: JSONContext{
+			MarketTime:      mc.Time,
+			TotalGems:       mc.TotalGems,
+			VelocityMean:    mc.VelocityMean,
+			VelocitySigma:   mc.VelocitySigma,
+			ListingVelMean:  mc.ListingVelMean,
+			ListingVelSigma: mc.ListingVelSigma,
+			EvalPoints:      evalCount,
+			DroppedPoints:   droppedCount,
+			Hours:           hours,
+			Horizon:         horizon,
+		},
+		PerSignalCapture:      report.PerSignalCapture,
+		FloorHoldRate:         report.FloorHoldRate,
+		ConfidenceCalibration: report.ConfidenceCalibration,
+		PerTierCapture:        report.PerTierCapture,
+		TotalEvals:            report.TotalEvals,
 	}
 
 	enc := json.NewEncoder(os.Stdout)

--- a/internal/lab/optimizer.go
+++ b/internal/lab/optimizer.go
@@ -1,6 +1,7 @@
 package lab
 
 import (
+	"math"
 	"sort"
 	"time"
 )
@@ -675,4 +676,221 @@ func ValidateDefaults(evals []EvalPoint, mc MarketContext) ValidationReport {
 	report.OverallAcc = float64(overallCorrect) / float64(len(evals)) * 100
 
 	return report
+}
+
+// ValueCapture holds percentile statistics for actual-vs-predicted value ratios.
+type ValueCapture struct {
+	Count         int     `json:"count"`
+	AvgCapture    float64 `json:"avg_capture"`    // mean(actualPrice / predictedRiskAdjValue)
+	MedianCapture float64 `json:"median_capture"`
+	P25Capture    float64 `json:"p25_capture"`    // 25th percentile
+	P75Capture    float64 `json:"p75_capture"`    // 75th percentile
+}
+
+// ConfidenceCalResult holds calibration metrics for a sell confidence level.
+type ConfidenceCalResult struct {
+	Count     int     `json:"count"`
+	PriceHeld int     `json:"price_held"` // count where future_price >= 0.9 * current_price
+	HeldRate  float64 `json:"held_rate"`  // PriceHeld / Count
+	AvgChange float64 `json:"avg_change"` // mean price change %
+}
+
+// SellabilityReport holds the full output of ValidateSellability.
+type SellabilityReport struct {
+	TotalEvals            int                            `json:"total_evals"`
+	PerSignalCapture      map[string]ValueCapture        `json:"per_signal_capture"`
+	FloorHoldRate         map[string]FloorHoldResult     `json:"floor_hold_rate"`
+	ConfidenceCalibration map[string]ConfidenceCalResult `json:"confidence_calibration"`
+	PerTierCapture        map[string]ValueCapture        `json:"per_tier_capture"`
+}
+
+// FloorHoldResult holds floor hold statistics for a tier.
+type FloorHoldResult struct {
+	Count    int     `json:"count"`
+	Held     int     `json:"held"`
+	HeldRate float64 `json:"held_rate"`
+}
+
+// ValidateSellability evaluates how well the risk-adjusted scoring predicts
+// actual value capture. For each EvalPoint, it computes the risk-adjusted value
+// and compares it against the realized future price.
+func ValidateSellability(evals []EvalPoint, mc MarketContext) SellabilityReport {
+	report := SellabilityReport{
+		PerSignalCapture:      make(map[string]ValueCapture),
+		FloorHoldRate:         make(map[string]FloorHoldResult),
+		ConfidenceCalibration: make(map[string]ConfidenceCalResult),
+		PerTierCapture:        make(map[string]ValueCapture),
+	}
+
+	if len(evals) == 0 {
+		return report
+	}
+
+	cfg := DefaultSignalConfig()
+
+	// Accumulators: capture ratios grouped by signal, tier, and sell confidence.
+	type captureAcc struct {
+		ratios []float64
+	}
+	signalCaptures := make(map[string]*captureAcc)
+	tierCaptures := make(map[string]*captureAcc)
+
+	// Floor hold accumulators by tier.
+	type floorAcc struct {
+		total int
+		held  int
+	}
+	floorAccs := make(map[string]*floorAcc)
+
+	// Confidence calibration accumulators.
+	type confCalAcc struct {
+		total     int
+		priceHeld int
+		changeSum float64
+	}
+	confCalAccs := make(map[string]*confCalAcc)
+
+	skipped := 0
+
+	for _, ep := range evals {
+		// Compute risk-adjusted value from feature data.
+		riskAdjValue := ep.Feature.Chaos * ep.Feature.SellProbabilityFactor * ep.Feature.StabilityDiscount
+
+		// Skip if risk-adjusted value is too small (avoids division by zero / noise).
+		if riskAdjValue < 0.01 {
+			skipped++
+			continue
+		}
+
+		// Derive future price from the percentage change.
+		// FuturePct = (futurePrice - baseline) / baseline * 100
+		// We use feature.Chaos as the baseline for consistency with risk-adjusted value.
+		futurePrice := ep.Feature.Chaos * (1.0 + ep.FuturePct/100.0)
+
+		// Actual value capture ratio.
+		actualCapture := futurePrice / riskAdjValue
+
+		// Classify the signal for grouping.
+		signal := classifySignalWithConfig(
+			ep.Feature.VelMedPrice,
+			ep.Feature.VelMedListing,
+			ep.Feature.CV,
+			ep.Feature.Listings,
+			cfg,
+		)
+
+		// Classify sell confidence.
+		sellConf := classifySellConfidence(ep.Feature.SellProbabilityFactor, ep.Feature.StabilityDiscount)
+
+		// Determine tier.
+		tier := ep.Feature.Tier
+		if tier == "" {
+			tier = "LOW"
+		}
+
+		// Accumulate per-signal capture.
+		if _, ok := signalCaptures[signal]; !ok {
+			signalCaptures[signal] = &captureAcc{}
+		}
+		signalCaptures[signal].ratios = append(signalCaptures[signal].ratios, actualCapture)
+
+		// Accumulate per-tier capture.
+		if _, ok := tierCaptures[tier]; !ok {
+			tierCaptures[tier] = &captureAcc{}
+		}
+		tierCaptures[tier].ratios = append(tierCaptures[tier].ratios, actualCapture)
+
+		// Floor hold: did price stay above Low7d?
+		if _, ok := floorAccs[tier]; !ok {
+			floorAccs[tier] = &floorAcc{}
+		}
+		fa := floorAccs[tier]
+		fa.total++
+		if futurePrice >= ep.Feature.Low7d {
+			fa.held++
+		}
+
+		// Confidence calibration: did price hold within 10% of current?
+		if _, ok := confCalAccs[sellConf]; !ok {
+			confCalAccs[sellConf] = &confCalAcc{}
+		}
+		ca := confCalAccs[sellConf]
+		ca.total++
+		if futurePrice >= 0.9*ep.Feature.Chaos {
+			ca.priceHeld++
+		}
+		ca.changeSum += ep.FuturePct
+	}
+
+	// Build per-signal capture map.
+	for sig, acc := range signalCaptures {
+		report.PerSignalCapture[sig] = computeValueCapture(acc.ratios)
+	}
+
+	// Build per-tier capture map.
+	for tier, acc := range tierCaptures {
+		report.PerTierCapture[tier] = computeValueCapture(acc.ratios)
+	}
+
+	// Build floor hold rate map.
+	for tier, fa := range floorAccs {
+		var rate float64
+		if fa.total > 0 {
+			rate = float64(fa.held) / float64(fa.total) * 100
+		}
+		report.FloorHoldRate[tier] = FloorHoldResult{
+			Count:    fa.total,
+			Held:     fa.held,
+			HeldRate: rate,
+		}
+	}
+
+	// Build confidence calibration map.
+	for conf, ca := range confCalAccs {
+		var heldRate float64
+		if ca.total > 0 {
+			heldRate = float64(ca.priceHeld) / float64(ca.total) * 100
+		}
+		var avgChange float64
+		if ca.total > 0 {
+			avgChange = ca.changeSum / float64(ca.total)
+		}
+		report.ConfidenceCalibration[conf] = ConfidenceCalResult{
+			Count:     ca.total,
+			PriceHeld: ca.priceHeld,
+			HeldRate:  heldRate,
+			AvgChange: avgChange,
+		}
+	}
+
+	report.TotalEvals = len(evals) - skipped
+
+	return report
+}
+
+// computeValueCapture computes ValueCapture statistics from a slice of capture ratios.
+func computeValueCapture(ratios []float64) ValueCapture {
+	if len(ratios) == 0 {
+		return ValueCapture{}
+	}
+
+	// Compute mean.
+	var sum float64
+	for _, r := range ratios {
+		sum += r
+	}
+	avg := sum / float64(len(ratios))
+
+	// Sort for percentiles.
+	sorted := make([]float64, len(ratios))
+	copy(sorted, ratios)
+	sort.Float64s(sorted)
+
+	return ValueCapture{
+		Count:         len(ratios),
+		AvgCapture:    math.Round(avg*100) / 100,
+		MedianCapture: math.Round(percentile(sorted, 0.50)*100) / 100,
+		P25Capture:    math.Round(percentile(sorted, 0.25)*100) / 100,
+		P75Capture:    math.Round(percentile(sorted, 0.75)*100) / 100,
+	}
 }

--- a/internal/lab/sellability_test.go
+++ b/internal/lab/sellability_test.go
@@ -1,0 +1,478 @@
+package lab
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// ValidateSellability tests
+// ---------------------------------------------------------------------------
+
+func TestValidateSellability_EmptyEvals(t *testing.T) {
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	report := ValidateSellability(nil, mc)
+
+	if report.TotalEvals != 0 {
+		t.Errorf("TotalEvals: got %d, want 0", report.TotalEvals)
+	}
+	if len(report.PerSignalCapture) != 0 {
+		t.Errorf("PerSignalCapture: expected empty, got %d entries", len(report.PerSignalCapture))
+	}
+	if len(report.FloorHoldRate) != 0 {
+		t.Errorf("FloorHoldRate: expected empty, got %d entries", len(report.FloorHoldRate))
+	}
+	if len(report.ConfidenceCalibration) != 0 {
+		t.Errorf("ConfidenceCalibration: expected empty, got %d entries", len(report.ConfidenceCalibration))
+	}
+	if len(report.PerTierCapture) != 0 {
+		t.Errorf("PerTierCapture: expected empty, got %d entries", len(report.PerTierCapture))
+	}
+}
+
+func TestValidateSellability_ValueCapture(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	// Create eval points with known SellProbabilityFactor and StabilityDiscount.
+	// STABLE signal: low velocity.
+	// RiskAdjustedValue = Chaos * SellProbabilityFactor * StabilityDiscount
+	//
+	// For feature with Chaos=100, SellProb=0.8, StabDisc=0.9:
+	//   RAV = 100 * 0.8 * 0.9 = 72
+	// If future price = 100 (0% change): capture = 100/72 = 1.389
+	// If future price = 80 (-20% change): capture = 80/72 = 1.111
+	evals := []EvalPoint{
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "MID", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120, HistPosition: 50,
+			},
+			FuturePct: 0.0, // future price = 100
+			SnapTime:  t0,
+		},
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.2, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "MID", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120, HistPosition: 50,
+			},
+			FuturePct: -20.0, // future price = 80
+			SnapTime:  t0,
+		},
+	}
+
+	report := ValidateSellability(evals, mc)
+
+	if report.TotalEvals != 2 {
+		t.Fatalf("TotalEvals: got %d, want 2", report.TotalEvals)
+	}
+
+	// Both should be STABLE signal with these low velocities.
+	vc, ok := report.PerSignalCapture["STABLE"]
+	if !ok {
+		// Check what signals were actually generated.
+		for sig := range report.PerSignalCapture {
+			t.Logf("Signal found: %s", sig)
+		}
+		t.Fatal("expected STABLE signal in PerSignalCapture")
+	}
+	if vc.Count != 2 {
+		t.Errorf("STABLE count: got %d, want 2", vc.Count)
+	}
+
+	// RAV = 72. Captures: 100/72 = 1.39, 80/72 = 1.11. Avg = 1.25.
+	expectedAvg := (100.0/72.0 + 80.0/72.0) / 2.0
+	if !approxEqual(vc.AvgCapture, math.Round(expectedAvg*100)/100, 0.01) {
+		t.Errorf("STABLE AvgCapture: got %.2f, want %.2f", vc.AvgCapture, expectedAvg)
+	}
+}
+
+func TestValidateSellability_FloorHoldRate(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	evals := []EvalPoint{
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "HIGH", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: 0.0, // future price = 100, above Low7d=80
+			SnapTime:  t0,
+		},
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.2, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "HIGH", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: -25.0, // future price = 75, below Low7d=80
+			SnapTime:  t0,
+		},
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: -0.1, VelMedListing: 0.2, CV: 10, Listings: 30,
+				Tier: "HIGH", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: -10.0, // future price = 90, above Low7d=80
+			SnapTime:  t0,
+		},
+	}
+
+	report := ValidateSellability(evals, mc)
+
+	fh, ok := report.FloorHoldRate["HIGH"]
+	if !ok {
+		t.Fatal("expected HIGH tier in FloorHoldRate")
+	}
+	if fh.Count != 3 {
+		t.Errorf("FloorHoldRate[HIGH].Count: got %d, want 3", fh.Count)
+	}
+	if fh.Held != 2 {
+		t.Errorf("FloorHoldRate[HIGH].Held: got %d, want 2", fh.Held)
+	}
+	// 2/3 = 66.67%
+	if !approxEqual(fh.HeldRate, 66.67, 0.1) {
+		t.Errorf("FloorHoldRate[HIGH].HeldRate: got %.2f, want ~66.67", fh.HeldRate)
+	}
+}
+
+func TestValidateSellability_ConfidenceCalibration(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	// GREEN: sellProb >= 0.7 AND stabilityDisc >= 0.8
+	evals := []EvalPoint{
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "MID", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: -5.0, // future price = 95, >= 0.9*100=90: held
+			SnapTime:  t0,
+		},
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.2, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "MID", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: -15.0, // future price = 85, < 0.9*100=90: NOT held
+			SnapTime:  t0,
+		},
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "MID", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: 5.0, // future price = 105, >= 90: held
+			SnapTime:  t0,
+		},
+	}
+
+	report := ValidateSellability(evals, mc)
+
+	// All three should be GREEN (sellProb=0.8 >= 0.7, stabDisc=0.9 >= 0.8).
+	cal, ok := report.ConfidenceCalibration["GREEN"]
+	if !ok {
+		for conf := range report.ConfidenceCalibration {
+			t.Logf("Confidence found: %s", conf)
+		}
+		t.Fatal("expected GREEN in ConfidenceCalibration")
+	}
+	if cal.Count != 3 {
+		t.Errorf("GREEN count: got %d, want 3", cal.Count)
+	}
+	if cal.PriceHeld != 2 {
+		t.Errorf("GREEN PriceHeld: got %d, want 2", cal.PriceHeld)
+	}
+	// 2/3 = 66.67%
+	if !approxEqual(cal.HeldRate, 66.67, 0.1) {
+		t.Errorf("GREEN HeldRate: got %.2f, want ~66.67", cal.HeldRate)
+	}
+	// avg change: (-5 + -15 + 5) / 3 = -5
+	if !approxEqual(cal.AvgChange, -5.0, 0.1) {
+		t.Errorf("GREEN AvgChange: got %.2f, want -5.0", cal.AvgChange)
+	}
+}
+
+func TestValidateSellability_PerTierCapture(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	evals := []EvalPoint{
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "TOP", Chaos: 200,
+				SellProbabilityFactor: 0.9, StabilityDiscount: 0.95,
+				Low7d: 180, High7d: 220,
+			},
+			FuturePct: 0.0,
+			SnapTime:  t0,
+		},
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.2, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "LOW", Chaos: 10,
+				SellProbabilityFactor: 0.5, StabilityDiscount: 0.8,
+				Low7d: 8, High7d: 12,
+			},
+			FuturePct: 0.0,
+			SnapTime:  t0,
+		},
+	}
+
+	report := ValidateSellability(evals, mc)
+
+	// TOP tier should have 1 entry.
+	topVC, ok := report.PerTierCapture["TOP"]
+	if !ok {
+		t.Fatal("expected TOP in PerTierCapture")
+	}
+	if topVC.Count != 1 {
+		t.Errorf("TOP count: got %d, want 1", topVC.Count)
+	}
+
+	// LOW tier should have 1 entry.
+	lowVC, ok := report.PerTierCapture["LOW"]
+	if !ok {
+		t.Fatal("expected LOW in PerTierCapture")
+	}
+	if lowVC.Count != 1 {
+		t.Errorf("LOW count: got %d, want 1", lowVC.Count)
+	}
+
+	// TOP: RAV = 200*0.9*0.95 = 171, future=200, capture=200/171 = 1.17
+	expectedTopCapture := 200.0 / (200.0 * 0.9 * 0.95)
+	if !approxEqual(topVC.AvgCapture, math.Round(expectedTopCapture*100)/100, 0.01) {
+		t.Errorf("TOP AvgCapture: got %.2f, want %.2f", topVC.AvgCapture, expectedTopCapture)
+	}
+}
+
+func TestValidateSellability_SkipsZeroRAV(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	evals := []EvalPoint{
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "MID", Chaos: 0, // zero chaos => RAV = 0
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 0, High7d: 0,
+			},
+			FuturePct: 10.0,
+			SnapTime:  t0,
+		},
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "MID", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: 0.0,
+			SnapTime:  t0,
+		},
+	}
+
+	report := ValidateSellability(evals, mc)
+
+	// Only 1 eval should be scored (the zero-RAV one is skipped).
+	if report.TotalEvals != 1 {
+		t.Errorf("TotalEvals: got %d, want 1 (zero-RAV should be skipped)", report.TotalEvals)
+	}
+}
+
+func TestValidateSellability_EmptyTierDefaultsToLOW(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	evals := []EvalPoint{
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "", Chaos: 100, // empty tier
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: 0.0,
+			SnapTime:  t0,
+		},
+	}
+
+	report := ValidateSellability(evals, mc)
+
+	// Empty tier should be counted as LOW.
+	if _, ok := report.PerTierCapture["LOW"]; !ok {
+		t.Error("expected empty tier to be counted as LOW in PerTierCapture")
+	}
+	if _, ok := report.FloorHoldRate["LOW"]; !ok {
+		t.Error("expected empty tier to be counted as LOW in FloorHoldRate")
+	}
+}
+
+func TestValidateSellability_MultipleSignalTypes(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	// DefaultSignalConfig: DumpPriceVel=-5, DumpListingVel=5
+	// DUMPING: priceVel < -5 && listingVel > 5
+	// STABLE: |priceVel| < 2 && |listingVel| < 3
+	evals := []EvalPoint{
+		// STABLE
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "MID", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: 0.0,
+			SnapTime:  t0,
+		},
+		// DUMPING: priceVel=-10 < -5, listingVel=10 > 5
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: -10, VelMedListing: 10, CV: 10, Listings: 30,
+				Tier: "MID", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: -15.0,
+			SnapTime:  t0,
+		},
+	}
+
+	report := ValidateSellability(evals, mc)
+
+	if len(report.PerSignalCapture) < 2 {
+		t.Errorf("expected at least 2 signal types, got %d", len(report.PerSignalCapture))
+	}
+
+	if _, ok := report.PerSignalCapture["STABLE"]; !ok {
+		t.Error("expected STABLE in PerSignalCapture")
+	}
+	if _, ok := report.PerSignalCapture["DUMPING"]; !ok {
+		t.Error("expected DUMPING in PerSignalCapture")
+	}
+}
+
+func TestValidateSellability_ConfCalibrationMultipleColors(t *testing.T) {
+	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
+	mc := sweepMarketContext(0, 10, 0, 5)
+
+	evals := []EvalPoint{
+		// GREEN: sellProb=0.8 >= 0.7, stabDisc=0.9 >= 0.8
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "MID", Chaos: 100,
+				SellProbabilityFactor: 0.8, StabilityDiscount: 0.9,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: 0.0,
+			SnapTime:  t0,
+		},
+		// RED: sellProb=0.35 < 0.5, stabDisc=0.55 < 0.7
+		{
+			Feature: GemFeature{
+				Time: t0, VelMedPrice: 0.2, VelMedListing: 0.1, CV: 10, Listings: 30,
+				Tier: "MID", Chaos: 100,
+				SellProbabilityFactor: 0.35, StabilityDiscount: 0.55,
+				Low7d: 80, High7d: 120,
+			},
+			FuturePct: -20.0,
+			SnapTime:  t0,
+		},
+	}
+
+	report := ValidateSellability(evals, mc)
+
+	if _, ok := report.ConfidenceCalibration["GREEN"]; !ok {
+		t.Error("expected GREEN in ConfidenceCalibration")
+	}
+	if _, ok := report.ConfidenceCalibration["RED"]; !ok {
+		t.Error("expected RED in ConfidenceCalibration")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// computeValueCapture tests
+// ---------------------------------------------------------------------------
+
+func TestComputeValueCapture_Empty(t *testing.T) {
+	vc := computeValueCapture(nil)
+
+	if vc.Count != 0 {
+		t.Errorf("Count: got %d, want 0", vc.Count)
+	}
+	if vc.AvgCapture != 0 {
+		t.Errorf("AvgCapture: got %.2f, want 0", vc.AvgCapture)
+	}
+}
+
+func TestComputeValueCapture_SingleValue(t *testing.T) {
+	vc := computeValueCapture([]float64{1.5})
+
+	if vc.Count != 1 {
+		t.Errorf("Count: got %d, want 1", vc.Count)
+	}
+	if !approxEqual(vc.AvgCapture, 1.5, 0.01) {
+		t.Errorf("AvgCapture: got %.2f, want 1.5", vc.AvgCapture)
+	}
+	if !approxEqual(vc.MedianCapture, 1.5, 0.01) {
+		t.Errorf("MedianCapture: got %.2f, want 1.5", vc.MedianCapture)
+	}
+	if !approxEqual(vc.P25Capture, 1.5, 0.01) {
+		t.Errorf("P25Capture: got %.2f, want 1.5", vc.P25Capture)
+	}
+	if !approxEqual(vc.P75Capture, 1.5, 0.01) {
+		t.Errorf("P75Capture: got %.2f, want 1.5", vc.P75Capture)
+	}
+}
+
+func TestComputeValueCapture_KnownDistribution(t *testing.T) {
+	// 5 values: 0.5, 0.8, 1.0, 1.2, 1.5
+	// Mean = (0.5+0.8+1.0+1.2+1.5)/5 = 1.0
+	// Median (p50) = 1.0
+	// P25 = interpolation at index 1.0 = 0.8
+	// P75 = interpolation at index 3.0 = 1.2
+	ratios := []float64{1.0, 0.5, 1.5, 0.8, 1.2}
+
+	vc := computeValueCapture(ratios)
+
+	if vc.Count != 5 {
+		t.Errorf("Count: got %d, want 5", vc.Count)
+	}
+	if !approxEqual(vc.AvgCapture, 1.0, 0.01) {
+		t.Errorf("AvgCapture: got %.2f, want 1.0", vc.AvgCapture)
+	}
+	if !approxEqual(vc.MedianCapture, 1.0, 0.01) {
+		t.Errorf("MedianCapture: got %.2f, want 1.0", vc.MedianCapture)
+	}
+	if !approxEqual(vc.P25Capture, 0.8, 0.01) {
+		t.Errorf("P25Capture: got %.2f, want 0.8", vc.P25Capture)
+	}
+	if !approxEqual(vc.P75Capture, 1.2, 0.01) {
+		t.Errorf("P75Capture: got %.2f, want 1.2", vc.P75Capture)
+	}
+}
+


### PR DESCRIPTION
## Summary

Adds `--validate-sellability` CLI flag to `cmd/optimize` for validating risk-adjusted value scoring against historical data. Replaces the broken directional accuracy metric (55%) with value-capture analysis.

### New validation metrics

- **Per-signal value capture**: when system assigns signal X, what % of RiskAdjustedValue was actually realized? (avg, median, p25, p75)
- **Floor hold rate**: what % of time did price stay above 7-day floor? (per tier)
- **Sell confidence calibration**: when system says GREEN, what % of time did price hold within 10%? (GREEN/YELLOW/RED)
- **Per-tier value capture**: do TOP gems realize expected value differently than MID?

### Usage

```bash
# Text output
docker compose exec -T app go run ./cmd/optimize --validate-sellability

# JSON output
docker compose exec -T app go run ./cmd/optimize --validate-sellability --json
```

### Implementation

- `ValidateSellability()` on Optimizer — reuses existing EvalPoint data loading
- `SellabilityReport` with ValueCapture, ConfidenceCalResult, FloorHoldResult structs
- Reuses `percentile()` from market_context.go for p25/p75
- Existing `--validate` (directional) completely untouched

### 3 files, 827 additions, 12 tests

## Test plan

- [x] 12 new tests (value capture, floor hold, confidence calibration, per-tier, edge cases)
- [x] All lab tests pass
- [x] `go vet` clean
- [x] Existing `--validate` unchanged
- [ ] Run against real data: `--validate-sellability --json`

Closes POE-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)