### PR TITLE
feat(compass): add daily lab layout API with strict validation

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -99,6 +99,7 @@ func main() {
 	}
 
 	labRepo := lab.NewRepository(pool)
+	layoutRepo := lab.NewLayoutRepository(pool)
 	labCache := lab.NewCache()
 	throttler := lab.NewThrottler(mercureURL, mercureSecret, 2*time.Second, labCache)
 	analyzer := lab.NewAnalyzer(labRepo, throttler, labCache)
@@ -234,6 +235,7 @@ func main() {
 		DevMode:              devMode,
 		Pool:                 pool,
 		LabRepo:              labRepo,
+		LayoutRepo:           layoutRepo,
 		LabCache:             labCache,
 		MercureSubscriberKey: os.Getenv("MERCURE_SUBSCRIBER_KEY"),
 		MercurePublicURL:     os.Getenv("MERCURE_PUBLIC_URL"),

--- a/internal/db/migrations/20260401205030_create_lab_layouts.down.sql
+++ b/internal/db/migrations/20260401205030_create_lab_layouts.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS lab_layouts;

--- a/internal/db/migrations/20260401205030_create_lab_layouts.up.sql
+++ b/internal/db/migrations/20260401205030_create_lab_layouts.up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS lab_layouts (
+    difficulty TEXT NOT NULL,
+    date DATE NOT NULL,
+    layout JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (difficulty, date)
+);

--- a/internal/lab/layout_repository.go
+++ b/internal/lab/layout_repository.go
@@ -1,0 +1,51 @@
+package lab
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// LayoutRepository handles persistence of daily lab layouts.
+type LayoutRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewLayoutRepository creates a LayoutRepository backed by the given connection pool.
+func NewLayoutRepository(pool *pgxpool.Pool) *LayoutRepository {
+	return &LayoutRepository{pool: pool}
+}
+
+// GetLayout retrieves the lab layout for the given difficulty and date.
+// Returns nil if no layout exists for that combination.
+func (r *LayoutRepository) GetLayout(ctx context.Context, difficulty string, date string) (json.RawMessage, error) {
+	var layout json.RawMessage
+	err := r.pool.QueryRow(ctx,
+		`SELECT layout FROM lab_layouts WHERE difficulty = $1 AND date = $2`,
+		difficulty, date,
+	).Scan(&layout)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("lab layout repo: get layout: %w", err)
+	}
+	return layout, nil
+}
+
+// SaveLayout stores a lab layout. Returns true if the layout was inserted,
+// false if a layout already existed for that difficulty+date (ON CONFLICT DO NOTHING).
+func (r *LayoutRepository) SaveLayout(ctx context.Context, difficulty string, date string, layout json.RawMessage) (bool, error) {
+	tag, err := r.pool.Exec(ctx,
+		`INSERT INTO lab_layouts (difficulty, date, layout) VALUES ($1, $2, $3)
+		 ON CONFLICT (difficulty, date) DO NOTHING`,
+		difficulty, date, layout,
+	)
+	if err != nil {
+		return false, fmt.Errorf("lab layout repo: save layout: %w", err)
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/internal/lab/layout_validate.go
+++ b/internal/lab/layout_validate.go
@@ -1,0 +1,175 @@
+package lab
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// LabLayout is the strict Go representation of a poelab.com daily layout JSON.
+type LabLayout struct {
+	Difficulty     string    `json:"difficulty"`
+	Date           string    `json:"date"`
+	Weapon         string    `json:"weapon"`
+	Phase1         string    `json:"phase1"`
+	Phase2         string    `json:"phase2"`
+	Trap1          string    `json:"trap1"`
+	Trap2          string    `json:"trap2"`
+	Section1Layout string    `json:"section1layout,omitempty"`
+	Section2Layout string    `json:"section2layout,omitempty"`
+	Section3Layout string    `json:"section3layout,omitempty"`
+	Rooms          []LabRoom `json:"rooms"`
+}
+
+// LabRoom represents a single room in the lab layout.
+type LabRoom struct {
+	Name              string            `json:"name"`
+	AreaCode          string            `json:"areacode"`
+	ID                string            `json:"id"`
+	X                 string            `json:"x"`
+	Y                 string            `json:"y"`
+	Dangerous         string            `json:"dangerous"`
+	Contents          []string          `json:"contents"`
+	ContentDirections []string          `json:"content_directions"`
+	Exits             map[string]string `json:"exits"`
+	SecretPassage     string            `json:"secret_passage,omitempty"`
+}
+
+var (
+	validDifficulties = map[string]bool{
+		"Normal": true, "Cruel": true, "Merciless": true, "Uber": true,
+	}
+	validDirections = map[string]bool{
+		"N": true, "NE": true, "E": true, "SE": true,
+		"S": true, "SW": true, "W": true, "NW": true,
+		"C": true,
+	}
+	validAreaCodes = map[string]bool{
+		"c_branch": true, "c_branch_bottleneck_1": true, "c_branch_bottleneck_2": true,
+		"c_branch_door": true, "c_end_bottleneck": true, "c_quad": true,
+		"c_quad_door": true, "c_straight": true, "c_straight_bottleneck": true,
+		"dg_branch": true, "dg_branch_bottleneck_1": true, "dg_branch_bottleneck_2": true,
+		"dg_branch_door": true, "dg_end_bottleneck": true, "dg_quad": true,
+		"dg_quad_door": true, "dg_straight": true, "dg_straight_bottleneck": true,
+		"eh_block_branch": true, "eh_branch": true, "eh_branch_bottleneck_2": true,
+		"eh_branch_door": true, "eh_end_bottleneck": true, "eh_quad": true,
+		"eh_quad_door": true, "eh_straight": true, "eh_straight_bottleneck": true,
+		"oh_branch": true, "oh_branch_bottleneck_1": true, "oh_branch_bottleneck_2": true,
+		"oh_branch_door": true, "oh_end_bottleneck": true, "oh_quad": true,
+		"oh_quad_door": true, "oh_straight": true, "oh_straight_bottleneck": true,
+		"p_branch": true, "p_branch_bottleneck_1": true, "p_branch_bottleneck_2": true,
+		"p_branch_door": true, "p_end_bottleneck": true, "p_quad": true,
+		"p_straight": true, "p_straight_bottleneck": true,
+		"rt_branch": true, "rt_branch_bottleneck_1": true, "rt_branch_bottleneck_2": true,
+		"rt_branch_door": true, "rt_end_bottleneck": true, "rt_quad": true,
+		"rt_quad_door": true, "rt_straight": true, "rt_straight_bottleneck": true,
+	}
+
+	datePattern     = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+	roomNamePattern = regexp.MustCompile(`^[A-Za-z' ]+$`)
+	roomIDPattern   = regexp.MustCompile(`^[A-Za-z0-9]+$`)
+	safeStrPattern  = regexp.MustCompile(`^[A-Za-z0-9_ ]+$`)
+	htmlTagPattern  = regexp.MustCompile(`<[^>]*>`)
+)
+
+// ValidateLayout checks a parsed LabLayout against business rules.
+// Returns a descriptive error on the first validation failure, nil if valid.
+func ValidateLayout(layout *LabLayout) error {
+	if !validDifficulties[layout.Difficulty] {
+		return fmt.Errorf("invalid difficulty %q", layout.Difficulty)
+	}
+	if !datePattern.MatchString(layout.Date) {
+		return fmt.Errorf("invalid date format %q (expected YYYY-MM-DD)", layout.Date)
+	}
+
+	for _, field := range []struct {
+		name, value string
+	}{
+		{"weapon", layout.Weapon},
+		{"phase1", layout.Phase1},
+		{"phase2", layout.Phase2},
+		{"trap1", layout.Trap1},
+		{"trap2", layout.Trap2},
+	} {
+		if len(field.value) > 50 {
+			return fmt.Errorf("%s too long (%d chars, max 50)", field.name, len(field.value))
+		}
+		if field.value != "" && !safeStrPattern.MatchString(field.value) {
+			return fmt.Errorf("%s contains invalid characters: %q", field.name, field.value)
+		}
+	}
+
+	if len(layout.Rooms) == 0 {
+		return fmt.Errorf("rooms array is empty")
+	}
+	if len(layout.Rooms) > 50 {
+		return fmt.Errorf("too many rooms (%d, max 50)", len(layout.Rooms))
+	}
+
+	roomIDs := make(map[string]bool, len(layout.Rooms))
+	for _, room := range layout.Rooms {
+		roomIDs[room.ID] = true
+	}
+
+	for i, room := range layout.Rooms {
+		if err := validateRoom(&room, roomIDs, i); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateRoom(room *LabRoom, validIDs map[string]bool, index int) error {
+	if room.ID == "" {
+		return fmt.Errorf("room[%d]: id is empty", index)
+	}
+	if len(room.ID) > 10 || !roomIDPattern.MatchString(room.ID) {
+		return fmt.Errorf("room[%d]: invalid id %q", index, room.ID)
+	}
+
+	if room.Name == "" {
+		return fmt.Errorf("room[%d]: name is empty", index)
+	}
+	if len(room.Name) > 100 || !roomNamePattern.MatchString(room.Name) {
+		return fmt.Errorf("room[%d]: invalid name %q", index, room.Name)
+	}
+
+	if room.AreaCode != "" && !validAreaCodes[room.AreaCode] {
+		return fmt.Errorf("room[%d]: invalid area code %q", index, room.AreaCode)
+	}
+
+	for dir, target := range room.Exits {
+		if !validDirections[dir] {
+			return fmt.Errorf("room[%d]: invalid exit direction %q", index, dir)
+		}
+		if !validIDs[target] {
+			return fmt.Errorf("room[%d]: exit %s references unknown room ID %q", index, dir, target)
+		}
+	}
+
+	for j, content := range room.Contents {
+		if len(content) > 100 {
+			return fmt.Errorf("room[%d].contents[%d]: too long (%d chars, max 100)", index, j, len(content))
+		}
+		if htmlTagPattern.MatchString(content) {
+			return fmt.Errorf("room[%d].contents[%d]: HTML tags not allowed", index, j)
+		}
+	}
+
+	return nil
+}
+
+// SanitizeLayout strips any HTML tags from user-controlled string fields.
+func SanitizeLayout(layout *LabLayout) {
+	layout.Difficulty = strings.TrimSpace(layout.Difficulty)
+	layout.Date = strings.TrimSpace(layout.Date)
+	for i := range layout.Rooms {
+		layout.Rooms[i].Name = strings.TrimSpace(layout.Rooms[i].Name)
+		layout.Rooms[i].AreaCode = strings.TrimSpace(layout.Rooms[i].AreaCode)
+		layout.Rooms[i].ID = strings.TrimSpace(layout.Rooms[i].ID)
+		for j := range layout.Rooms[i].Contents {
+			layout.Rooms[i].Contents[j] = htmlTagPattern.ReplaceAllString(layout.Rooms[i].Contents[j], "")
+		}
+	}
+}

--- a/internal/server/handlers/layout.go
+++ b/internal/server/handlers/layout.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"profitofexile/internal/lab"
+	"github.com/go-chi/chi/v5"
+)
+
+// GetLayout handles GET /api/lab/layout/{difficulty}.
+// Returns today's lab layout for the given difficulty, or 404 if not yet uploaded.
+func GetLayout(repo *lab.LayoutRepository) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		difficulty := chi.URLParam(r, "difficulty")
+		if !isValidDifficulty(difficulty) {
+			jsonError(w, http.StatusBadRequest, "invalid difficulty: must be Normal, Cruel, Merciless, or Uber")
+			return
+		}
+
+		today := time.Now().UTC().Format("2006-01-02")
+		layout, err := repo.GetLayout(r.Context(), difficulty, today)
+		if err != nil {
+			slog.Error("get layout: query failed", "error", err, "difficulty", difficulty)
+			http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+			return
+		}
+		if layout == nil {
+			jsonError(w, http.StatusNotFound, "no layout available for today")
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(layout)
+	}
+}
+
+// UploadLayout handles POST /api/lab/layout/{difficulty}.
+// Validates and stores a poelab.com layout JSON. First upload per difficulty+date wins.
+func UploadLayout(repo *lab.LayoutRepository) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		difficulty := chi.URLParam(r, "difficulty")
+		if !isValidDifficulty(difficulty) {
+			jsonError(w, http.StatusBadRequest, "invalid difficulty: must be Normal, Cruel, Merciless, or Uber")
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, 102400) // 100KB max
+
+		var layout lab.LabLayout
+		if err := json.NewDecoder(r.Body).Decode(&layout); err != nil {
+			jsonError(w, http.StatusBadRequest, "invalid JSON body")
+			return
+		}
+
+		lab.SanitizeLayout(&layout)
+
+		if err := lab.ValidateLayout(&layout); err != nil {
+			jsonError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+
+		if !strings.EqualFold(layout.Difficulty, difficulty) {
+			jsonError(w, http.StatusBadRequest, "difficulty in body does not match URL")
+			return
+		}
+
+		rawJSON, err := json.Marshal(layout)
+		if err != nil {
+			slog.Error("upload layout: marshal failed", "error", err)
+			http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+			return
+		}
+
+		inserted, err := repo.SaveLayout(r.Context(), layout.Difficulty, layout.Date, rawJSON)
+		if err != nil {
+			slog.Error("upload layout: save failed", "error", err, "difficulty", difficulty)
+			http.Error(w, `{"error":"save failed"}`, http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if inserted {
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{
+				"status":     "created",
+				"difficulty": layout.Difficulty,
+				"date":       layout.Date,
+				"rooms":      len(layout.Rooms),
+			})
+		} else {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]string{
+				"status": "already exists",
+			})
+		}
+	}
+}
+
+func isValidDifficulty(d string) bool {
+	switch d {
+	case "Normal", "Cruel", "Merciless", "Uber":
+		return true
+	}
+	return false
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -46,6 +46,8 @@ type RouterConfig struct {
 	League string
 	// Analyzer is the lab analysis engine for admin recalculation endpoint.
 	Analyzer *lab.Analyzer
+	// LayoutRepo is the repository for daily lab layout data.
+	LayoutRepo *lab.LayoutRepository
 	// AllowedOrigins for CORS (desktop app needs cross-origin access).
 	// Example: ["http://localhost:1420", "tauri://localhost"]
 	AllowedOrigins []string
@@ -123,6 +125,11 @@ func NewRouter(pinger handlers.Pinger, frontendFS fs.FS, cfg RouterConfig) http.
 
 	if cfg.Pool != nil {
 		r.Post("/api/desktop/font-session", handlers.FontSession(cfg.Pool))
+	}
+
+	if cfg.LayoutRepo != nil {
+		r.Get("/api/lab/layout/{difficulty}", handlers.GetLayout(cfg.LayoutRepo))
+		r.Post("/api/lab/layout/{difficulty}", handlers.UploadLayout(cfg.LayoutRepo))
 	}
 
 	if cfg.DevMode {


### PR DESCRIPTION
## Summary
- Add `GET /api/lab/layout/{difficulty}` — returns today's layout or 404
- Add `POST /api/lab/layout/{difficulty}` — upload poelab.com JSON with strict validation
- Create `lab_layouts` table (difficulty + date PK, JSONB layout, ON CONFLICT DO NOTHING)
- Area code whitelist (53 known presets), room name regex, exit direction enum, HTML tag stripping

Closes POE-90

## Test plan
- [ ] `go build ./...` compiles clean
- [ ] `go test ./internal/lab/...` and `./internal/server/...` pass
- [ ] POST real `uber-2026-04-01.json` → 201 created
- [ ] GET `/api/lab/layout/Uber` → returns the uploaded layout
- [ ] POST again → 200 "already exists"
- [ ] POST with XSS in room name → 400 rejected
- [ ] POST with invalid area code → 400 rejected
- [ ] POST > 100KB body → rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)