### PR TITLE
feat(compass): add Client.txt parsing for lab navigation events

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "profitofexile-desktop"
-version = "0.1.0"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/desktop/src-tauri/src/lab_navigation.rs
+++ b/desktop/src-tauri/src/lab_navigation.rs
@@ -1,0 +1,234 @@
+use serde::Serialize;
+
+/// Navigation events emitted during lab runs.
+/// Parsed from Client.txt independently of the font/OCR state machine.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type")]
+pub enum NavEvent {
+    PlazaEntered,
+    LabStarted,
+    RoomChanged { name: String },
+    SectionFinished,
+    LabFinished,
+    IzaroBattleStarted,
+    PortalSpawned,
+    LabExited,
+}
+
+// Lab room name components (title case as they appear in Client.txt).
+const LAB_ROOM_PREFIXES: &[&str] = &[
+    "Estate",
+    "Domain",
+    "Basilica",
+    "Mansion",
+    "Sepulchre",
+    "Sanitorium",
+];
+
+const LAB_ROOM_SUFFIXES: &[&str] = &[
+    "Walkways",
+    "Path",
+    "Crossing",
+    "Annex",
+    "Halls",
+    "Passage",
+    "Enclosure",
+    "Atrium",
+];
+
+// Izaro voicelines (from legacy LabCompass, verified in 3.28 Mirage).
+const LAB_START_LINES: &[&str] = &[
+    "Izaro: Ascend with precision.",
+    "Izaro: The Goddess is watching.",
+    "Izaro: Justice will prevail.",
+];
+
+const IZARO_BATTLE_LINES: &[&str] = &[
+    "Izaro: Complex machinations converge to a single act of power.",
+    "Izaro: Slowness lends strength to one's enemies.",
+    "Izaro: When one defiles the effigy, one defiles the emperor.",
+    "Izaro: The essence of an empire must be shared equally amongst all of its citizens.",
+    "Izaro: It is the sovereign who empowers the sceptre. Not the other way round.",
+    "Izaro: Some things that slumber should never be awoken.",
+    "Izaro: An emperor is only as efficient as those he commands.",
+    "Izaro: The emperor beckons and the world attends.",
+];
+
+const SECTION_FINISH_LINES: &[&str] = &[
+    "Izaro: By the Goddess! What ambition!",
+    "Izaro: Such resilience!",
+    "Izaro: You are inexhaustible!",
+    "Izaro: You were born for this!",
+];
+
+const LAB_FINISH_LINES: &[&str] = &[
+    "Izaro: I die for the Empire!",
+    "Izaro: Delight in your gilded dungeon, ascendant.",
+    "Izaro: Your destination is more dangerous than the journey, ascendant.",
+    "Izaro: Triumphant at last!",
+    "Izaro: You are free!",
+    "Izaro: The trap of tyranny is inescapable.",
+];
+
+const PORTAL_LINE: &str = ": A portal to Izaro appears.";
+
+/// Check if a room name matches the lab room prefix+suffix pattern.
+pub fn is_lab_room(name: &str) -> bool {
+    let parts: Vec<&str> = name.split_whitespace().collect();
+    if parts.len() != 2 {
+        return false;
+    }
+    LAB_ROOM_PREFIXES.contains(&parts[0]) && LAB_ROOM_SUFFIXES.contains(&parts[1])
+}
+
+/// Extract the area name from a "You have entered X." log line.
+/// Returns None if the line doesn't match the pattern.
+pub fn parse_entered_area(line: &str) -> Option<&str> {
+    let marker = ": You have entered ";
+    let start = line.find(marker)? + marker.len();
+    let rest = &line[start..];
+    let end = rest.find('.')?;
+    Some(&rest[..end])
+}
+
+/// Check if a log line contains an Izaro voiceline and return the corresponding event.
+fn parse_izaro_line(line: &str) -> Option<NavEvent> {
+    for quote in LAB_START_LINES {
+        if line.contains(quote) {
+            return Some(NavEvent::LabStarted);
+        }
+    }
+    for quote in LAB_FINISH_LINES {
+        if line.contains(quote) {
+            return Some(NavEvent::LabFinished);
+        }
+    }
+    for quote in SECTION_FINISH_LINES {
+        if line.contains(quote) {
+            return Some(NavEvent::SectionFinished);
+        }
+    }
+    for quote in IZARO_BATTLE_LINES {
+        if line.contains(quote) {
+            return Some(NavEvent::IzaroBattleStarted);
+        }
+    }
+    if line.contains(PORTAL_LINE) {
+        return Some(NavEvent::PortalSpawned);
+    }
+    None
+}
+
+/// Parse a Client.txt log line for navigation events.
+/// `in_lab` indicates whether the player is currently in the labyrinth.
+pub fn parse_nav_event(line: &str, in_lab: bool) -> Option<NavEvent> {
+    // Check Izaro voicelines first (can fire from any lab state).
+    if let Some(event) = parse_izaro_line(line) {
+        return Some(event);
+    }
+
+    // Check area transitions.
+    if let Some(area) = parse_entered_area(line) {
+        if area == "Aspirants' Plaza" || area == "Aspirant's Plaza" {
+            return Some(NavEvent::PlazaEntered);
+        }
+        if area == "Aspirant's Trial" {
+            return Some(NavEvent::RoomChanged {
+                name: area.to_string(),
+            });
+        }
+        if is_lab_room(area) {
+            return Some(NavEvent::RoomChanged {
+                name: area.to_string(),
+            });
+        }
+        // Non-lab area while in lab → lab exit.
+        if in_lab {
+            return Some(NavEvent::LabExited);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_lab_room() {
+        assert!(is_lab_room("Estate Walkways"));
+        assert!(is_lab_room("Domain Crossing"));
+        assert!(is_lab_room("Basilica Atrium"));
+        assert!(is_lab_room("Mansion Annex"));
+        assert!(is_lab_room("Sepulchre Halls"));
+        assert!(is_lab_room("Sanitorium Passage"));
+        assert!(!is_lab_room("Hideout"));
+        assert!(!is_lab_room("Aspirant's Trial"));
+        assert!(!is_lab_room("Aspirants' Plaza"));
+        assert!(!is_lab_room("The Blood Aqueduct"));
+        assert!(!is_lab_room("Estate")); // prefix only
+    }
+
+    #[test]
+    fn test_parse_entered_area() {
+        let line = "2026/04/01 20:00:00 12345678 [INFO Client 1234] : You have entered Estate Walkways.";
+        assert_eq!(parse_entered_area(line), Some("Estate Walkways"));
+
+        let line2 = "2026/04/01 20:00:00 12345678 [INFO Client 1234] : You have entered Aspirants' Plaza.";
+        assert_eq!(parse_entered_area(line2), Some("Aspirants' Plaza"));
+
+        assert_eq!(parse_entered_area("some random log line"), None);
+    }
+
+    #[test]
+    fn test_parse_izaro_lines() {
+        for quote in LAB_START_LINES {
+            let line = format!("2026/04/01 20:00:00 12345678 [INFO Client 1234] {}", quote);
+            assert!(matches!(parse_izaro_line(&line), Some(NavEvent::LabStarted)));
+        }
+        for quote in LAB_FINISH_LINES {
+            let line = format!("2026/04/01 20:00:00 12345678 [INFO Client 1234] {}", quote);
+            assert!(matches!(parse_izaro_line(&line), Some(NavEvent::LabFinished)));
+        }
+        for quote in SECTION_FINISH_LINES {
+            let line = format!("2026/04/01 20:00:00 12345678 [INFO Client 1234] {}", quote);
+            assert!(matches!(parse_izaro_line(&line), Some(NavEvent::SectionFinished)));
+        }
+        for quote in IZARO_BATTLE_LINES {
+            let line = format!("2026/04/01 20:00:00 12345678 [INFO Client 1234] {}", quote);
+            assert!(matches!(parse_izaro_line(&line), Some(NavEvent::IzaroBattleStarted)));
+        }
+        let portal = "2026/04/01 20:00:00 12345678 [INFO Client 1234] : A portal to Izaro appears.";
+        assert!(matches!(parse_izaro_line(portal), Some(NavEvent::PortalSpawned)));
+    }
+
+    #[test]
+    fn test_nav_event_room_changed() {
+        let line = "2026/04/01 20:00:00 12345678 [INFO Client 1234] : You have entered Estate Walkways.";
+        let event = parse_nav_event(line, true);
+        assert!(matches!(event, Some(NavEvent::RoomChanged { ref name }) if name == "Estate Walkways"));
+    }
+
+    #[test]
+    fn test_nav_event_plaza() {
+        let line = "2026/04/01 20:00:00 12345678 [INFO Client 1234] : You have entered Aspirants' Plaza.";
+        assert!(matches!(parse_nav_event(line, false), Some(NavEvent::PlazaEntered)));
+    }
+
+    #[test]
+    fn test_nav_event_lab_exit() {
+        let line = "2026/04/01 20:00:00 12345678 [INFO Client 1234] : You have entered Highgate.";
+        // In lab → LabExited
+        assert!(matches!(parse_nav_event(line, true), Some(NavEvent::LabExited)));
+        // Not in lab → None (ignore non-lab areas)
+        assert!(parse_nav_event(line, false).is_none());
+    }
+
+    #[test]
+    fn test_nav_event_aspirants_trial() {
+        let line = "2026/04/01 20:00:00 12345678 [INFO Client 1234] : You have entered Aspirant's Trial.";
+        let event = parse_nav_event(line, true);
+        assert!(matches!(event, Some(NavEvent::RoomChanged { ref name }) if name == "Aspirant's Trial"));
+    }
+}

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod capture;
 #[allow(dead_code)] // Font panel OCR — not yet wired into the scan pipeline
 mod font_parser;
 mod gem_matcher;
+mod lab_navigation;
 mod lab_state;
 mod log_watcher;
 mod ocr;
@@ -118,6 +119,9 @@ pub struct AppState {
     /// Set when gem scan completes with 3/3 gems. Used to distinguish CONFIRM
     /// from CRAFT clicks (both fire FontOpened). Reset on next CRAFT.
     pub gem_scan_done: AtomicBool,
+    /// True when player is inside the labyrinth (between PlazaEntered and LabExited).
+    /// Used by lab_navigation to determine if a non-lab area entry is a lab exit.
+    pub in_lab: AtomicBool,
 }
 
 /// Build the full AppStatus from current state. Used by get_status command and event emitting.
@@ -1528,6 +1532,45 @@ fn spawn_log_watcher(app: AppHandle) {
                         }
                     }
 
+                    // --- Lab navigation events (outside state machine) ---
+                    {
+                        let state = app.state::<AppState>();
+                        let in_lab = state.in_lab.load(Ordering::SeqCst);
+                        if let Some(nav_event) = lab_navigation::parse_nav_event(&line, in_lab) {
+                            match &nav_event {
+                                lab_navigation::NavEvent::PlazaEntered => {
+                                    state.in_lab.store(true, Ordering::SeqCst);
+                                    app_log(&app, "Lab nav: Plaza entered".to_string());
+                                }
+                                lab_navigation::NavEvent::LabStarted => {
+                                    app_log(&app, "Lab nav: Izaro started".to_string());
+                                }
+                                lab_navigation::NavEvent::RoomChanged { name } => {
+                                    app_log(&app, format!("Lab nav: room {}", name));
+                                }
+                                lab_navigation::NavEvent::LabExited => {
+                                    state.in_lab.store(false, Ordering::SeqCst);
+                                    app_log(&app, "Lab nav: exited lab".to_string());
+                                }
+                                lab_navigation::NavEvent::LabFinished => {
+                                    app_log(&app, "Lab nav: Izaro defeated!".to_string());
+                                }
+                                lab_navigation::NavEvent::SectionFinished => {
+                                    app_log(&app, "Lab nav: section finished".to_string());
+                                }
+                                lab_navigation::NavEvent::IzaroBattleStarted => {
+                                    app_log(&app, "Lab nav: Izaro battle started".to_string());
+                                }
+                                lab_navigation::NavEvent::PortalSpawned => {
+                                    app_log(&app, "Lab nav: portal spawned".to_string());
+                                }
+                            }
+                            if let Err(e) = app.emit("lab-nav", &nav_event) {
+                                log::warn!("emit lab-nav failed: {}", e);
+                            }
+                        }
+                    }
+
                     if let Some(event) = state_machine.process_line(&line) {
                         let state = app.state::<AppState>();
                         match &event {
@@ -1656,6 +1699,7 @@ pub fn run() {
         font_session: Mutex::new(FontSessionData::default()),
         font_exhausted: AtomicBool::new(false),
         gem_scan_done: AtomicBool::new(false),
+        in_lab: AtomicBool::new(false),
     };
 
     tauri::Builder::default()


### PR DESCRIPTION
## Summary
- New `lab_navigation.rs` module — parses Client.txt for lab navigation events independently of font/OCR state machine
- Detects: PlazaEntered, RoomChanged (6 prefixes × 8 suffixes), LabStarted/Finished (Izaro voicelines), SectionFinished, IzaroBattleStarted, PortalSpawned, LabExited
- All 22 Izaro voicelines from legacy LabCompass, verified in 3.28 Mirage
- Single `lab-nav` Tauri event with tagged enum payload
- 7 unit tests

Closes POE-91

## Test plan
- [ ] `cargo check` compiles clean
- [ ] `cargo test -- lab_navigation` — 7 tests pass
- [ ] Run lab, verify "Lab nav:" log entries appear at zone transitions
- [ ] Verify existing font/OCR lifecycle is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)