### PR TITLE
fix(lab): per-variant scoring, SAFE/FAIR/RISKY rename, TRAP requires active velocity

### DIFF
--- a/frontend/src/lib/tooltips.ts
+++ b/frontend/src/lib/tooltips.ts
@@ -54,9 +54,9 @@ export const METRIC_TOOLTIPS: Record<string, string> = {
 };
 
 export const SELL_CONFIDENCE_TOOLTIPS: Record<string, string> = {
-	GREEN: 'Liquid market, stable price \u2014 will sell near listed price',
-	YELLOW: 'Moderate risk \u2014 may need patience or small undercut',
-	RED: 'Thin market or volatile \u2014 significant gap between listed and realizable price',
+	SAFE: 'Liquid market, stable price \u2014 will sell near listed price',
+	FAIR: 'Moderate risk \u2014 may need patience or small undercut',
+	RISKY: 'Thin market or volatile \u2014 significant gap between listed and realizable price',
 };
 
 export const LIQUIDITY_TOOLTIPS: Record<string, string> = {

--- a/frontend/src/routes/lab/components/SignalBadge.svelte
+++ b/frontend/src/routes/lab/components/SignalBadge.svelte
@@ -35,9 +35,9 @@
 	};
 
 	const CONFIDENCE_STYLES: Record<string, { prefix: string; cssClass: string }> = {
-		GREEN:  { prefix: '\u2713', cssClass: 'badge-green' },
-		YELLOW: { prefix: '\u26A0', cssClass: 'badge-yellow' },
-		RED:    { prefix: '\u2717', cssClass: 'badge-red' },
+		SAFE:  { prefix: '\u2713', cssClass: 'badge-green' },
+		FAIR:  { prefix: '\u26A0', cssClass: 'badge-yellow' },
+		RISKY: { prefix: '\u2717', cssClass: 'badge-red' },
 	};
 
 	function getStyle() {

--- a/internal/db/migrations/20260320161358_add_variant_stats_to_market_context.down.sql
+++ b/internal/db/migrations/20260320161358_add_variant_stats_to_market_context.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE market_context DROP COLUMN variant_stats;

--- a/internal/db/migrations/20260320161358_add_variant_stats_to_market_context.up.sql
+++ b/internal/db/migrations/20260320161358_add_variant_stats_to_market_context.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE market_context ADD COLUMN variant_stats JSONB NOT NULL DEFAULT '{}';

--- a/internal/lab/collective.go
+++ b/internal/lab/collective.go
@@ -355,19 +355,19 @@ func BuildCompareResults(
 	return results
 }
 
-// deriveSellConfidence returns GREEN/YELLOW/RED based on market conditions.
-// GREEN = liquid + stable, YELLOW = moderate risk, RED = thin/volatile.
+// deriveSellConfidence returns SAFE/FAIR/RISKY based on market conditions.
+// SAFE = liquid + stable, FAIR = moderate risk, RISKY = thin/volatile.
 func deriveSellConfidence(listings int, cv float64, signal string) string {
 	if signal == "TRAP" || signal == "DUMPING" {
-		return "RED"
+		return "RISKY"
 	}
 	if listings >= 15 && cv < 30 {
-		return "GREEN"
+		return "SAFE"
 	}
 	if listings >= 5 && cv < 60 {
-		return "YELLOW"
+		return "FAIR"
 	}
-	return "RED"
+	return "RISKY"
 }
 
 // deriveSellConfidenceReason returns a human-readable explanation of sell confidence.
@@ -380,9 +380,9 @@ func deriveSellConfidenceReason(listings int, cv float64, signal string) string 
 	}
 	conf := deriveSellConfidence(listings, cv, signal)
 	switch conf {
-	case "GREEN":
+	case "SAFE":
 		return fmt.Sprintf("%d listings — liquid, stable", listings)
-	case "YELLOW":
+	case "FAIR":
 		return fmt.Sprintf("%d listings — moderate liquidity", listings)
 	default:
 		if listings < 5 {

--- a/internal/lab/gem_features.go
+++ b/internal/lab/gem_features.go
@@ -84,7 +84,11 @@ func ComputeGemFeatures(snapTime time.Time, gems []GemPrice, history []GemPriceH
 		// else: stay at zero defaults (insufficient history)
 
 		// Risk-adjusted scoring fields.
-		f.SellProbabilityFactor = sellProbabilityFactor(g.Listings, f.Low7d, g.Chaos)
+		variantMedianListings := 30.0 // fallback for missing data
+		if vs, ok := mc.VariantStats[g.Variant]; ok && vs.MedianListings > 0 {
+			variantMedianListings = vs.MedianListings
+		}
+		f.SellProbabilityFactor = sellProbabilityFactor(g.Listings, f.Low7d, g.Chaos, variantMedianListings)
 		f.StabilityDiscount = stabilityDiscount(f.CV)
 
 		// Sanitize non-velocity float fields.
@@ -113,10 +117,15 @@ func extractListings(p PricePoint) float64 { return float64(p.Listings) }
 
 // sellProbabilityFactor returns a 0.3-1.0 factor representing how likely this gem
 // is to sell within an hour, calibrated from listing count with context-aware
-// thin-market adjustments.
-func sellProbabilityFactor(listings int, low7d, currentPrice float64) float64 {
-	// Base: sigmoid on listing count.
-	base := 0.3 + 0.7*(1.0/(1.0+math.Exp(-0.1*float64(listings-20))))
+// thin-market adjustments. The medianListings parameter is the variant's median
+// listing count, used as the sigmoid center for per-variant calibration.
+func sellProbabilityFactor(listings int, low7d, currentPrice, medianListings float64) float64 {
+	// Sigmoid centered at the variant's median listings.
+	center := medianListings
+	if center < 5 {
+		center = 5 // floor to prevent degenerate sigmoid
+	}
+	base := 0.3 + 0.7*(1.0/(1.0+math.Exp(-0.1*float64(listings-int(center)))))
 
 	// Context-aware thin-market adjustment.
 	if listings < 10 && currentPrice > 0 {

--- a/internal/lab/gem_signals.go
+++ b/internal/lab/gem_signals.go
@@ -153,14 +153,17 @@ func quickSellUndercutFactor(listings int, tier string) float64 {
 	return base
 }
 
-// classifySellConfidence returns GREEN, YELLOW, or RED based on the
+// classifySellConfidence returns SAFE, FAIR, or RISKY based on the
 // sell probability factor and stability discount.
+// SAFE: both factors well above typical (top quartile).
+// RISKY: at least one factor is poor.
+// FAIR: everything in between.
 func classifySellConfidence(sellProb, stabilityDisc float64) string {
-	if sellProb >= 0.7 && stabilityDisc >= 0.8 {
-		return "GREEN"
+	if sellProb >= 0.8 && stabilityDisc >= 0.85 {
+		return "SAFE"
 	}
-	if sellProb >= 0.5 || stabilityDisc >= 0.7 {
-		return "YELLOW"
+	if sellProb < 0.5 && stabilityDisc < 0.7 {
+		return "RISKY"
 	}
-	return "RED"
+	return "FAIR"
 }

--- a/internal/lab/gem_signals_test.go
+++ b/internal/lab/gem_signals_test.go
@@ -186,10 +186,10 @@ func TestComputeGemSignals_TRAPLowConfidence(t *testing.T) {
 	mc := testSignalMarketContext()
 
 	f := testFeature("Volatile of Storm", "20/20", 100, 10)
-	// Very high CV => TRAP signal.
+	// Very high CV + active velocity => TRAP signal.
 	f.CV = 110
-	f.VelShortPrice = 5
-	f.VelMedPrice = -3
+	f.VelShortPrice = 8
+	f.VelMedPrice = -7
 	f.VelLongPrice = 2
 	f.Tier = "MID"
 
@@ -257,7 +257,8 @@ func TestComputeGemSignals_RecommendationAVOID_TRAP(t *testing.T) {
 	mc := testSignalMarketContext()
 
 	f := testFeature("Volatile of Storm", "20/20", 100, 10)
-	f.CV = 110 // TRAP
+	f.CV = 110 // TRAP requires high CV + active velocity
+	f.VelMedPrice = -8
 	f.Tier = "MID"
 
 	gems := testBaseGems("Volatile", 30)
@@ -308,7 +309,8 @@ func TestComputeGemSignals_RecommendationAVOID_SELL_NOW(t *testing.T) {
 	// TRAP signal on a HIGH tier gem always produces SellUrgency=SELL_NOW.
 	// See trends.go: sellUrgency checks TRAP before any other condition for non-LOW tiers.
 	f := testFeature("Trap of Danger", "20/20", 100, 10)
-	f.CV = 110 // CV > 100 => TRAP
+	f.CV = 110 // TRAP requires high CV + active velocity
+	f.VelMedPrice = 10
 	f.Tier = "HIGH"
 
 	gems := testBaseGems("Trap", 30)

--- a/internal/lab/market_context.go
+++ b/internal/lab/market_context.go
@@ -87,6 +87,9 @@ func ComputeMarketContext(snapTime time.Time, gems []GemPrice, history []GemPric
 		mc.ListingVelMean, mc.ListingVelSigma = meanStddev(velListings)
 	}
 
+	// Compute per-variant baselines from active gems.
+	mc.VariantStats = computeVariantBaselines(active)
+
 	// Compute tier boundaries using natural gap detection.
 	mc.TierBoundaries = DetectTierBoundaries(gems)
 
@@ -193,4 +196,40 @@ func meanStddev(vals []float64) (float64, float64) {
 	variance /= float64(n)
 
 	return sanitizeFloat(mean), sanitizeFloat(math.Sqrt(variance))
+}
+
+// computeVariantBaselines groups active (transfigured, non-corrupted) gems by
+// variant and computes median listings, median CV, and median price for each.
+// CV requires history (computed per-gem elsewhere), but here we use listings
+// as the primary calibration metric. CV is set to 0 since we don't have
+// per-gem CV at this stage; the calling code uses stabilityDiscount(cv)
+// which operates on the individual gem's CV rather than the variant median.
+func computeVariantBaselines(active []GemPrice) map[string]VariantBaseline {
+	// Group gems by variant.
+	type variantData struct {
+		listings []float64
+		prices   []float64
+	}
+	byVariant := make(map[string]*variantData)
+	for _, g := range active {
+		vd, ok := byVariant[g.Variant]
+		if !ok {
+			vd = &variantData{}
+			byVariant[g.Variant] = vd
+		}
+		vd.listings = append(vd.listings, float64(g.Listings))
+		vd.prices = append(vd.prices, g.Chaos)
+	}
+
+	result := make(map[string]VariantBaseline, len(byVariant))
+	for variant, vd := range byVariant {
+		sort.Float64s(vd.listings)
+		sort.Float64s(vd.prices)
+		result[variant] = VariantBaseline{
+			MedianListings: percentile(vd.listings, 0.50),
+			MedianPrice:    percentile(vd.prices, 0.50),
+			GemCount:       len(vd.listings),
+		}
+	}
+	return result
 }

--- a/internal/lab/optimizer.go
+++ b/internal/lab/optimizer.go
@@ -755,7 +755,11 @@ func ValidateSellability(evals []EvalPoint, mc MarketContext) SellabilityReport 
 	for _, ep := range evals {
 		// Always compute sell probability and stability on-the-fly from feature data.
 		// DB-stored values may be zero for pre-POE-69 data that hasn't been backfilled.
-		sellProb := sellProbabilityFactor(ep.Feature.Listings, ep.Feature.Low7d, ep.Feature.Chaos)
+		medianListings := 30.0 // default
+		if vs, ok := mc.VariantStats[ep.Feature.Variant]; ok && vs.MedianListings > 0 {
+			medianListings = vs.MedianListings
+		}
+		sellProb := sellProbabilityFactor(ep.Feature.Listings, ep.Feature.Low7d, ep.Feature.Chaos, medianListings)
 		stabDisc := stabilityDiscount(ep.Feature.CV)
 
 		// Compute risk-adjusted value.

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -801,6 +801,11 @@ func (r *Repository) SaveMarketContext(ctx context.Context, mc MarketContext) er
 		return fmt.Errorf("lab repo: marshal weekday activity: %w", err)
 	}
 
+	variantStats, err := json.Marshal(mc.VariantStats)
+	if err != nil {
+		return fmt.Errorf("lab repo: marshal variant stats: %w", err)
+	}
+
 	_, err = r.pool.Exec(ctx, `
 		INSERT INTO market_context
 		 (time, price_percentiles, listing_percentiles,
@@ -808,8 +813,9 @@ func (r *Repository) SaveMarketContext(ctx context.Context, mc MarketContext) er
 		  total_gems, total_listings, tier_boundaries,
 		  hourly_bias, hourly_volatility, hourly_activity,
 		  weekday_bias, weekday_volatility, weekday_activity,
-		  temporal_coefficient, temporal_mode, temporal_buckets)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
+		  temporal_coefficient, temporal_mode, temporal_buckets,
+		  variant_stats)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
 		ON CONFLICT DO NOTHING`,
 		mc.Time, pricePerc, listPerc,
 		mc.VelocityMean, mc.VelocitySigma, mc.ListingVelMean, mc.ListingVelSigma,
@@ -817,6 +823,7 @@ func (r *Repository) SaveMarketContext(ctx context.Context, mc MarketContext) er
 		hourly, hourlyVol, hourlyAct,
 		weekday, weekdayVol, weekdayAct,
 		mc.TemporalCoefficient, mc.TemporalMode, mc.TemporalBuckets,
+		variantStats,
 	)
 	if err != nil {
 		return fmt.Errorf("lab repo: insert market context: %w", err)
@@ -831,6 +838,7 @@ func (r *Repository) LatestMarketContext(ctx context.Context) (*MarketContext, e
 	var pricePerc, listPerc, tierBounds []byte
 	var hourly, hourlyVol, hourlyAct []byte
 	var weekday, weekdayVol, weekdayAct []byte
+	var variantStatsJSON []byte
 
 	err := r.pool.QueryRow(ctx, `
 		SELECT time, price_percentiles, listing_percentiles,
@@ -838,7 +846,8 @@ func (r *Repository) LatestMarketContext(ctx context.Context) (*MarketContext, e
 		       total_gems, total_listings, tier_boundaries,
 		       hourly_bias, hourly_volatility, hourly_activity,
 		       weekday_bias, weekday_volatility, weekday_activity,
-		       temporal_coefficient, temporal_mode, temporal_buckets
+		       temporal_coefficient, temporal_mode, temporal_buckets,
+		       variant_stats
 		FROM market_context
 		WHERE time = (SELECT MAX(time) FROM market_context)`).
 		Scan(&mc.Time, &pricePerc, &listPerc,
@@ -846,7 +855,8 @@ func (r *Repository) LatestMarketContext(ctx context.Context) (*MarketContext, e
 			&mc.TotalGems, &mc.TotalListings, &tierBounds,
 			&hourly, &hourlyVol, &hourlyAct,
 			&weekday, &weekdayVol, &weekdayAct,
-			&mc.TemporalCoefficient, &mc.TemporalMode, &mc.TemporalBuckets)
+			&mc.TemporalCoefficient, &mc.TemporalMode, &mc.TemporalBuckets,
+			&variantStatsJSON)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, nil
@@ -880,6 +890,11 @@ func (r *Repository) LatestMarketContext(ctx context.Context) (*MarketContext, e
 	}
 	if err := json.Unmarshal(weekdayAct, &mc.WeekdayActivity); err != nil {
 		return nil, fmt.Errorf("lab repo: unmarshal weekday activity: %w", err)
+	}
+	if len(variantStatsJSON) > 0 {
+		if err := json.Unmarshal(variantStatsJSON, &mc.VariantStats); err != nil {
+			return nil, fmt.Errorf("lab repo: unmarshal variant stats: %w", err)
+		}
 	}
 
 	if err := mc.ValidateTemporalSlices(); err != nil {

--- a/internal/lab/risk_scoring_test.go
+++ b/internal/lab/risk_scoring_test.go
@@ -11,10 +11,11 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestSellProbabilityFactor_SigmoidCurve(t *testing.T) {
-	// Test pure sigmoid at key listing counts.
+	// Test pure sigmoid at key listing counts with medianListings=20.
 	// Use low7d=60 with currentPrice=100 to avoid thin-market adjustments:
 	// low7d=60 is between 0.5*100=50 and 0.7*100=70, so no boost or penalty.
 	// For listings >= 10, thin-market adjustments don't apply regardless.
+	medianListings := 20.0
 	tests := []struct {
 		listings int
 		wantMin  float64
@@ -28,10 +29,10 @@ func TestSellProbabilityFactor_SigmoidCurve(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := sellProbabilityFactor(tt.listings, 60, 100)
+		got := sellProbabilityFactor(tt.listings, 60, 100, medianListings)
 		if got < tt.wantMin || got > tt.wantMax {
-			t.Errorf("sellProbabilityFactor(listings=%d) = %f, want [%f, %f]",
-				tt.listings, got, tt.wantMin, tt.wantMax)
+			t.Errorf("sellProbabilityFactor(listings=%d, median=%v) = %f, want [%f, %f]",
+				tt.listings, medianListings, got, tt.wantMin, tt.wantMax)
 		}
 	}
 }
@@ -41,9 +42,10 @@ func TestSellProbabilityFactor_ThinMarketStablePrice(t *testing.T) {
 	// should boost the factor (genuine rarity).
 	currentPrice := 100.0
 	stableLow7d := 80.0 // 80 > 0.7 * 100 = 70
+	median := 30.0
 
-	boosted := sellProbabilityFactor(5, stableLow7d, currentPrice)
-	normal := sellProbabilityFactor(5, 50, currentPrice) // low7d=50, between 50 and 70
+	boosted := sellProbabilityFactor(5, stableLow7d, currentPrice, median)
+	normal := sellProbabilityFactor(5, 50, currentPrice, median) // low7d=50, between 50 and 70
 
 	if boosted <= normal {
 		t.Errorf("stable thin market should boost: boosted=%f, normal=%f", boosted, normal)
@@ -59,9 +61,10 @@ func TestSellProbabilityFactor_ThinMarketSpikePrice(t *testing.T) {
 	// should penalize the factor (manipulation risk).
 	currentPrice := 200.0
 	spikeLow7d := 80.0 // 80 < 0.5 * 200 = 100
+	median := 30.0
 
-	penalized := sellProbabilityFactor(5, spikeLow7d, currentPrice)
-	normal := sellProbabilityFactor(5, 120, currentPrice) // low7d=120, in the middle
+	penalized := sellProbabilityFactor(5, spikeLow7d, currentPrice, median)
+	normal := sellProbabilityFactor(5, 120, currentPrice, median) // low7d=120, in the middle
 
 	if penalized >= normal {
 		t.Errorf("spike thin market should penalize: penalized=%f, normal=%f", penalized, normal)
@@ -72,9 +75,10 @@ func TestSellProbabilityFactor_NotThinMarketNoAdjustment(t *testing.T) {
 	// With >= 10 listings, thin-market adjustments should not apply.
 	currentPrice := 100.0
 	stableLow7d := 90.0 // stable, but listings >= 10
+	median := 30.0
 
-	val10 := sellProbabilityFactor(10, stableLow7d, currentPrice)
-	val15 := sellProbabilityFactor(15, stableLow7d, currentPrice)
+	val10 := sellProbabilityFactor(10, stableLow7d, currentPrice, median)
+	val15 := sellProbabilityFactor(15, stableLow7d, currentPrice, median)
 
 	// These should be pure sigmoid values, no rarity boost.
 	if val10 < 0.3 || val10 > 1.0 {
@@ -87,19 +91,19 @@ func TestSellProbabilityFactor_NotThinMarketNoAdjustment(t *testing.T) {
 
 func TestSellProbabilityFactor_ZeroPrice(t *testing.T) {
 	// Zero price should not trigger thin-market adjustment (guarded by currentPrice > 0).
-	got := sellProbabilityFactor(5, 0, 0)
+	got := sellProbabilityFactor(5, 0, 0, 30)
 	if got < 0.3 || got > 1.0 {
 		t.Errorf("sellProbabilityFactor with zero price = %f, want [0.3, 1.0]", got)
 	}
 }
 
 func TestSellProbabilityFactor_FloorEnforced(t *testing.T) {
-	// With 1 listing (base ~0.307) and spike penalty (*0.5), the result
-	// would be ~0.154 without the floor. The floor should enforce 0.3 minimum.
+	// With 1 listing and spike penalty (*0.5), the result
+	// should be at least 0.3 (floor enforced).
 	currentPrice := 200.0
 	spikeLow7d := 50.0 // 50 < 0.5 * 200 = 100 → penalty
 
-	got := sellProbabilityFactor(1, spikeLow7d, currentPrice)
+	got := sellProbabilityFactor(1, spikeLow7d, currentPrice, 30)
 	if got < 0.3 {
 		t.Errorf("sellProbabilityFactor(1 listing, spike) = %f, want >= 0.3 (floor)", got)
 	}
@@ -199,49 +203,51 @@ func TestQuickSellUndercutFactor_TierModifier(t *testing.T) {
 // classifySellConfidence tests
 // ---------------------------------------------------------------------------
 
-func TestClassifySellConfidence_GREEN(t *testing.T) {
-	// GREEN requires sellProb >= 0.7 AND stabilityDisc >= 0.8.
-	got := classifySellConfidence(0.7, 0.8)
-	if got != "GREEN" {
-		t.Errorf("classifySellConfidence(0.7, 0.8) = %q, want GREEN", got)
+func TestClassifySellConfidence_SAFE(t *testing.T) {
+	// SAFE requires sellProb >= 0.8 AND stabilityDisc >= 0.85.
+	got := classifySellConfidence(0.8, 0.85)
+	if got != "SAFE" {
+		t.Errorf("classifySellConfidence(0.8, 0.85) = %q, want SAFE", got)
 	}
 
 	got = classifySellConfidence(0.9, 0.95)
-	if got != "GREEN" {
-		t.Errorf("classifySellConfidence(0.9, 0.95) = %q, want GREEN", got)
+	if got != "SAFE" {
+		t.Errorf("classifySellConfidence(0.9, 0.95) = %q, want SAFE", got)
 	}
 }
 
-func TestClassifySellConfidence_YELLOW(t *testing.T) {
-	// YELLOW: sellProb >= 0.5 OR stabilityDisc >= 0.7.
+func TestClassifySellConfidence_FAIR(t *testing.T) {
+	// FAIR: not SAFE and not RISKY.
 	tests := []struct {
 		sellProb     float64
 		stabilityDsc float64
 	}{
-		{0.5, 0.6},  // sellProb >= 0.5, stabilityDisc < 0.7
-		{0.4, 0.7},  // sellProb < 0.5, stabilityDisc >= 0.7
-		{0.6, 0.75}, // sellProb >= 0.5, stabilityDisc >= 0.7 but sellProb < 0.7 => not GREEN
+		{0.5, 0.8},  // sellProb >= 0.5 but < 0.8, stabilityDisc < 0.85
+		{0.8, 0.7},  // sellProb >= 0.8 but stabilityDisc < 0.85
+		{0.6, 0.75}, // both moderate
+		{0.4, 0.8},  // sellProb < 0.5 but stabilityDisc >= 0.7 → not RISKY
+		{0.5, 0.6},  // sellProb >= 0.5, so not RISKY
 	}
 
 	for _, tt := range tests {
 		got := classifySellConfidence(tt.sellProb, tt.stabilityDsc)
-		if got != "YELLOW" {
-			t.Errorf("classifySellConfidence(%f, %f) = %q, want YELLOW",
+		if got != "FAIR" {
+			t.Errorf("classifySellConfidence(%f, %f) = %q, want FAIR",
 				tt.sellProb, tt.stabilityDsc, got)
 		}
 	}
 }
 
-func TestClassifySellConfidence_RED(t *testing.T) {
-	// RED: sellProb < 0.5 AND stabilityDisc < 0.7.
+func TestClassifySellConfidence_RISKY(t *testing.T) {
+	// RISKY: sellProb < 0.5 AND stabilityDisc < 0.7.
 	got := classifySellConfidence(0.4, 0.6)
-	if got != "RED" {
-		t.Errorf("classifySellConfidence(0.4, 0.6) = %q, want RED", got)
+	if got != "RISKY" {
+		t.Errorf("classifySellConfidence(0.4, 0.6) = %q, want RISKY", got)
 	}
 
 	got = classifySellConfidence(0.3, 0.5)
-	if got != "RED" {
-		t.Errorf("classifySellConfidence(0.3, 0.5) = %q, want RED", got)
+	if got != "RISKY" {
+		t.Errorf("classifySellConfidence(0.3, 0.5) = %q, want RISKY", got)
 	}
 }
 
@@ -323,9 +329,9 @@ func TestIntegration_RiskAdjustedValueNonZero(t *testing.T) {
 	}
 
 	// SellConfidence should be one of the valid values.
-	validConf := map[string]bool{"GREEN": true, "YELLOW": true, "RED": true}
+	validConf := map[string]bool{"SAFE": true, "FAIR": true, "RISKY": true}
 	if !validConf[sig.SellConfidence] {
-		t.Errorf("SellConfidence = %q, want GREEN/YELLOW/RED", sig.SellConfidence)
+		t.Errorf("SellConfidence = %q, want SAFE/FAIR/RISKY", sig.SellConfidence)
 	}
 }
 
@@ -367,8 +373,8 @@ func TestIntegration_NoHistoryProducesValidRiskFields(t *testing.T) {
 	if sig.QuickSellPrice <= 0 {
 		t.Errorf("QuickSellPrice = %f, want > 0", sig.QuickSellPrice)
 	}
-	validConf := map[string]bool{"GREEN": true, "YELLOW": true, "RED": true}
+	validConf := map[string]bool{"SAFE": true, "FAIR": true, "RISKY": true}
 	if !validConf[sig.SellConfidence] {
-		t.Errorf("SellConfidence = %q, want GREEN/YELLOW/RED", sig.SellConfidence)
+		t.Errorf("SellConfidence = %q, want SAFE/FAIR/RISKY", sig.SellConfidence)
 	}
 }

--- a/internal/lab/sellability_test.go
+++ b/internal/lab/sellability_test.go
@@ -38,14 +38,14 @@ func TestValidateSellability_ValueCapture(t *testing.T) {
 	// Create eval points with known SellProbabilityFactor and StabilityDiscount.
 	// STABLE signal: low velocity.
 	// RiskAdjustedValue is computed on-the-fly from feature data:
-	//   sellProb = sellProbabilityFactor(listings=30, low7d=80, chaos=100)
+	//   sellProb = sellProbabilityFactor(listings=30, low7d=80, chaos=100, median=30)
 	//   stabDisc = stabilityDiscount(cv=10)
 	//   RAV = chaos * sellProb * stabDisc
 	chaos := 100.0
 	listings := 30
 	low7d := 80.0
 	cv := 10.0
-	expectedSellProb := sellProbabilityFactor(listings, low7d, chaos)
+	expectedSellProb := sellProbabilityFactor(listings, low7d, chaos, 30)
 	expectedStabDisc := stabilityDiscount(cv)
 	expectedRAV := chaos * expectedSellProb * expectedStabDisc
 
@@ -154,7 +154,11 @@ func TestValidateSellability_ConfidenceCalibration(t *testing.T) {
 	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
 	mc := sweepMarketContext(0, 10, 0, 5)
 
-	// GREEN: sellProb >= 0.7 AND stabilityDisc >= 0.8
+	// With 30 listings and CV=10, on-the-fly computation:
+	// sellProb = sellProbabilityFactor(30, 80, 100, 30) ≈ 0.65 (sigmoid centered at 30)
+	// stabDisc = stabilityDiscount(10) = 0.95
+	// With new thresholds: SAFE requires sellProb >= 0.8 AND stabDisc >= 0.85.
+	// sellProb ~0.65 < 0.8, so these will be FAIR (not SAFE).
 	evals := []EvalPoint{
 		{
 			Feature: GemFeature{
@@ -190,27 +194,27 @@ func TestValidateSellability_ConfidenceCalibration(t *testing.T) {
 
 	report := ValidateSellability(evals, mc)
 
-	// All three should be GREEN (sellProb=0.8 >= 0.7, stabDisc=0.9 >= 0.8).
-	cal, ok := report.ConfidenceCalibration["GREEN"]
+	// On-the-fly computation with default median=30 produces FAIR for all three.
+	cal, ok := report.ConfidenceCalibration["FAIR"]
 	if !ok {
 		for conf := range report.ConfidenceCalibration {
 			t.Logf("Confidence found: %s", conf)
 		}
-		t.Fatal("expected GREEN in ConfidenceCalibration")
+		t.Fatal("expected FAIR in ConfidenceCalibration")
 	}
 	if cal.Count != 3 {
-		t.Errorf("GREEN count: got %d, want 3", cal.Count)
+		t.Errorf("FAIR count: got %d, want 3", cal.Count)
 	}
 	if cal.PriceHeld != 2 {
-		t.Errorf("GREEN PriceHeld: got %d, want 2", cal.PriceHeld)
+		t.Errorf("FAIR PriceHeld: got %d, want 2", cal.PriceHeld)
 	}
 	// 2/3 = 66.67%
 	if !approxEqual(cal.HeldRate, 66.67, 0.1) {
-		t.Errorf("GREEN HeldRate: got %.2f, want ~66.67", cal.HeldRate)
+		t.Errorf("FAIR HeldRate: got %.2f, want ~66.67", cal.HeldRate)
 	}
 	// avg change: (-5 + -15 + 5) / 3 = -5
 	if !approxEqual(cal.AvgChange, -5.0, 0.1) {
-		t.Errorf("GREEN AvgChange: got %.2f, want -5.0", cal.AvgChange)
+		t.Errorf("FAIR AvgChange: got %.2f, want -5.0", cal.AvgChange)
 	}
 }
 
@@ -262,7 +266,7 @@ func TestValidateSellability_PerTierCapture(t *testing.T) {
 	}
 
 	// TOP: RAV computed on-the-fly from feature data.
-	topSellProb := sellProbabilityFactor(30, 180, 200)
+	topSellProb := sellProbabilityFactor(30, 180, 200, 30)
 	topStabDisc := stabilityDiscount(10)
 	expectedTopRAV := 200.0 * topSellProb * topStabDisc
 	expectedTopCapture := 200.0 / expectedTopRAV
@@ -380,12 +384,13 @@ func TestValidateSellability_MultipleSignalTypes(t *testing.T) {
 	}
 }
 
-func TestValidateSellability_ConfCalibrationMultipleColors(t *testing.T) {
+func TestValidateSellability_ConfCalibrationMultipleLevels(t *testing.T) {
 	t0 := time.Date(2026, 3, 18, 16, 0, 0, 0, time.UTC)
 	mc := sweepMarketContext(0, 10, 0, 5)
 
 	evals := []EvalPoint{
-		// GREEN: sellProb=0.8 >= 0.7, stabDisc=0.9 >= 0.8
+		// FAIR: on-the-fly sellProb ~0.65 (30 listings, median=30), stabDisc=0.95
+		// sellProb < 0.8 → not SAFE, but sellProb >= 0.5 → not RISKY
 		{
 			Feature: GemFeature{
 				Time: t0, VelMedPrice: 0.1, VelMedListing: 0.1, CV: 10, Listings: 30,
@@ -396,7 +401,7 @@ func TestValidateSellability_ConfCalibrationMultipleColors(t *testing.T) {
 			FuturePct: 0.0,
 			SnapTime:  t0,
 		},
-		// RED: very few listings (2) + high CV (120) + price spike → low sellProb, low stabDisc
+		// RISKY: very few listings (2) + high CV (120) + price spike → low sellProb, low stabDisc
 		{
 			Feature: GemFeature{
 				Time: t0, VelMedPrice: 0.2, VelMedListing: 0.1, CV: 120, Listings: 2,
@@ -410,11 +415,11 @@ func TestValidateSellability_ConfCalibrationMultipleColors(t *testing.T) {
 
 	report := ValidateSellability(evals, mc)
 
-	if _, ok := report.ConfidenceCalibration["GREEN"]; !ok {
-		t.Error("expected GREEN in ConfidenceCalibration")
+	if _, ok := report.ConfidenceCalibration["FAIR"]; !ok {
+		t.Error("expected FAIR in ConfidenceCalibration")
 	}
-	if _, ok := report.ConfidenceCalibration["RED"]; !ok {
-		t.Error("expected RED in ConfidenceCalibration")
+	if _, ok := report.ConfidenceCalibration["RISKY"]; !ok {
+		t.Error("expected RISKY in ConfidenceCalibration")
 	}
 }
 

--- a/internal/lab/trends.go
+++ b/internal/lab/trends.go
@@ -618,7 +618,10 @@ func classifySignal(priceVel, listingVel, cv float64, currentListings int) strin
 
 // classifySignalWithConfig uses custom thresholds (for optimizer).
 func classifySignalWithConfig(priceVel, listingVel, cv float64, currentListings int, cfg SignalConfig) string {
-	if cv > cfg.TrapCV {
+	// TRAP requires BOTH high historical volatility AND current instability.
+	// A gem with high 7-day CV but stable recent prices is not a trap —
+	// it had a volatile episode earlier but has since settled.
+	if cv > cfg.TrapCV && (math.Abs(priceVel) > 5 || math.Abs(listingVel) > 5) {
 		return "TRAP"
 	}
 	if priceVel < cfg.DumpPriceVel && listingVel > cfg.DumpListingVel {

--- a/internal/lab/trends_test.go
+++ b/internal/lab/trends_test.go
@@ -102,9 +102,15 @@ func TestVelocity_SameTimestamp(t *testing.T) {
 }
 
 func TestClassifySignal_TRAP(t *testing.T) {
-	s := classifySignal(0, 0, 150, 50)
+	// TRAP requires BOTH high CV AND current instability (velocity > 5).
+	s := classifySignal(8, 0, 150, 50)
 	if s != "TRAP" {
 		t.Errorf("signal = %s, want TRAP", s)
+	}
+	// High CV but stable velocity → NOT trap (settled down).
+	s = classifySignal(0, 0, 150, 50)
+	if s == "TRAP" {
+		t.Errorf("signal = %s, want NOT TRAP (stable velocity despite high CV)", s)
 	}
 }
 
@@ -163,10 +169,10 @@ func TestClassifySignal_UNCERTAIN_Negative(t *testing.T) {
 }
 
 func TestClassifySignal_TRAPOverridesDUMPING(t *testing.T) {
-	// CV > 100 should override any velocity-based signal.
+	// CV > 100 + active velocity should override DUMPING.
 	s := classifySignal(-10, 10, 200, 50)
 	if s != "TRAP" {
-		t.Errorf("signal = %s, want TRAP (CV overrides DUMPING)", s)
+		t.Errorf("signal = %s, want TRAP (CV + velocity overrides DUMPING)", s)
 	}
 }
 
@@ -187,7 +193,8 @@ func TestClassifySignal_Boundaries(t *testing.T) {
 	}{
 		// CV boundary: exactly 100 is NOT TRAP (uses > 100)
 		{"cv=100 not TRAP", 0, 0, 100, 50, "STABLE"},
-		{"cv=100.01 is TRAP", 0, 0, 100.01, 50, "TRAP"},
+		{"cv=100.01 no vel not TRAP", 0, 0, 100.01, 50, "STABLE"},
+		{"cv=100.01 with vel is TRAP", 8, 0, 100.01, 50, "TRAP"},
 		// DUMPING boundary: priceVel must be < -5 (not <=)
 		{"priceVel=-5 not DUMPING", -5, 10, 50, 50, "UNCERTAIN"},
 		{"priceVel=-5.01 is DUMPING", -5.01, 10, 50, 50, "DUMPING"},

--- a/internal/lab/v2types.go
+++ b/internal/lab/v2types.go
@@ -28,6 +28,18 @@ type MarketContext struct {
 	TemporalCoefficient float64 // coefficient for this snapshot's time; 1.0 = no adjustment
 	TemporalMode        string  // "none", "hourly", "weekday_hour"
 	TemporalBuckets     []byte  // raw JSONB, keyed by variant
+
+	// Per-variant baselines for scoring calibration.
+	VariantStats map[string]VariantBaseline `json:"variant_stats,omitempty"`
+}
+
+// VariantBaseline holds per-variant market statistics used to calibrate
+// scoring functions (e.g., sigmoid center for sell probability).
+type VariantBaseline struct {
+	MedianListings float64 `json:"median_listings"`
+	MedianCV       float64 `json:"median_cv"`
+	MedianPrice    float64 `json:"median_price"`
+	GemCount       int     `json:"gem_count"`
 }
 
 // ValidateTemporalSlices checks that all temporal slices have the expected lengths:
@@ -117,5 +129,5 @@ type GemSignal struct {
 	Tier              string
 	RiskAdjustedValue float64 // price * sell_probability * stability_discount
 	QuickSellPrice    float64 // aggressive undercut estimate
-	SellConfidence    string  // "GREEN", "YELLOW", "RED"
+	SellConfidence    string  // "SAFE", "FAIR", "RISKY"
 }


### PR DESCRIPTION
## Summary

Three fixes in one:

### 1. Per-variant scoring parameters
Sigmoid center now auto-calibrates from `MarketContext.VariantStats` (median listings per variant). 20/20 gems (median 14 listings) get a sigmoid centered at 14, not 30. Fixes inverted GREEN/YELLOW confidence for 20/20 variant.

### 2. SAFE/FAIR/RISKY rename
Sell confidence labels renamed from GREEN/YELLOW/RED to avoid confusion with gem colors (RED/GREEN/BLUE). All backend + frontend updated.

### 3. TRAP requires active velocity
TRAP now requires BOTH high historical CV (>100) AND current instability (|priceVel| > 5 or |listingVel| > 5). A gem with high 7-day CV but stable recent prices is not a trap — it had a volatile episode but has settled.

## Test plan
- [x] All lab tests pass
- [x] `go vet` clean

Closes POE-66 refinement

🤖 Generated with [Claude Code](https://claude.com/claude-code)