### PR TITLE
feat(compass): add navigation engine with position tracking and auto-routing

### DIFF
--- a/desktop/src/lib/README.md
+++ b/desktop/src/lib/README.md
@@ -29,6 +29,7 @@ Component registry for the ProfitOfExile desktop app. Read this first before cre
 |------|---------|-------------|
 | `compass/room-presets.ts` | `getPresetByAreaCode()`, `getPresetsByName()`, `getTileRect()`, `getDoorExitLocations()`, `getContentLocations()`, `VALID_AREA_CODES` | Room preset data + coordinate math. Loads `room-presets.json` at import time. 35 rooms, 53 variants. |
 | `compass/svg-loader.ts` | `getRoomSvgUrl()`, `getDisabledSvgUrl()` | Resolves area code to SVG path in `/compass/presets/`. Returns null for invalid codes. |
+| `compass/navigation.ts` | `createNavState()`, `loadLayout()`, `handleNavEvent()`, `computeRoute()`, `getNextDirection()`, `getNextExitText()`, `setStrategy()` | Navigation engine — position tracking, auto-routing (BFS + target waypoints), golden key/door tracking. Pure functions, no Svelte reactivity. |
 
 ## Compass Components
 

--- a/desktop/src/lib/compass/navigation.ts
+++ b/desktop/src/lib/compass/navigation.ts
@@ -1,0 +1,513 @@
+/**
+ * Lab Compass navigation engine.
+ *
+ * Tracks player position in the labyrinth using daily layout data and
+ * lab-nav events from Rust. Computes optimal routes based on strategy.
+ *
+ * Pure functions — no side effects, no Svelte reactivity. The overlay
+ * page calls these and stores the result in $state.
+ */
+
+// --- Types ---
+
+export interface LabLayoutRoom {
+	name: string;
+	areacode: string;
+	id: string;
+	x: string;
+	y: string;
+	contents: string[];
+	exits: Record<string, string>;
+	dangerous?: string;
+	secret_passage?: string;
+	content_directions?: string[];
+}
+
+export interface LabLayout {
+	difficulty: string;
+	date: string;
+	weapon: string;
+	phase1: string;
+	phase2: string;
+	trap1: string;
+	trap2: string;
+	rooms: LabLayoutRoom[];
+}
+
+export interface LabSection {
+	roomIds: string[];
+	startRoom: string;
+	endRoom: string; // Aspirant's Trial that ends this section
+}
+
+export type RouteStrategy = 'shortest' | 'darkshrines' | 'darkshrines-argus' | 'everything';
+
+export interface NavState {
+	layout: LabLayout | null;
+	inLab: boolean;
+	finished: boolean;
+	currentRoom: string | null;
+	possibleRooms: Set<string>;
+	previousRoom: string | null;
+	plannedRoute: string[];
+	targetRooms: string[];
+	strategy: RouteStrategy;
+	goldenKeys: number;
+	lockedDoors: [string, string][];
+	portalRooms: Set<string>;
+	sections: LabSection[];
+	adjacency: Map<string, string[]>;
+	roomById: Map<string, LabLayoutRoom>;
+}
+
+export type NavEvent =
+	| { type: 'PlazaEntered' }
+	| { type: 'RoomChanged'; name: string }
+	| { type: 'LabStarted' }
+	| { type: 'SectionFinished' }
+	| { type: 'LabFinished' }
+	| { type: 'IzaroBattleStarted' }
+	| { type: 'PortalSpawned' }
+	| { type: 'LabExited' };
+
+// --- Factory ---
+
+export function createNavState(): NavState {
+	return {
+		layout: null,
+		inLab: false,
+		finished: false,
+		currentRoom: null,
+		possibleRooms: new Set(),
+		previousRoom: null,
+		plannedRoute: [],
+		targetRooms: [],
+		strategy: 'darkshrines',
+		goldenKeys: 0,
+		lockedDoors: [],
+		portalRooms: new Set(),
+		sections: [],
+		adjacency: new Map(),
+		roomById: new Map(),
+	};
+}
+
+// --- Layout loading ---
+
+export function loadLayout(state: NavState, layout: LabLayout): NavState {
+	const roomById = new Map<string, LabLayoutRoom>();
+	const adjacency = new Map<string, string[]>();
+
+	for (const room of layout.rooms) {
+		roomById.set(room.id, room);
+		if (!adjacency.has(room.id)) adjacency.set(room.id, []);
+	}
+
+	// Build bidirectional adjacency from exits
+	for (const room of layout.rooms) {
+		for (const targetId of Object.values(room.exits)) {
+			const neighbors = adjacency.get(room.id)!;
+			if (!neighbors.includes(targetId)) neighbors.push(targetId);
+			const reverseNeighbors = adjacency.get(targetId);
+			if (reverseNeighbors && !reverseNeighbors.includes(room.id)) {
+				reverseNeighbors.push(room.id);
+			}
+		}
+	}
+
+	// Detect sections: split at Aspirant's Trial rooms
+	const sections = detectSections(layout.rooms, adjacency);
+
+	// Identify golden door/key locations
+	const lockedDoors: [string, string][] = [];
+	for (const room of layout.rooms) {
+		if (room.contents.some((c) => c.toLowerCase().includes('golden-door'))) {
+			// Find the connection through the golden door
+			for (const neighborId of adjacency.get(room.id) ?? []) {
+				const neighbor = roomById.get(neighborId);
+				if (neighbor?.contents.some((c) => c.toLowerCase().includes('golden-door'))) {
+					const pair: [string, string] = [room.id, neighborId].sort() as [string, string];
+					if (!lockedDoors.some(([a, b]) => a === pair[0] && b === pair[1])) {
+						lockedDoors.push(pair);
+					}
+				}
+			}
+		}
+	}
+
+	const newState: NavState = {
+		...state,
+		layout,
+		roomById,
+		adjacency,
+		sections,
+		lockedDoors,
+		goldenKeys: 0,
+		portalRooms: new Set(),
+	};
+
+	newState.plannedRoute = computeRoute(newState, state.strategy);
+	newState.targetRooms = getTargetRooms(newState, state.strategy);
+
+	return newState;
+}
+
+function detectSections(rooms: LabLayoutRoom[], adjacency: Map<string, string[]>): LabSection[] {
+	const sections: LabSection[] = [];
+	let currentSection: string[] = [];
+	const trialRooms: string[] = [];
+
+	// Rooms are ordered in the poelab JSON — trials separate sections
+	for (const room of rooms) {
+		if (room.name.toLowerCase() === "aspirant's trial") {
+			trialRooms.push(room.id);
+			if (currentSection.length > 0) {
+				sections.push({
+					roomIds: currentSection,
+					startRoom: currentSection[0],
+					endRoom: room.id,
+				});
+				currentSection = [];
+			}
+		} else {
+			currentSection.push(room.id);
+		}
+	}
+
+	// Last section (after last trial) — if any rooms remain
+	if (currentSection.length > 0 && trialRooms.length > 0) {
+		sections.push({
+			roomIds: currentSection,
+			startRoom: currentSection[0],
+			endRoom: trialRooms[trialRooms.length - 1],
+		});
+	}
+
+	return sections;
+}
+
+// --- Event handling ---
+
+export function handleNavEvent(state: NavState, event: NavEvent): NavState {
+	switch (event.type) {
+		case 'PlazaEntered':
+			return {
+				...state,
+				inLab: true,
+				finished: false,
+				currentRoom: null,
+				possibleRooms: new Set(),
+				previousRoom: null,
+				goldenKeys: 0,
+				portalRooms: new Set(),
+				targetRooms: getTargetRooms(state, state.strategy),
+				plannedRoute: computeRoute(state, state.strategy),
+			};
+
+		case 'RoomChanged': {
+			if (!state.layout) return state;
+
+			const matchingRooms = state.layout.rooms
+				.filter((r) => r.name.toLowerCase() === event.name.toLowerCase())
+				.map((r) => r.id);
+
+			if (matchingRooms.length === 0) return state;
+
+			let candidates: string[];
+
+			// Priority 1: if following planned route and next room matches
+			if (
+				state.currentRoom &&
+				state.plannedRoute.length >= 2 &&
+				matchingRooms.includes(state.plannedRoute[1])
+			) {
+				candidates = [state.plannedRoute[1]];
+			}
+			// Priority 2: intersect with rooms connected to current position
+			else if (state.currentRoom) {
+				const connected = state.adjacency.get(state.currentRoom) ?? [];
+				candidates = matchingRooms.filter((id) => connected.includes(id));
+				if (candidates.length === 0) candidates = matchingRooms;
+			}
+			// Priority 3: first room (entering from plaza)
+			else {
+				candidates = matchingRooms;
+			}
+
+			const newState = { ...state };
+			newState.possibleRooms = new Set(candidates);
+
+			if (candidates.length === 1) {
+				const confirmedId = candidates[0];
+				newState.previousRoom = state.currentRoom;
+				newState.currentRoom = confirmedId;
+
+				// Golden key pickup
+				const room = state.roomById.get(confirmedId);
+				if (room?.contents.some((c) => c.toLowerCase().includes('golden-key'))) {
+					newState.goldenKeys = state.goldenKeys + 1;
+				}
+
+				// Golden door unlock (crossing between locked pair)
+				if (state.previousRoom) {
+					const pair = [state.previousRoom, confirmedId].sort() as [string, string];
+					const doorIdx = state.lockedDoors.findIndex(
+						([a, b]) => a === pair[0] && b === pair[1],
+					);
+					if (doorIdx >= 0) {
+						newState.lockedDoors = [...state.lockedDoors];
+						newState.lockedDoors.splice(doorIdx, 1);
+						newState.goldenKeys = Math.max(0, newState.goldenKeys - 1);
+					}
+				}
+
+				// Remove from targets
+				newState.targetRooms = state.targetRooms.filter((id) => id !== confirmedId);
+
+				// Recompute remaining route from current position
+				newState.plannedRoute = computeRouteFrom(newState, confirmedId, state.strategy);
+			} else {
+				newState.currentRoom = null;
+			}
+
+			return newState;
+		}
+
+		case 'PortalSpawned': {
+			if (!state.currentRoom) return state;
+			const portalRooms = new Set(state.portalRooms);
+			portalRooms.add(state.currentRoom);
+			return { ...state, portalRooms };
+		}
+
+		case 'LabFinished':
+			return { ...state, finished: true };
+
+		case 'LabExited':
+			return {
+				...state,
+				inLab: false,
+				finished: false,
+				currentRoom: null,
+				possibleRooms: new Set(),
+				previousRoom: null,
+				goldenKeys: 0,
+				portalRooms: new Set(),
+			};
+
+		default:
+			return state;
+	}
+}
+
+// --- Routing ---
+
+function getTargetRooms(state: NavState, strategy: RouteStrategy): string[] {
+	if (!state.layout) return [];
+	const targets: string[] = [];
+	for (const room of state.layout.rooms) {
+		if (room.name.toLowerCase() === "aspirant's trial") continue;
+		const contentsLower = room.contents.map((c) => c.toLowerCase());
+		switch (strategy) {
+			case 'shortest':
+				break;
+			case 'darkshrines':
+				if (contentsLower.includes('darkshrine')) targets.push(room.id);
+				break;
+			case 'darkshrines-argus':
+				if (contentsLower.includes('darkshrine') || contentsLower.includes('argus'))
+					targets.push(room.id);
+				break;
+			case 'everything':
+				if (room.contents.length > 0) targets.push(room.id);
+				break;
+		}
+	}
+	return targets;
+}
+
+export function computeRoute(state: NavState, strategy: RouteStrategy): string[] {
+	if (!state.layout || state.sections.length === 0) return [];
+	const firstRoom = state.layout.rooms[0];
+	if (!firstRoom) return [];
+	return computeRouteFrom(state, firstRoom.id, strategy);
+}
+
+function computeRouteFrom(state: NavState, fromRoom: string, strategy: RouteStrategy): string[] {
+	if (!state.layout || state.sections.length === 0) return [];
+
+	const route: string[] = [];
+	const targets = getTargetRooms(state, strategy);
+
+	// Find which section the fromRoom belongs to
+	let startSectionIdx = 0;
+	for (let i = 0; i < state.sections.length; i++) {
+		if (state.sections[i].roomIds.includes(fromRoom)) {
+			startSectionIdx = i;
+			break;
+		}
+	}
+
+	for (let i = startSectionIdx; i < state.sections.length; i++) {
+		const section = state.sections[i];
+		const start = i === startSectionIdx ? fromRoom : section.startRoom;
+		const end = section.endRoom;
+		const sectionTargets = targets.filter((t) => section.roomIds.includes(t));
+
+		const sectionRoute = shortestPathThroughTargets(
+			state.adjacency,
+			start,
+			end,
+			sectionTargets,
+		);
+		// Avoid duplicate room at section boundaries
+		if (route.length > 0 && sectionRoute.length > 0 && route[route.length - 1] === sectionRoute[0]) {
+			route.push(...sectionRoute.slice(1));
+		} else {
+			route.push(...sectionRoute);
+		}
+	}
+
+	return route;
+}
+
+function shortestPathThroughTargets(
+	adjacency: Map<string, string[]>,
+	start: string,
+	end: string,
+	targets: string[],
+): string[] {
+	if (targets.length === 0) {
+		return bfs(adjacency, start, end);
+	}
+
+	// For small target sets (typically 1-4 per section), try all permutations
+	const perms = permutations(targets);
+	let bestRoute: string[] = [];
+	let bestLength = Infinity;
+
+	for (const perm of perms) {
+		const waypoints = [start, ...perm, end];
+		let route: string[] = [];
+		let valid = true;
+
+		for (let i = 0; i < waypoints.length - 1; i++) {
+			const segment = bfs(adjacency, waypoints[i], waypoints[i + 1]);
+			if (segment.length === 0) {
+				valid = false;
+				break;
+			}
+			if (route.length > 0) {
+				route.push(...segment.slice(1));
+			} else {
+				route = segment;
+			}
+		}
+
+		if (valid && route.length < bestLength) {
+			bestLength = route.length;
+			bestRoute = route;
+		}
+	}
+
+	return bestRoute;
+}
+
+function bfs(adjacency: Map<string, string[]>, start: string, end: string): string[] {
+	if (start === end) return [start];
+	const visited = new Set<string>([start]);
+	const parent = new Map<string, string>();
+	const queue = [start];
+
+	while (queue.length > 0) {
+		const current = queue.shift()!;
+		for (const neighbor of adjacency.get(current) ?? []) {
+			if (visited.has(neighbor)) continue;
+			visited.add(neighbor);
+			parent.set(neighbor, current);
+			if (neighbor === end) {
+				// Reconstruct path
+				const path: string[] = [];
+				let node: string | undefined = end;
+				while (node !== undefined) {
+					path.unshift(node);
+					node = parent.get(node);
+				}
+				return path;
+			}
+			queue.push(neighbor);
+		}
+	}
+
+	return []; // No path found
+}
+
+function permutations<T>(arr: T[]): T[][] {
+	if (arr.length <= 1) return [arr];
+	const result: T[][] = [];
+	for (let i = 0; i < arr.length; i++) {
+		const rest = [...arr.slice(0, i), ...arr.slice(i + 1)];
+		for (const perm of permutations(rest)) {
+			result.push([arr[i], ...perm]);
+		}
+	}
+	return result;
+}
+
+// --- Query helpers ---
+
+/** Get the exit direction from currentRoom to the next room on the planned route. */
+export function getNextDirection(state: NavState): string | null {
+	if (!state.currentRoom || state.plannedRoute.length < 2) return null;
+
+	const currentIdx = state.plannedRoute.indexOf(state.currentRoom);
+	if (currentIdx < 0 || currentIdx >= state.plannedRoute.length - 1) return null;
+
+	const nextRoomId = state.plannedRoute[currentIdx + 1];
+	const currentRoom = state.roomById.get(state.currentRoom);
+	if (!currentRoom) return null;
+
+	// Find which exit direction leads to the next room
+	for (const [direction, targetId] of Object.entries(currentRoom.exits)) {
+		if (targetId === nextRoomId) return direction;
+	}
+
+	return null;
+}
+
+/** Get the exit text description (e.g., "Northwest Exit To Estate Path"). */
+export function getNextExitText(state: NavState): string | null {
+	const dir = getNextDirection(state);
+	if (!dir || state.plannedRoute.length < 2) return null;
+
+	const currentIdx = state.plannedRoute.indexOf(state.currentRoom!);
+	if (currentIdx < 0) return null;
+
+	const nextRoomId = state.plannedRoute[currentIdx + 1];
+	const nextRoom = state.roomById.get(nextRoomId);
+	if (!nextRoom) return null;
+
+	const dirNames: Record<string, string> = {
+		N: 'North', NE: 'Northeast', E: 'East', SE: 'Southeast',
+		S: 'South', SW: 'Southwest', W: 'West', NW: 'Northwest', C: 'Secret',
+	};
+
+	return `${dirNames[dir] ?? dir} Exit — ${nextRoom.name}`;
+}
+
+/** Get contents for a specific room. */
+export function getRoomContents(state: NavState, roomId: string): string[] {
+	return state.roomById.get(roomId)?.contents ?? [];
+}
+
+/** Update the routing strategy and recompute the route. */
+export function setStrategy(state: NavState, strategy: RouteStrategy): NavState {
+	const newState = { ...state, strategy };
+	newState.targetRooms = getTargetRooms(newState, strategy);
+	if (state.currentRoom) {
+		newState.plannedRoute = computeRouteFrom(newState, state.currentRoom, strategy);
+	} else {
+		newState.plannedRoute = computeRoute(newState, strategy);
+	}
+	return newState;
+}

--- a/desktop/src/routes/overlay/compass/+page.svelte
+++ b/desktop/src/routes/overlay/compass/+page.svelte
@@ -2,34 +2,26 @@
 	import { listen } from '@tauri-apps/api/event';
 	import { invoke } from '@tauri-apps/api/core';
 	import CompassOverlay from '$lib/compass/CompassOverlay.svelte';
+	import { getPresetByAreaCode, getDoorExitLocations, getContentLocations } from '$lib/compass/room-presets';
 	import {
-		getPresetsByName,
-		getDoorExitLocations,
-		getContentLocations,
-		type RoomPreset,
-		type DoorExitLocation,
-		type ContentLocation,
-	} from '$lib/compass/room-presets';
-
-	// --- Navigation event payload (tagged enum from Rust) ---
-	type NavEvent =
-		| { type: 'PlazaEntered' }
-		| { type: 'RoomChanged'; name: string }
-		| { type: 'SectionFinished' }
-		| { type: 'LabFinished' }
-		| { type: 'LabExited' };
+		createNavState,
+		loadLayout,
+		handleNavEvent,
+		getNextDirection,
+		getNextExitText,
+		getRoomContents,
+		type NavEvent,
+		type LabLayout,
+	} from '$lib/compass/navigation';
+	import type { DoorExitLocation, ContentLocation } from '$lib/compass/room-presets';
 
 	// --- State ---
-	let inLab = $state(false);
-	let roomName = $state('');
-	let currentPreset = $state<RoomPreset | null>(null);
-	let doors = $state<DoorExitLocation[]>([]);
-	let contents = $state<ContentLocation[]>([]);
+	let navState = $state(createNavState());
 	let mode = $state<'minimap' | 'direction' | 'minimal'>('minimap');
 
 	// Timer state
 	let timerStart = $state<number | null>(null);
-	let timerInterval = $state<ReturnType<typeof setInterval> | null>(null);
+	let timerInterval: ReturnType<typeof setInterval> | null = null;
 	let elapsed = $state(0);
 
 	let timerText = $derived(formatTimer(elapsed));
@@ -41,7 +33,7 @@
 	}
 
 	function startTimer() {
-		if (timerStart !== null) return; // already running
+		if (timerStart !== null) return;
 		timerStart = Date.now();
 		elapsed = 0;
 		timerInterval = setInterval(() => {
@@ -56,91 +48,91 @@
 			clearInterval(timerInterval);
 			timerInterval = null;
 		}
-		// Keep timerStart and elapsed so the display persists
 	}
 
-	function clearAll() {
-		inLab = false;
-		roomName = '';
-		currentPreset = null;
-		doors = [];
-		contents = [];
+	function resetTimer() {
 		stopTimer();
 		timerStart = null;
 		elapsed = 0;
 	}
 
-	function handleNavEvent(event: NavEvent) {
+	// --- Derived from navigation state ---
+	let currentRoom = $derived(navState.currentRoom ? navState.roomById.get(navState.currentRoom) : null);
+	let preset = $derived(currentRoom?.areacode ? getPresetByAreaCode(currentRoom.areacode) : null);
+	let doors = $derived<DoorExitLocation[]>(preset ? getDoorExitLocations(preset) : []);
+	let contents = $derived<ContentLocation[]>(preset ? getContentLocations(preset) : []);
+	let targetDirection = $derived(getNextDirection(navState));
+	let exitText = $derived(getNextExitText(navState));
+	let roomName = $derived(currentRoom?.name ?? '');
+	let areaCode = $derived(currentRoom?.areacode ?? '');
+	let contentNames = $derived(currentRoom ? getRoomContents(navState, currentRoom.id) : []);
+	let showOverlay = $derived(navState.inLab || navState.currentRoom !== null);
+
+	// --- Event handling ---
+
+	function onNavEvent(event: NavEvent) {
+		navState = handleNavEvent(navState, event);
+
 		switch (event.type) {
 			case 'PlazaEntered':
-				inLab = true;
-				roomName = '';
-				currentPreset = null;
-				doors = [];
-				contents = [];
+				resetTimer();
 				break;
-
-			case 'RoomChanged': {
-				const presets = getPresetsByName(event.name, false);
-				roomName = event.name;
-
-				if (presets.length === 0) {
-					currentPreset = null;
-					doors = [];
-					contents = [];
-				} else {
-					const variant = presets[0];
-					currentPreset = variant;
-					doors = getDoorExitLocations(variant);
-					contents = getContentLocations(variant);
-				}
-
-				// Start timer on first room change inside the lab
-				if (inLab && timerStart === null) {
+			case 'RoomChanged':
+				if (navState.inLab && timerStart === null) {
 					startTimer();
 				}
 				break;
-			}
-
-			case 'SectionFinished':
-				// No special handling — room data stays
-				break;
-
 			case 'LabFinished':
 				stopTimer();
-				// Keep display so the player can see final state
 				break;
-
 			case 'LabExited':
-				clearAll();
+				resetTimer();
 				break;
 		}
 	}
 
 	// --- Initialization via $effect (onMount does not fire in overlay windows) ---
 
-	// Load compass mode setting from Rust
+	// Load compass mode setting
 	$effect(() => {
-		invoke<string>('get_compass_settings')
-			.then((settings: any) => {
-				if (settings?.mode) {
-					mode = settings.mode;
-				}
+		invoke<any>('get_compass_settings')
+			.then((settings) => {
+				if (settings?.mode) mode = settings.mode;
 			})
-			.catch((e) => {
-				console.warn('[compass] get_compass_settings failed, using default:', e);
-			});
+			.catch((e) => console.warn('[compass] get_compass_settings failed:', e));
 	});
 
-	// Listen for lab-nav events from the Rust backend
+	// Fetch today's layout from server
+	$effect(() => {
+		invoke<any>('get_status')
+			.then((status) => {
+				const serverUrl = status?.server_url;
+				if (!serverUrl) return;
+				// Try all difficulties — Uber is most common for lab farming
+				for (const diff of ['Uber', 'Merciless', 'Cruel', 'Normal']) {
+					fetch(`${serverUrl}/api/lab/layout/${diff}`)
+						.then((r) => {
+							if (r.ok) return r.json();
+							return null;
+						})
+						.then((layout: LabLayout | null) => {
+							if (layout && !navState.layout) {
+								navState = loadLayout(navState, layout);
+							}
+						})
+						.catch(() => {});
+				}
+			})
+			.catch((e) => console.warn('[compass] get_status failed:', e));
+	});
+
+	// Listen for lab-nav events
 	$effect(() => {
 		let cancelled = false;
-
 		const unlistenPromise = listen<NavEvent>('lab-nav', (event) => {
 			if (cancelled) return;
-			handleNavEvent(event.payload);
+			onNavEvent(event.payload);
 		});
-
 		return () => {
 			cancelled = true;
 			unlistenPromise.then((unlisten) => unlisten());
@@ -149,15 +141,20 @@
 </script>
 
 <div class="compass-container">
-	{#if inLab || currentPreset}
+	{#if showOverlay}
 		<CompassOverlay
 			{mode}
-			areaCode={currentPreset?.areaCode ?? ''}
+			{areaCode}
 			{doors}
 			{contents}
-			roomName={roomName}
+			{targetDirection}
+			{roomName}
+			{contentNames}
 			{timerText}
 		/>
+		{#if exitText && mode === 'minimap'}
+			<div class="exit-text">{exitText}</div>
+		{/if}
 	{/if}
 </div>
 
@@ -167,5 +164,16 @@
 		top: 0;
 		right: 0;
 		pointer-events: none;
+	}
+
+	.exit-text {
+		color: #9ca3af;
+		font-size: 9px;
+		font-family: system-ui, sans-serif;
+		text-align: center;
+		margin-top: 2px;
+		padding: 2px 6px;
+		background: rgba(13, 13, 21, 0.85);
+		border-radius: 3px;
 	}
 </style>


### PR DESCRIPTION
## Summary
- New `navigation.ts` module: position tracking (connected-room matching, ambiguity resolution), auto-routing (BFS + target waypoints, 4 strategies), golden key/door tracking
- Updated overlay page to use navigation engine instead of inline preset resolution
- Derives targetDirection from planned route for exit highlighting in minimap
- Fetches daily layout from server on init

Closes POE-93

## Test plan
- [ ] TypeScript compiles (no type errors in navigation.ts)
- [ ] loadLayout with real uber-2026-04-01.json builds correct adjacency map (15 rooms, 3 sections)
- [ ] computeRoute 'shortest' returns direct path through sections
- [ ] computeRoute 'darkshrines' includes darkshrine rooms as waypoints
- [ ] handleNavEvent RoomChanged correctly tracks position
- [ ] getNextDirection returns correct exit for planned route
- [ ] Overlay page renders with targetDirection highlighting the correct exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)