### PR TITLE
POE-102: Hardware-based device fingerprint for lightweight identity

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -39,6 +39,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           POE_SERVER_URL: ${{ secrets.POE_SERVER_URL }}
           VITE_SERVER_URL: ${{ secrets.POE_SERVER_URL }}
+          APP_FINGERPRINT_SECRET: ${{ secrets.APP_FINGERPRINT_SECRET }}
         run: cd desktop && npx tauri build
 
       - name: Upload exe artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ARG GIT_SHA=dev
 RUN CGO_ENABLED=0 go build -ldflags="-s -w -X profitofexile/internal/server/handlers.Version=${GIT_SHA}" -o /bin/server ./cmd/server
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /bin/collector ./cmd/collector
 RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /bin/recalculate ./cmd/recalculate
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /bin/promote ./cmd/promote
 
 # Stage 2: Minimal production image (collector)
 # NOTE: build with --target to select image:
@@ -48,6 +49,7 @@ FROM gcr.io/distroless/static-debian12 AS server
 
 COPY --from=build /bin/server /server
 COPY --from=build /bin/recalculate /recalculate
+COPY --from=build /bin/promote /promote
 
 EXPOSE 8080
 

--- a/cmd/promote/main.go
+++ b/cmd/promote/main.go
@@ -78,8 +78,8 @@ func runList(ctx context.Context, repo *device.Repository) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(w, "PREFIX\tALIAS\tROLE\tVERSION\tLAST SEEN")
-	fmt.Fprintln(w, "------\t-----\t----\t-------\t---------")
+	fmt.Fprintln(w, "PREFIX\tALIAS\tROLE\tBANNED\tVERSION\tLAST SEEN")
+	fmt.Fprintln(w, "------\t-----\t----\t------\t-------\t---------")
 	for _, d := range devices {
 		prefix := d.Fingerprint
 		if len(prefix) > 8 {
@@ -91,6 +91,11 @@ func runList(ctx context.Context, repo *device.Repository) error {
 			alias = *d.Alias
 		}
 
+		banned := "no"
+		if d.Banned {
+			banned = "YES"
+		}
+
 		version := "-"
 		if d.AppVersion != nil {
 			version = *d.AppVersion
@@ -98,7 +103,7 @@ func runList(ctx context.Context, repo *device.Repository) error {
 
 		lastSeen := d.LastSeen.Format(time.RFC3339)
 
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", prefix, alias, d.Role, version, lastSeen)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n", prefix, alias, d.Role, banned, version, lastSeen)
 	}
 	return w.Flush()
 }
@@ -161,7 +166,7 @@ Commands:
 Valid roles: user, editor, admin
 
 Environment:
-  DATABASE_URL    PostgreSQL connection string (required)
+  DATABASE_URL    PostgreSQL connection string (defaults to local Docker dev DB)
 
 Examples:
   promote list

--- a/cmd/promote/main.go
+++ b/cmd/promote/main.go
@@ -56,6 +56,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error: %v\n", err)
 			os.Exit(1)
 		}
+	case "stats":
+		if err := runStats(ctx, repo); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
 	case "help", "--help", "-h":
 		printUsage()
 	default:
@@ -155,11 +160,49 @@ func runPromote(ctx context.Context, repo *device.Repository, args []string) err
 	return nil
 }
 
+func runStats(ctx context.Context, repo *device.Repository) error {
+	s, err := repo.Stats(ctx)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Total devices:  %d\n", s.Total)
+	fmt.Printf("Active (24h):   %d\n", s.Active24h)
+	fmt.Printf("Active (7d):    %d\n", s.Active7d)
+	fmt.Printf("Identified:     %d\n", s.Identified)
+	fmt.Printf("Banned:         %d\n", s.Banned)
+
+	fmt.Print("\nBy role: ")
+	first := true
+	for role, count := range s.ByRole {
+		if !first {
+			fmt.Print(", ")
+		}
+		fmt.Printf("%s=%d", role, count)
+		first = false
+	}
+	fmt.Println()
+
+	fmt.Print("By version: ")
+	first = true
+	for version, count := range s.ByVersion {
+		if !first {
+			fmt.Print(", ")
+		}
+		fmt.Printf("%s=%d", version, count)
+		first = false
+	}
+	fmt.Println()
+
+	return nil
+}
+
 func printUsage() {
 	fmt.Fprintf(os.Stderr, `Usage: promote <command>
 
 Commands:
   list                         List all identified devices
+  stats                        Show device statistics (total, active, by role/version)
   <prefix> <role>              Set role for device matching fingerprint prefix
   <prefix> <role> "alias"      Set role and alias
 

--- a/cmd/promote/main.go
+++ b/cmd/promote/main.go
@@ -1,0 +1,171 @@
+// cmd/promote is a CLI tool for promoting device roles.
+//
+// Usage:
+//
+//	promote list                         — list all identified devices
+//	promote <prefix> <role>              — set role for device matching fingerprint prefix
+//	promote <prefix> <role> "New Alias"  — set role + alias
+//
+// Valid roles: user, editor, admin.
+// The tool connects directly to the database via DATABASE_URL.
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"profitofexile/internal/db"
+	"profitofexile/internal/device"
+)
+
+var validRoles = map[string]bool{
+	"user":   true,
+	"editor": true,
+	"admin":  true,
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		dbURL = "postgresql://profitofexile:profitofexile@postgres:5432/profitofexile"
+	}
+
+	pool, err := db.NewPool(ctx, dbURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: database connection failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer pool.Close()
+
+	repo := device.NewRepository(pool)
+
+	switch os.Args[1] {
+	case "list":
+		if err := runList(ctx, repo); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	case "help", "--help", "-h":
+		printUsage()
+	default:
+		if err := runPromote(ctx, repo, os.Args[1:]); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
+	}
+}
+
+func runList(ctx context.Context, repo *device.Repository) error {
+	devices, err := repo.ListIdentified(ctx)
+	if err != nil {
+		return fmt.Errorf("list identified devices: %w", err)
+	}
+
+	if len(devices) == 0 {
+		fmt.Println("No identified devices found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(w, "PREFIX\tALIAS\tROLE\tVERSION\tLAST SEEN")
+	fmt.Fprintln(w, "------\t-----\t----\t-------\t---------")
+	for _, d := range devices {
+		prefix := d.Fingerprint
+		if len(prefix) > 8 {
+			prefix = prefix[:8]
+		}
+
+		alias := "-"
+		if d.Alias != nil {
+			alias = *d.Alias
+		}
+
+		version := "-"
+		if d.AppVersion != nil {
+			version = *d.AppVersion
+		}
+
+		lastSeen := d.LastSeen.Format(time.RFC3339)
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", prefix, alias, d.Role, version, lastSeen)
+	}
+	return w.Flush()
+}
+
+func runPromote(ctx context.Context, repo *device.Repository, args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("usage: promote <prefix> <role> [alias]\n\nRun 'promote help' for details")
+	}
+
+	prefix := args[0]
+	role := args[1]
+	alias := ""
+	if len(args) >= 3 {
+		alias = args[2]
+	}
+
+	if !validRoles[role] {
+		return fmt.Errorf("invalid role %q — must be one of: user, editor, admin", role)
+	}
+
+	d, err := repo.GetByPrefix(ctx, prefix)
+	if err != nil {
+		if errors.Is(err, device.ErrNotFound) {
+			return fmt.Errorf("no device found with fingerprint prefix %q", prefix)
+		}
+		if errors.Is(err, device.ErrAmbiguousPrefix) {
+			return fmt.Errorf("prefix %q matches multiple devices — use a longer prefix", prefix)
+		}
+		return fmt.Errorf("lookup device: %w", err)
+	}
+
+	if err := repo.SetRole(ctx, d.Fingerprint, role, alias); err != nil {
+		return fmt.Errorf("set role: %w", err)
+	}
+
+	displayAlias := "-"
+	if alias != "" {
+		displayAlias = alias
+	} else if d.Alias != nil {
+		displayAlias = *d.Alias
+	}
+
+	shortFP := d.Fingerprint
+	if len(shortFP) > 8 {
+		shortFP = shortFP[:8]
+	}
+
+	fmt.Printf("Device %s promoted to %s (alias: %s)\n", shortFP, role, displayAlias)
+	return nil
+}
+
+func printUsage() {
+	fmt.Fprintf(os.Stderr, `Usage: promote <command>
+
+Commands:
+  list                         List all identified devices
+  <prefix> <role>              Set role for device matching fingerprint prefix
+  <prefix> <role> "alias"      Set role and alias
+
+Valid roles: user, editor, admin
+
+Environment:
+  DATABASE_URL    PostgreSQL connection string (required)
+
+Examples:
+  promote list
+  promote a1b2c3d4 admin
+  promote a1b2 editor "Seb's PC"
+`)
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"profitofexile/internal/db"
+	"profitofexile/internal/device"
 	"profitofexile/internal/lab"
 	"profitofexile/internal/mercure"
 	"profitofexile/internal/server"
@@ -201,6 +202,8 @@ func main() {
 		// POST /api/internal/trade/refresh for collector to trigger.
 	}
 
+	deviceRepo := device.NewRepository(pool)
+
 	routerCfg := server.RouterConfig{
 		MercureURL:           mercureURL,
 		MercureSecret:        mercureSecret,
@@ -219,6 +222,7 @@ func main() {
 		League:               os.Getenv("LEAGUE"),
 		Analyzer:             analyzer,
 		AllowedOrigins:       corsOrigins(),
+		DeviceRepo:           deviceRepo,
 	}
 
 	router := server.NewRouter(pool, frontendFS, routerCfg)

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -29,8 +29,12 @@ anyhow = "1"
 rfd = "0.15"
 sysinfo = "0.33"
 chrono = { version = "0.4", features = ["serde"] }
+sha2 = "0.10"
+hex = "0.4"
+uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(windows)'.dependencies]
+winreg = "0.55"
 windows = { version = "0.58", features = [
     "Media_Ocr",
     "Graphics_Imaging",

--- a/desktop/src-tauri/src/fingerprint.rs
+++ b/desktop/src-tauri/src/fingerprint.rs
@@ -1,0 +1,115 @@
+//! Device fingerprint computation.
+//!
+//! Generates a stable, hardware-based device ID by hashing:
+//!   - Windows MachineGuid (registry)
+//!   - CPU ProcessorId (WMI)
+//!   - Motherboard serial number (WMI)
+//!   - A build-time secret (prevents raw hardware data leaks)
+//!
+//! Falls back to a random UUID when hardware data is unavailable (e.g. WMI
+//! service disabled). The fallback is volatile — a new ID is generated on each
+//! app launch — but it still allows activity tracking within a single session.
+
+use sha2::{Digest, Sha256};
+
+/// Build-time secret injected via `APP_FINGERPRINT_SECRET` env var.
+/// Falls back to a fixed dev-only value so local builds work without CI secrets.
+const APP_SECRET: &str = match option_env!("APP_FINGERPRINT_SECRET") {
+    Some(s) => s,
+    None => "poe-dev-fingerprint-salt",
+};
+
+/// Compute the device fingerprint. Returns a hex-encoded SHA-256 hash.
+///
+/// On non-Windows platforms (or when all hardware queries fail), returns a
+/// random UUID v4 string instead.
+pub fn compute_device_id() -> String {
+    #[cfg(windows)]
+    {
+        match try_hardware_fingerprint() {
+            Some(fp) => fp,
+            None => {
+                log::warn!("Hardware fingerprint failed — using volatile random UUID");
+                uuid::Uuid::new_v4().to_string()
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    {
+        log::warn!("Non-Windows platform — using volatile random UUID as device ID");
+        uuid::Uuid::new_v4().to_string()
+    }
+}
+
+/// Attempt to read hardware identifiers and hash them.
+#[cfg(windows)]
+fn try_hardware_fingerprint() -> Option<String> {
+    let machine_guid = read_machine_guid().unwrap_or_default();
+    let cpu_id = read_wmi_value("Win32_Processor", "ProcessorId").unwrap_or_default();
+    let board_serial = read_wmi_value("Win32_BaseBoard", "SerialNumber").unwrap_or_default();
+
+    // Need at least one real identifier — otherwise the hash is just the secret.
+    if machine_guid.is_empty() && cpu_id.is_empty() && board_serial.is_empty() {
+        log::warn!("All hardware identifiers empty");
+        return None;
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(machine_guid.as_bytes());
+    hasher.update(cpu_id.as_bytes());
+    hasher.update(board_serial.as_bytes());
+    hasher.update(APP_SECRET.as_bytes());
+
+    Some(hex::encode(hasher.finalize()))
+}
+
+/// Read MachineGuid from the Windows registry.
+#[cfg(windows)]
+fn read_machine_guid() -> Option<String> {
+    use winreg::enums::HKEY_LOCAL_MACHINE;
+    use winreg::RegKey;
+
+    let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);
+    let key = hklm
+        .open_subkey("SOFTWARE\\Microsoft\\Cryptography")
+        .ok()?;
+    let guid: String = key.get_value("MachineGuid").ok()?;
+    Some(guid)
+}
+
+/// Query a single WMI value via a PowerShell one-liner.
+///
+/// WMI COM bindings are fragile in Rust — PowerShell is reliable and only runs
+/// once at startup, so the ~200ms overhead is acceptable.
+#[cfg(windows)]
+fn read_wmi_value(class: &str, property: &str) -> Option<String> {
+    let output = std::process::Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            &format!(
+                "(Get-CimInstance -ClassName {} -Property {}).{}",
+                class, property, property
+            ),
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        log::warn!(
+            "WMI query {}.{} failed: {}",
+            class,
+            property,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+        return None;
+    }
+
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if value.is_empty() || value == "None" {
+        return None;
+    }
+    Some(value)
+}

--- a/desktop/src-tauri/src/fingerprint.rs
+++ b/desktop/src-tauri/src/fingerprint.rs
@@ -90,7 +90,7 @@ fn read_wmi_value(class: &str, property: &str) -> Option<String> {
             "-NonInteractive",
             "-Command",
             &format!(
-                "(Get-CimInstance -ClassName {} -Property {}).{}",
+                "(Get-CimInstance -ClassName '{}' -Property '{}').'{}'",
                 class, property, property
             ),
         ])

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod capture;
+mod fingerprint;
 #[allow(dead_code)] // Font panel OCR — not yet wired into the scan pipeline
 mod font_parser;
 mod gem_matcher;
@@ -52,6 +53,7 @@ pub struct AppStatus {
     pub trade_stale_critical_secs: u32,
     pub trade_auto_refresh_secs: u32,
     pub auto_trade_enabled: bool,
+    pub device_id: String,
 }
 
 /// Accumulated font session data — shared between font scan loop and event handlers.
@@ -76,6 +78,9 @@ pub struct FontRound {
 }
 
 pub struct AppState {
+    /// Hardware-based device fingerprint — computed once at startup, immutable.
+    /// String is Sync so no Mutex needed.
+    pub device_id: String,
     pub pair_code: Mutex<String>,
     pub client_txt_path: Mutex<String>,
     pub server_url: Mutex<String>,
@@ -147,6 +152,7 @@ fn build_status(state: &AppState) -> AppStatus {
         trade_stale_critical_secs: *state.trade_stale_critical_secs.lock().unwrap_or_else(|e| e.into_inner()),
         trade_auto_refresh_secs: *state.trade_auto_refresh_secs.lock().unwrap_or_else(|e| e.into_inner()),
         auto_trade_enabled: *state.auto_trade_enabled.lock().unwrap_or_else(|e| e.into_inner()),
+        device_id: state.device_id.clone(),
     }
 }
 
@@ -232,6 +238,12 @@ fn get_status(state: tauri::State<AppState>) -> AppStatus {
 #[tauri::command]
 fn get_pair_code(state: tauri::State<AppState>) -> String {
     state.pair_code.lock().unwrap_or_else(|e| e.into_inner()).clone()
+}
+
+/// Returns the first 8 characters of the device fingerprint (for display in the identify dialog).
+#[tauri::command]
+fn get_device_id(state: tauri::State<AppState>) -> String {
+    state.device_id.chars().take(8).collect()
 }
 
 #[tauri::command]
@@ -1094,16 +1106,9 @@ async fn send_test_gems(app: AppHandle) -> Result<String, String> {
 
     app_log(&app, format!("Sending test gems to {}", url));
 
-    let client = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()
-        .map_err(|e| {
-            let msg = format!("HTTP client error: {}", e);
-            app_log(&app, msg.clone());
-            msg
-        })?;
+    let http = state.server_http.clone();
 
-    let res = client
+    let res = http
         .post(&url)
         .json(&serde_json::json!({
             "pair": pair,
@@ -1139,21 +1144,11 @@ async fn send_gems_to_server(app: &AppHandle, gems: Vec<String>) {
     let pair = state.pair_code.lock().unwrap_or_else(|e| e.into_inner()).clone();
     let server = state.server_url.lock().unwrap_or_else(|e| e.into_inner()).clone();
     let url = format!("{}/api/desktop/gems", server);
+    let http = state.server_http.clone();
 
     app_log(app, format!("Sending {} gems to server", gems.len()));
 
-    let client = match reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            app_log(app, format!("HTTP client error: {}", e));
-            return;
-        }
-    };
-
-    match client
+    match http
         .post(&url)
         .json(&serde_json::json!({
             "pair": pair,
@@ -1557,11 +1552,13 @@ fn send_font_session_data(app: &AppHandle) {
     let pair = state.pair_code.lock().unwrap_or_else(|e| e.into_inner()).clone();
     let server = state.server_url.lock().unwrap_or_else(|e| e.into_inner()).clone();
 
+    let device_id = state.device_id.clone();
+
     let session_data = serde_json::json!({
         "lab_type": "Unknown",
         "total_crafts": session.rounds.len(),
         "variant": "20/20",
-        "device_id": "desktop",
+        "device_id": device_id,
         "pair_code": pair,
         "rounds": session.rounds.iter().map(|r| serde_json::json!({
             "craft_options": r.options,
@@ -1970,9 +1967,26 @@ pub fn run() {
     let pair_code = generate_pair_code();
     log::info!("Pair code: {}", pair_code);
 
-    let server_http = reqwest::Client::new();
+    let device_id = fingerprint::compute_device_id();
+    log::info!("Device ID: {}... ({})", &device_id[..device_id.len().min(8)],
+        if device_id.len() == 64 { "hardware" } else { "volatile" });
+
+    // Build server HTTP client with default device headers.
+    let version = env!("CARGO_PKG_VERSION");
+    let mut default_headers = reqwest::header::HeaderMap::new();
+    if let Ok(v) = reqwest::header::HeaderValue::from_str(&device_id) {
+        default_headers.insert("X-Device-ID", v);
+    }
+    if let Ok(v) = reqwest::header::HeaderValue::from_str(version) {
+        default_headers.insert("X-App-Version", v);
+    }
+    let server_http = reqwest::Client::builder()
+        .default_headers(default_headers)
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
 
     let app_state = AppState {
+        device_id: device_id.clone(),
         pair_code: Mutex::new(pair_code),
         client_txt_path: Mutex::new(String::from(
             r"C:\Program Files (x86)\Grinding Gear Games\Path of Exile\logs\Client.txt",
@@ -2016,6 +2030,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             get_status,
             get_pair_code,
+            get_device_id,
             regenerate_pair_code,
             set_client_txt_path,
             reset_client_txt_path,

--- a/desktop/src/lib/README.md
+++ b/desktop/src/lib/README.md
@@ -16,6 +16,7 @@ Component registry for the ProfitOfExile desktop app. Read this first before cre
 | `components/TopBar.svelte` | `status` | Custom title bar — logo, status indicators, debug toggle (dev only), settings link, window controls (min/max/close). Draggable. |
 | `components/Sidebar.svelte` | `open`, `currentPath`, `onToggle` | Collapsible nav — strategies, tools, overlay quick-toggles. Collapsed state shows thin clickable strip. |
 | `components/Select.svelte` | `value` (bindable), `options`, `onchange` | Custom dropdown select — styled dark theme, chevron indicator. Used by dashboard components. |
+| `components/IdentifyDialog.svelte` | `open` (bindable) | Device identify dialog — shows short device ID, alias input, POST to `/api/device/identify`. Triggered by Ctrl+Shift+I. |
 
 ## Overlay Utilities
 

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -5,6 +5,7 @@
 
 import { store } from '$lib/stores/status.svelte';
 import type { TradeLookupResult } from './tradeApi';
+import { getVersion } from '@tauri-apps/api/app';
 
 // --- Types ---
 
@@ -169,6 +170,26 @@ export interface CompareGem {
 
 // --- API helpers ---
 
+/** Cached app version — resolved once, reused on every request. */
+let cachedVersion = '';
+getVersion().then(v => { cachedVersion = v; }).catch(() => {});
+
+/**
+ * Build device identity headers for server requests.
+ * Omits headers when values are not yet available (prevents sending "undefined").
+ */
+function deviceHeaders(): Record<string, string> {
+	const headers: Record<string, string> = {};
+	const deviceId = store.status?.device_id;
+	if (deviceId && typeof deviceId === 'string') {
+		headers['X-Device-ID'] = deviceId;
+	}
+	if (cachedVersion) {
+		headers['X-App-Version'] = cachedVersion;
+	}
+	return headers;
+}
+
 /**
  * Returns the API base URL from the Rust backend settings.
  * Called fresh on every request so it picks up server_url changes (e.g. after settings edit).
@@ -184,7 +205,7 @@ async function get<T>(path: string, params?: Record<string, string>): Promise<T>
 			if (v) url.searchParams.set(k, v);
 		}
 	}
-	const resp = await fetch(url.toString());
+	const resp = await fetch(url.toString(), { headers: deviceHeaders() });
 	if (!resp.ok) {
 		throw new Error(`API ${path}: ${resp.status} ${resp.statusText}`);
 	}
@@ -415,7 +436,7 @@ export async function fetchCompare(gems: string[], variant: string, signal?: Abo
 	const url = new URL(`${getApiBase()}/analysis/compare`);
 	url.searchParams.set('gems', gems.join(','));
 	url.searchParams.set('variant', variant);
-	const resp = await fetch(url.toString(), { signal });
+	const resp = await fetch(url.toString(), { signal, headers: deviceHeaders() });
 	if (!resp.ok) {
 		throw new Error(`API /analysis/compare: ${resp.status} ${resp.statusText}`);
 	}

--- a/desktop/src/lib/components/IdentifyDialog.svelte
+++ b/desktop/src/lib/components/IdentifyDialog.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { invoke } from '@tauri-apps/api/core';
 	import { store } from '$lib/stores/status.svelte';
 	import { getVersion } from '@tauri-apps/api/app';
 
@@ -18,9 +17,7 @@
 			error = '';
 			success = '';
 			submitting = false;
-			invoke<string>('get_device_id')
-				.then(id => { shortId = id; })
-				.catch(() => { shortId = '??'; });
+			shortId = store.status?.device_id?.slice(0, 8) ?? '??';
 			getVersion()
 				.then(v => { appVersion = v; })
 				.catch(() => {});

--- a/desktop/src/lib/components/IdentifyDialog.svelte
+++ b/desktop/src/lib/components/IdentifyDialog.svelte
@@ -1,0 +1,294 @@
+<script lang="ts">
+	import { invoke } from '@tauri-apps/api/core';
+	import { store } from '$lib/stores/status.svelte';
+	import { getVersion } from '@tauri-apps/api/app';
+
+	let { open = $bindable(false) } = $props();
+
+	let alias = $state('');
+	let shortId = $state('');
+	let submitting = $state(false);
+	let error = $state('');
+	let success = $state('');
+	let appVersion = $state('');
+
+	$effect(() => {
+		if (open) {
+			alias = '';
+			error = '';
+			success = '';
+			submitting = false;
+			invoke<string>('get_device_id')
+				.then(id => { shortId = id; })
+				.catch(() => { shortId = '??'; });
+			getVersion()
+				.then(v => { appVersion = v; })
+				.catch(() => {});
+		}
+	});
+
+	async function identify() {
+		const trimmed = alias.trim();
+		if (!trimmed) {
+			error = 'Alias cannot be empty';
+			return;
+		}
+		if (trimmed.length > 64) {
+			error = 'Alias too long (max 64 characters)';
+			return;
+		}
+
+		submitting = true;
+		error = '';
+		success = '';
+
+		try {
+			const serverUrl = store.status?.server_url || '';
+			if (!serverUrl) {
+				error = 'No server URL configured';
+				return;
+			}
+
+			const deviceId = store.status?.device_id;
+			const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+			if (deviceId && typeof deviceId === 'string') {
+				headers['X-Device-ID'] = deviceId;
+			}
+			if (appVersion) {
+				headers['X-App-Version'] = appVersion;
+			}
+
+			const resp = await fetch(`${serverUrl}/api/device/identify`, {
+				method: 'POST',
+				headers,
+				body: JSON.stringify({ alias: trimmed }),
+			});
+
+			if (!resp.ok) {
+				const body = await resp.json().catch(() => ({ error: resp.statusText }));
+				error = body.error || `Server returned ${resp.status}`;
+				return;
+			}
+
+			const body = await resp.json();
+			success = `Identified as "${body.alias}"`;
+
+			// Auto-close after a short delay
+			setTimeout(() => { open = false; }, 1500);
+		} catch (e: any) {
+			error = e.message || 'Failed to identify';
+		} finally {
+			submitting = false;
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			open = false;
+		} else if (e.key === 'Enter' && !submitting) {
+			identify();
+		}
+	}
+</script>
+
+{#if open}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div class="backdrop" onkeydown={handleKeydown} onclick={() => open = false}>
+		<!-- svelte-ignore a11y_no_static_element_interactions -->
+		<div class="dialog" onclick={(e) => e.stopPropagation()}>
+			<div class="header">
+				<h3>Identify Device</h3>
+				<button class="close-btn" onclick={() => open = false}>&times;</button>
+			</div>
+
+			<div class="body">
+				<div class="device-info">
+					<span class="label">Device</span>
+					<code class="device-code">{shortId || '...'}</code>
+				</div>
+
+				<div class="field">
+					<label for="identify-alias">Alias</label>
+					<!-- svelte-ignore a11y_autofocus -->
+					<input
+						id="identify-alias"
+						type="text"
+						placeholder="e.g. Gaming PC, Laptop"
+						bind:value={alias}
+						maxlength="64"
+						autofocus
+						disabled={submitting}
+					/>
+					<span class="hint">A name for this device so the server can identify it.</span>
+				</div>
+
+				{#if error}
+					<div class="message error">{error}</div>
+				{/if}
+				{#if success}
+					<div class="message success">{success}</div>
+				{/if}
+			</div>
+
+			<div class="footer">
+				<button class="btn cancel" onclick={() => open = false} disabled={submitting}>Cancel</button>
+				<button class="btn identify" onclick={identify} disabled={submitting || !alias.trim()}>
+					{submitting ? 'Identifying...' : 'Identify'}
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		z-index: 9999;
+	}
+
+	.dialog {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: 8px;
+		width: 380px;
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+	}
+
+	.header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		padding: 12px 16px;
+		border-bottom: 1px solid var(--border);
+	}
+
+	.header h3 {
+		font-size: 14px;
+		font-weight: 600;
+		color: var(--text);
+	}
+
+	.close-btn {
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		font-size: 18px;
+		cursor: pointer;
+		padding: 0 4px;
+		line-height: 1;
+	}
+	.close-btn:hover { color: var(--text); }
+
+	.body {
+		padding: 16px;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+	}
+
+	.device-info {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+	}
+
+	.label {
+		color: var(--text-muted);
+		font-size: 12px;
+	}
+
+	.device-code {
+		background: var(--bg);
+		padding: 2px 8px;
+		border-radius: 4px;
+		font-family: monospace;
+		font-size: 13px;
+		color: var(--accent);
+		letter-spacing: 0.5px;
+	}
+
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+	}
+
+	.field label {
+		font-size: 12px;
+		color: var(--text-muted);
+	}
+
+	.field input {
+		background: var(--bg);
+		border: 1px solid var(--border);
+		border-radius: 4px;
+		padding: 8px 10px;
+		color: var(--text);
+		font-size: 13px;
+		outline: none;
+	}
+	.field input:focus {
+		border-color: var(--accent);
+	}
+	.field input:disabled {
+		opacity: 0.5;
+	}
+
+	.hint {
+		font-size: 11px;
+		color: var(--text-muted);
+	}
+
+	.message {
+		font-size: 12px;
+		padding: 6px 10px;
+		border-radius: 4px;
+	}
+
+	.message.error {
+		background: rgba(239, 68, 68, 0.15);
+		color: #ef4444;
+	}
+
+	.message.success {
+		background: rgba(74, 222, 128, 0.15);
+		color: var(--success);
+	}
+
+	.footer {
+		display: flex;
+		justify-content: flex-end;
+		gap: 8px;
+		padding: 12px 16px;
+		border-top: 1px solid var(--border);
+	}
+
+	.btn {
+		padding: 6px 16px;
+		border-radius: 4px;
+		font-size: 13px;
+		cursor: pointer;
+		border: none;
+	}
+	.btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+	.btn.cancel {
+		background: transparent;
+		color: var(--text-muted);
+		border: 1px solid var(--border);
+	}
+	.btn.cancel:hover:not(:disabled) { color: var(--text); }
+
+	.btn.identify {
+		background: var(--accent);
+		color: white;
+	}
+	.btn.identify:hover:not(:disabled) {
+		filter: brightness(1.1);
+	}
+</style>

--- a/desktop/src/lib/stores/status.svelte.ts
+++ b/desktop/src/lib/stores/status.svelte.ts
@@ -28,7 +28,7 @@ export interface AppStatus {
 	trade_stale_critical_secs: number;
 	trade_auto_refresh_secs: number;
 	auto_trade_enabled: boolean;
-	/** First 8 chars of the hardware device fingerprint (via get_device_id command for display). */
+	/** Hardware device fingerprint — hex SHA-256 (64 chars) for hardware, UUID for fallback. */
 	device_id: string;
 }
 

--- a/desktop/src/lib/stores/status.svelte.ts
+++ b/desktop/src/lib/stores/status.svelte.ts
@@ -12,10 +12,30 @@
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 
+/** Shape of the Rust AppStatus struct emitted via "status-changed" events. */
+export interface AppStatus {
+	state: string;
+	pair_code: string;
+	detected_gems: string[];
+	client_txt_path: string;
+	client_txt_exists: boolean;
+	server_url: string;
+	gem_region: { x: number; y: number; w: number; h: number };
+	font_region: { x: number; y: number; w: number; h: number };
+	sidebar_open: boolean;
+	game_focused: boolean;
+	trade_stale_warn_secs: number;
+	trade_stale_critical_secs: number;
+	trade_auto_refresh_secs: number;
+	auto_trade_enabled: boolean;
+	/** First 8 chars of the hardware device fingerprint (via get_device_id command for display). */
+	device_id: string;
+}
+
 /** Reactive store — mutate properties, never reassign the export. */
 export const store = $state({
 	/** Full app status from Rust AppState. */
-	status: null as any,
+	status: null as AppStatus | null,
 	/** Log entries from Rust. */
 	logs: [] as string[],
 	/** Whether the Mercure SSE connection to the server is alive. */
@@ -33,7 +53,7 @@ export const store = $state({
  */
 export async function initStatusStore(): Promise<() => void> {
 	// Subscribe to backend events first (so we don't miss any)
-	const unlistenStatus = await listen('status-changed', (event) => {
+	const unlistenStatus = await listen<AppStatus>('status-changed', (event) => {
 		store.status = event.payload;
 	});
 
@@ -43,7 +63,7 @@ export async function initStatusStore(): Promise<() => void> {
 
 	// Then do initial load as fallback
 	try {
-		store.status = await invoke('get_status');
+		store.status = await invoke<AppStatus>('get_status');
 	} catch (e) {
 		console.warn('[store] initial get_status failed:', e);
 	}

--- a/desktop/src/routes/(app)/+layout.svelte
+++ b/desktop/src/routes/(app)/+layout.svelte
@@ -11,6 +11,7 @@
 	import LabPage from '$lib/pages/LabPage.svelte';
 	import SettingsPage from '$lib/pages/SettingsPage.svelte';
 	import DevPage from '$lib/pages/DevPage.svelte';
+	import IdentifyDialog from '$lib/components/IdentifyDialog.svelte';
 
 
 	// Sidebar state: driven by store.status.sidebar_open (persisted in Rust settings).
@@ -266,6 +267,8 @@
 
 	// Ctrl+Shift+F12 toggles debug mode (devtools + force-show overlays)
 	let debugMode = $state(false);
+	// Ctrl+Shift+I opens the identify dialog (device alias registration)
+	let identifyOpen = $state(false);
 
 	$effect(() => {
 		function handleKeydown(e: KeyboardEvent) {
@@ -282,6 +285,10 @@
 					(win as any).closeDevtools().catch((e: any) => console.warn('[debug] closeDevtools failed:', e));
 					console.log('[debug] Debug mode OFF');
 				}
+			}
+			if (e.ctrlKey && e.shiftKey && e.key === 'I') {
+				e.preventDefault();
+				identifyOpen = !identifyOpen;
 			}
 		}
 		window.addEventListener('keydown', handleKeydown);
@@ -452,6 +459,8 @@
 		</main>
 	</div>
 </div>
+
+<IdentifyDialog bind:open={identifyOpen} />
 
 <style>
 	.app-shell {

--- a/internal/db/migrations/20260406001159_create_devices.down.sql
+++ b/internal/db/migrations/20260406001159_create_devices.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS devices;

--- a/internal/db/migrations/20260406001159_create_devices.up.sql
+++ b/internal/db/migrations/20260406001159_create_devices.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS devices (
+    fingerprint TEXT PRIMARY KEY,
+    alias       TEXT,
+    role        TEXT NOT NULL DEFAULT 'user',
+    banned      BOOLEAN NOT NULL DEFAULT false,
+    app_version TEXT,
+    first_seen  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/internal/device/model.go
+++ b/internal/device/model.go
@@ -1,6 +1,9 @@
 package device
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Device represents a registered desktop app instance identified by a
 // hardware-derived fingerprint. Devices are auto-registered on first request
@@ -18,4 +21,22 @@ type Device struct {
 // IsIdentified returns true when the device has an alias set.
 func (d *Device) IsIdentified() bool {
 	return d.Alias != nil && *d.Alias != ""
+}
+
+// Upserter can register or refresh a device by fingerprint.
+// Implemented by Repository; used by the device middleware.
+type Upserter interface {
+	Upsert(ctx context.Context, fingerprint, appVersion string) (*Device, error)
+}
+
+// Lister can list all registered devices.
+// Implemented by Repository; used by the admin devices handler.
+type Lister interface {
+	List(ctx context.Context) ([]Device, error)
+}
+
+// AliasSetter can update a device alias.
+// Implemented by Repository; used by the identify handler.
+type AliasSetter interface {
+	SetAlias(ctx context.Context, fingerprint, alias string) error
 }

--- a/internal/device/model.go
+++ b/internal/device/model.go
@@ -1,0 +1,21 @@
+package device
+
+import "time"
+
+// Device represents a registered desktop app instance identified by a
+// hardware-derived fingerprint. Devices are auto-registered on first request
+// and tracked via the X-Device-ID header.
+type Device struct {
+	Fingerprint string    `json:"fingerprint"`
+	Alias       *string   `json:"alias"`
+	Role        string    `json:"role"`
+	Banned      bool      `json:"banned"`
+	AppVersion  *string   `json:"app_version"`
+	FirstSeen   time.Time `json:"first_seen"`
+	LastSeen    time.Time `json:"last_seen"`
+}
+
+// IsIdentified returns true when the device has an alias set.
+func (d *Device) IsIdentified() bool {
+	return d.Alias != nil && *d.Alias != ""
+}

--- a/internal/device/repository.go
+++ b/internal/device/repository.go
@@ -150,6 +150,65 @@ func (r *Repository) List(ctx context.Context) ([]Device, error) {
 	return collectDevices(rows)
 }
 
+// DeviceStats holds aggregate device statistics.
+type DeviceStats struct {
+	Total      int
+	Active24h  int
+	Active7d   int
+	Identified int
+	Banned     int
+	ByRole     map[string]int
+	ByVersion  map[string]int
+}
+
+// Stats returns aggregate device statistics.
+func (r *Repository) Stats(ctx context.Context) (*DeviceStats, error) {
+	s := &DeviceStats{ByRole: make(map[string]int), ByVersion: make(map[string]int)}
+
+	err := r.pool.QueryRow(ctx, `SELECT
+		COUNT(*),
+		COUNT(*) FILTER (WHERE last_seen > NOW() - INTERVAL '24 hours'),
+		COUNT(*) FILTER (WHERE last_seen > NOW() - INTERVAL '7 days'),
+		COUNT(*) FILTER (WHERE alias IS NOT NULL),
+		COUNT(*) FILTER (WHERE banned = true)
+		FROM devices`).Scan(&s.Total, &s.Active24h, &s.Active7d, &s.Identified, &s.Banned)
+	if err != nil {
+		return nil, fmt.Errorf("device stats: %w", err)
+	}
+
+	// By role
+	rows, err := r.pool.Query(ctx, `SELECT role, COUNT(*) FROM devices GROUP BY role`)
+	if err != nil {
+		return nil, fmt.Errorf("device stats by role: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var role string
+		var count int
+		if err := rows.Scan(&role, &count); err != nil {
+			continue
+		}
+		s.ByRole[role] = count
+	}
+
+	// By version
+	rows2, err := r.pool.Query(ctx, `SELECT COALESCE(app_version, 'unknown'), COUNT(*) FROM devices GROUP BY app_version`)
+	if err != nil {
+		return nil, fmt.Errorf("device stats by version: %w", err)
+	}
+	defer rows2.Close()
+	for rows2.Next() {
+		var version string
+		var count int
+		if err := rows2.Scan(&version, &count); err != nil {
+			continue
+		}
+		s.ByVersion[version] = count
+	}
+
+	return s, nil
+}
+
 // collectDevices scans all rows into a Device slice.
 func collectDevices(rows pgx.Rows) ([]Device, error) {
 	var devices []Device

--- a/internal/device/repository.go
+++ b/internal/device/repository.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -34,7 +35,7 @@ func (r *Repository) Upsert(ctx context.Context, fingerprint, appVersion string)
 		`INSERT INTO devices (fingerprint, app_version)
 		 VALUES ($1, $2)
 		 ON CONFLICT (fingerprint) DO UPDATE
-		   SET last_seen = NOW(), app_version = EXCLUDED.app_version
+		   SET last_seen = NOW(), app_version = COALESCE(EXCLUDED.app_version, devices.app_version)
 		 RETURNING fingerprint, alias, role, banned, app_version, first_seen, last_seen`,
 		fingerprint, nilIfEmpty(appVersion),
 	).Scan(&d.Fingerprint, &d.Alias, &d.Role, &d.Banned, &d.AppVersion, &d.FirstSeen, &d.LastSeen)
@@ -102,8 +103,11 @@ func (r *Repository) ListIdentified(ctx context.Context) ([]Device, error) {
 // SetRole updates the role and optionally the alias for a device.
 // An empty alias string leaves the existing alias unchanged.
 func (r *Repository) SetRole(ctx context.Context, fingerprint, role, alias string) error {
+	var ct pgconn.CommandTag
+	var err error
+
 	if alias != "" {
-		_, err := r.pool.Exec(ctx,
+		ct, err = r.pool.Exec(ctx,
 			`UPDATE devices SET role = $2, alias = $3 WHERE fingerprint = $1`,
 			fingerprint, role, alias,
 		)
@@ -111,7 +115,7 @@ func (r *Repository) SetRole(ctx context.Context, fingerprint, role, alias strin
 			return fmt.Errorf("device set role+alias %q: %w", fingerprint, err)
 		}
 	} else {
-		_, err := r.pool.Exec(ctx,
+		ct, err = r.pool.Exec(ctx,
 			`UPDATE devices SET role = $2 WHERE fingerprint = $1`,
 			fingerprint, role,
 		)
@@ -119,17 +123,23 @@ func (r *Repository) SetRole(ctx context.Context, fingerprint, role, alias strin
 			return fmt.Errorf("device set role %q: %w", fingerprint, err)
 		}
 	}
+	if ct.RowsAffected() == 0 {
+		return ErrNotFound
+	}
 	return nil
 }
 
 // SetAlias updates just the alias for a device. Used by the identify endpoint.
 func (r *Repository) SetAlias(ctx context.Context, fingerprint, alias string) error {
-	_, err := r.pool.Exec(ctx,
+	ct, err := r.pool.Exec(ctx,
 		`UPDATE devices SET alias = $2 WHERE fingerprint = $1`,
 		fingerprint, alias,
 	)
 	if err != nil {
 		return fmt.Errorf("device set alias %q: %w", fingerprint, err)
+	}
+	if ct.RowsAffected() == 0 {
+		return ErrNotFound
 	}
 	return nil
 }
@@ -186,9 +196,12 @@ func (r *Repository) Stats(ctx context.Context) (*DeviceStats, error) {
 		var role string
 		var count int
 		if err := rows.Scan(&role, &count); err != nil {
-			continue
+			return nil, fmt.Errorf("device stats scan role: %w", err)
 		}
 		s.ByRole[role] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("device stats rows role: %w", err)
 	}
 
 	// By version
@@ -201,9 +214,12 @@ func (r *Repository) Stats(ctx context.Context) (*DeviceStats, error) {
 		var version string
 		var count int
 		if err := rows2.Scan(&version, &count); err != nil {
-			continue
+			return nil, fmt.Errorf("device stats scan version: %w", err)
 		}
 		s.ByVersion[version] = count
+	}
+	if err := rows2.Err(); err != nil {
+		return nil, fmt.Errorf("device stats rows version: %w", err)
 	}
 
 	return s, nil

--- a/internal/device/repository.go
+++ b/internal/device/repository.go
@@ -51,7 +51,7 @@ func (r *Repository) GetByPrefix(ctx context.Context, prefix string) (*Device, e
 	rows, err := r.pool.Query(ctx,
 		`SELECT fingerprint, alias, role, banned, app_version, first_seen, last_seen
 		 FROM devices
-		 WHERE fingerprint LIKE $1 || '%'
+		 WHERE LEFT(fingerprint, LENGTH($1)) = $1
 		 LIMIT 2`,
 		prefix,
 	)

--- a/internal/device/repository.go
+++ b/internal/device/repository.go
@@ -1,0 +1,174 @@
+package device
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ErrAmbiguousPrefix is returned by GetByPrefix when the prefix matches
+// more than one device fingerprint.
+var ErrAmbiguousPrefix = errors.New("device: ambiguous fingerprint prefix — matches multiple devices")
+
+// ErrNotFound is returned when no device matches the query.
+var ErrNotFound = errors.New("device: not found")
+
+// Repository handles device persistence in PostgreSQL.
+type Repository struct {
+	pool *pgxpool.Pool
+}
+
+// NewRepository creates a device repository backed by the given connection pool.
+func NewRepository(pool *pgxpool.Pool) *Repository {
+	return &Repository{pool: pool}
+}
+
+// Upsert inserts a new device or updates last_seen and app_version for an
+// existing one. Returns the full device record after the upsert.
+func (r *Repository) Upsert(ctx context.Context, fingerprint, appVersion string) (*Device, error) {
+	var d Device
+	err := r.pool.QueryRow(ctx,
+		`INSERT INTO devices (fingerprint, app_version)
+		 VALUES ($1, $2)
+		 ON CONFLICT (fingerprint) DO UPDATE
+		   SET last_seen = NOW(), app_version = EXCLUDED.app_version
+		 RETURNING fingerprint, alias, role, banned, app_version, first_seen, last_seen`,
+		fingerprint, nilIfEmpty(appVersion),
+	).Scan(&d.Fingerprint, &d.Alias, &d.Role, &d.Banned, &d.AppVersion, &d.FirstSeen, &d.LastSeen)
+	if err != nil {
+		return nil, fmt.Errorf("device upsert %q: %w", fingerprint, err)
+	}
+	return &d, nil
+}
+
+// GetByPrefix finds a device whose fingerprint starts with the given prefix.
+// Returns ErrAmbiguousPrefix if more than one device matches, and ErrNotFound
+// if none match. Used by the promote CLI for short-prefix lookups.
+func (r *Repository) GetByPrefix(ctx context.Context, prefix string) (*Device, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT fingerprint, alias, role, banned, app_version, first_seen, last_seen
+		 FROM devices
+		 WHERE fingerprint LIKE $1 || '%'
+		 LIMIT 2`,
+		prefix,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("device get by prefix %q: %w", prefix, err)
+	}
+	defer rows.Close()
+
+	var devices []Device
+	for rows.Next() {
+		var d Device
+		if err := rows.Scan(&d.Fingerprint, &d.Alias, &d.Role, &d.Banned, &d.AppVersion, &d.FirstSeen, &d.LastSeen); err != nil {
+			return nil, fmt.Errorf("device scan: %w", err)
+		}
+		devices = append(devices, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("device rows: %w", err)
+	}
+
+	switch len(devices) {
+	case 0:
+		return nil, ErrNotFound
+	case 1:
+		return &devices[0], nil
+	default:
+		return nil, ErrAmbiguousPrefix
+	}
+}
+
+// ListIdentified returns all devices that have an alias set (alias IS NOT NULL).
+// Used by the promote CLI to show known devices.
+func (r *Repository) ListIdentified(ctx context.Context) ([]Device, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT fingerprint, alias, role, banned, app_version, first_seen, last_seen
+		 FROM devices
+		 WHERE alias IS NOT NULL
+		 ORDER BY last_seen DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("device list identified: %w", err)
+	}
+	defer rows.Close()
+
+	return collectDevices(rows)
+}
+
+// SetRole updates the role and optionally the alias for a device.
+// An empty alias string leaves the existing alias unchanged.
+func (r *Repository) SetRole(ctx context.Context, fingerprint, role, alias string) error {
+	if alias != "" {
+		_, err := r.pool.Exec(ctx,
+			`UPDATE devices SET role = $2, alias = $3 WHERE fingerprint = $1`,
+			fingerprint, role, alias,
+		)
+		if err != nil {
+			return fmt.Errorf("device set role+alias %q: %w", fingerprint, err)
+		}
+	} else {
+		_, err := r.pool.Exec(ctx,
+			`UPDATE devices SET role = $2 WHERE fingerprint = $1`,
+			fingerprint, role,
+		)
+		if err != nil {
+			return fmt.Errorf("device set role %q: %w", fingerprint, err)
+		}
+	}
+	return nil
+}
+
+// SetAlias updates just the alias for a device. Used by the identify endpoint.
+func (r *Repository) SetAlias(ctx context.Context, fingerprint, alias string) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE devices SET alias = $2 WHERE fingerprint = $1`,
+		fingerprint, alias,
+	)
+	if err != nil {
+		return fmt.Errorf("device set alias %q: %w", fingerprint, err)
+	}
+	return nil
+}
+
+// List returns all devices ordered by last_seen descending.
+// Used by the admin devices endpoint.
+func (r *Repository) List(ctx context.Context) ([]Device, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT fingerprint, alias, role, banned, app_version, first_seen, last_seen
+		 FROM devices
+		 ORDER BY last_seen DESC`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("device list: %w", err)
+	}
+	defer rows.Close()
+
+	return collectDevices(rows)
+}
+
+// collectDevices scans all rows into a Device slice.
+func collectDevices(rows pgx.Rows) ([]Device, error) {
+	var devices []Device
+	for rows.Next() {
+		var d Device
+		if err := rows.Scan(&d.Fingerprint, &d.Alias, &d.Role, &d.Banned, &d.AppVersion, &d.FirstSeen, &d.LastSeen); err != nil {
+			return nil, fmt.Errorf("device scan: %w", err)
+		}
+		devices = append(devices, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("device rows: %w", err)
+	}
+	return devices, nil
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/internal/device/repository_test.go
+++ b/internal/device/repository_test.go
@@ -1,0 +1,87 @@
+package device
+
+import "testing"
+
+func TestDevice_IsIdentified(t *testing.T) {
+	tests := []struct {
+		name  string
+		alias *string
+		want  bool
+	}{
+		{
+			name:  "nil alias is not identified",
+			alias: nil,
+			want:  false,
+		},
+		{
+			name:  "empty alias is not identified",
+			alias: strPtr(""),
+			want:  false,
+		},
+		{
+			name:  "non-empty alias is identified",
+			alias: strPtr("Seb's PC"),
+			want:  true,
+		},
+		{
+			name:  "whitespace-only alias is identified",
+			alias: strPtr("  "),
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Device{Alias: tt.alias}
+			if got := d.IsIdentified(); got != tt.want {
+				t.Errorf("IsIdentified() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNilIfEmpty(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantNil bool
+	}{
+		{"empty string returns nil", "", true},
+		{"non-empty string returns pointer", "hello", false},
+		{"single char returns pointer", "x", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nilIfEmpty(tt.input)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("nilIfEmpty(%q) = %v, want nil", tt.input, *got)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("nilIfEmpty(%q) = nil, want %q", tt.input, tt.input)
+				}
+				if *got != tt.input {
+					t.Errorf("nilIfEmpty(%q) = %q, want %q", tt.input, *got, tt.input)
+				}
+			}
+		})
+	}
+}
+
+func TestErrAmbiguousPrefix_ErrorMessage(t *testing.T) {
+	if ErrAmbiguousPrefix.Error() == "" {
+		t.Error("ErrAmbiguousPrefix should have a non-empty error message")
+	}
+}
+
+func TestErrNotFound_ErrorMessage(t *testing.T) {
+	if ErrNotFound.Error() == "" {
+		t.Error("ErrNotFound should have a non-empty error message")
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/internal/device/repository_test.go
+++ b/internal/device/repository_test.go
@@ -71,14 +71,16 @@ func TestNilIfEmpty(t *testing.T) {
 }
 
 func TestErrAmbiguousPrefix_ErrorMessage(t *testing.T) {
-	if ErrAmbiguousPrefix.Error() == "" {
-		t.Error("ErrAmbiguousPrefix should have a non-empty error message")
+	want := "device: ambiguous fingerprint prefix — matches multiple devices"
+	if got := ErrAmbiguousPrefix.Error(); got != want {
+		t.Errorf("ErrAmbiguousPrefix.Error() = %q, want %q", got, want)
 	}
 }
 
 func TestErrNotFound_ErrorMessage(t *testing.T) {
-	if ErrNotFound.Error() == "" {
-		t.Error("ErrNotFound should have a non-empty error message")
+	want := "device: not found"
+	if got := ErrNotFound.Error(); got != want {
+		t.Errorf("ErrNotFound.Error() = %q, want %q", got, want)
 	}
 }
 

--- a/internal/server/handlers/device.go
+++ b/internal/server/handlers/device.go
@@ -22,9 +22,7 @@ func AdminDevices(repo *device.Repository, internalSecret string) http.HandlerFu
 		devices, err := repo.List(r.Context())
 		if err != nil {
 			slog.Error("admin devices: list failed", "error", err)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(map[string]string{"error": "failed to list devices"})
+			jsonError(w, http.StatusInternalServerError, "failed to list devices")
 			return
 		}
 
@@ -48,32 +46,24 @@ func DeviceIdentify(repo *device.Repository) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		d := middleware.DeviceFromContext(r.Context())
 		if d == nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]string{"error": "X-Device-ID header required"})
+			jsonError(w, http.StatusBadRequest, "X-Device-ID header required")
 			return
 		}
 
 		r.Body = http.MaxBytesReader(w, r.Body, 4096)
 		var body identifyRequest
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON body"})
+			jsonError(w, http.StatusBadRequest, "invalid JSON body")
 			return
 		}
 
 		if body.Alias == "" {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]string{"error": "alias is required"})
+			jsonError(w, http.StatusBadRequest, "alias is required")
 			return
 		}
 
 		if len(body.Alias) > 64 {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusBadRequest)
-			json.NewEncoder(w).Encode(map[string]string{"error": "alias too long (max 64 characters)"})
+			jsonError(w, http.StatusBadRequest, "alias too long (max 64 characters)")
 			return
 		}
 
@@ -83,9 +73,7 @@ func DeviceIdentify(repo *device.Repository) http.HandlerFunc {
 				"alias", body.Alias,
 				"error", err,
 			)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
-			json.NewEncoder(w).Encode(map[string]string{"error": "failed to update alias"})
+			jsonError(w, http.StatusInternalServerError, "failed to update alias")
 			return
 		}
 

--- a/internal/server/handlers/device.go
+++ b/internal/server/handlers/device.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"strings"
+	"unicode/utf8"
 
 	"profitofexile/internal/device"
 	"profitofexile/internal/server/middleware"
@@ -57,12 +59,14 @@ func DeviceIdentify(repo device.AliasSetter) http.HandlerFunc {
 			return
 		}
 
+		body.Alias = strings.TrimSpace(body.Alias)
+
 		if body.Alias == "" {
 			jsonError(w, http.StatusBadRequest, "alias is required")
 			return
 		}
 
-		if len(body.Alias) > 64 {
+		if utf8.RuneCountInString(body.Alias) > 64 {
 			jsonError(w, http.StatusBadRequest, "alias too long (max 64 characters)")
 			return
 		}

--- a/internal/server/handlers/device.go
+++ b/internal/server/handlers/device.go
@@ -12,7 +12,7 @@ import (
 // AdminDevices returns an HTTP handler that lists all registered devices.
 // Protected by INTERNAL_SECRET.
 // GET /api/admin/devices
-func AdminDevices(repo *device.Repository, internalSecret string) http.HandlerFunc {
+func AdminDevices(repo device.Lister, internalSecret string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if internalSecret != "" && r.Header.Get("X-Internal-Token") != internalSecret {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
@@ -42,7 +42,7 @@ type identifyRequest struct {
 // DeviceIdentify handles POST /api/device/identify. Reads the device from
 // request context (set by DeviceMiddleware) and updates its alias.
 // Returns 400 if no device is in context (no X-Device-ID header).
-func DeviceIdentify(repo *device.Repository) http.HandlerFunc {
+func DeviceIdentify(repo device.AliasSetter) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		d := middleware.DeviceFromContext(r.Context())
 		if d == nil {

--- a/internal/server/handlers/device.go
+++ b/internal/server/handlers/device.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"profitofexile/internal/device"
+	"profitofexile/internal/server/middleware"
+)
+
+// AdminDevices returns an HTTP handler that lists all registered devices.
+// Protected by INTERNAL_SECRET.
+// GET /api/admin/devices
+func AdminDevices(repo *device.Repository, internalSecret string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if internalSecret != "" && r.Header.Get("X-Internal-Token") != internalSecret {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		devices, err := repo.List(r.Context())
+		if err != nil {
+			slog.Error("admin devices: list failed", "error", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": "failed to list devices"})
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"devices": devices,
+			"count":   len(devices),
+		})
+	}
+}
+
+// identifyRequest is the expected JSON body for POST /api/device/identify.
+type identifyRequest struct {
+	Alias string `json:"alias"`
+}
+
+// DeviceIdentify handles POST /api/device/identify. Reads the device from
+// request context (set by DeviceMiddleware) and updates its alias.
+// Returns 400 if no device is in context (no X-Device-ID header).
+func DeviceIdentify(repo *device.Repository) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		d := middleware.DeviceFromContext(r.Context())
+		if d == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "X-Device-ID header required"})
+			return
+		}
+
+		r.Body = http.MaxBytesReader(w, r.Body, 4096)
+		var body identifyRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "invalid JSON body"})
+			return
+		}
+
+		if body.Alias == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "alias is required"})
+			return
+		}
+
+		if len(body.Alias) > 64 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "alias too long (max 64 characters)"})
+			return
+		}
+
+		if err := repo.SetAlias(r.Context(), d.Fingerprint, body.Alias); err != nil {
+			slog.Error("device identify: set alias failed",
+				"fingerprint", d.Fingerprint,
+				"alias", body.Alias,
+				"error", err,
+			)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": "failed to update alias"})
+			return
+		}
+
+		slog.Info("device identified",
+			"fingerprint", d.Fingerprint,
+			"alias", body.Alias,
+		)
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"status":      "identified",
+			"fingerprint": d.Fingerprint,
+			"alias":       body.Alias,
+		})
+	}
+}

--- a/internal/server/handlers/device_test.go
+++ b/internal/server/handlers/device_test.go
@@ -218,6 +218,14 @@ func TestAdminDevices_ListError_Returns500(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
 	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["error"] != "failed to list devices" {
+		t.Errorf("error = %q, want %q", resp["error"], "failed to list devices")
+	}
 }
 
 // --- DeviceIdentify tests ---
@@ -400,8 +408,10 @@ func TestDeviceIdentify_MaxLengthAlias_Accepted(t *testing.T) {
 		},
 	}
 
+	setAliasCalled := false
 	setter := &mockAliasSetter{
 		SetAliasFn: func(_ context.Context, _, _ string) error {
+			setAliasCalled = true
 			return nil
 		},
 	}
@@ -420,24 +430,13 @@ func TestDeviceIdentify_MaxLengthAlias_Accepted(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
 	}
+	if !setAliasCalled {
+		t.Error("SetAlias should have been called for a valid max-length alias")
+	}
 }
 
 func TestDeviceIdentify_InvalidJSON_Returns400(t *testing.T) {
 	fingerprint := "abc123def456"
-	upserter := &mockUpserter{
-		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
-			return &device.Device{Fingerprint: fp, Role: "user"}, nil
-		},
-	}
-
-	setter := &mockAliasSetter{
-		SetAliasFn: func(_ context.Context, _, _ string) error {
-			t.Error("SetAlias should not be called with invalid JSON")
-			return nil
-		},
-	}
-
-	router := identifyRouter(upserter, setter)
 
 	tests := []struct {
 		name string
@@ -449,6 +448,21 @@ func TestDeviceIdentify_InvalidJSON_Returns400(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			upserter := &mockUpserter{
+				UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
+					return &device.Device{Fingerprint: fp, Role: "user"}, nil
+				},
+			}
+
+			setter := &mockAliasSetter{
+				SetAliasFn: func(_ context.Context, _, _ string) error {
+					t.Error("SetAlias should not be called with invalid JSON")
+					return nil
+				},
+			}
+
+			router := identifyRouter(upserter, setter)
+
 			req := httptest.NewRequest(http.MethodPost, "/api/device/identify", strings.NewReader(tt.body))
 			req.Header.Set("Content-Type", "application/json")
 			req.Header.Set("X-Device-ID", fingerprint)

--- a/internal/server/handlers/device_test.go
+++ b/internal/server/handlers/device_test.go
@@ -1,0 +1,509 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"profitofexile/internal/device"
+	"profitofexile/internal/server/middleware"
+)
+
+// mockLister implements device.Lister for testing AdminDevices.
+type mockLister struct {
+	ListFn func(ctx context.Context) ([]device.Device, error)
+}
+
+func (m *mockLister) List(ctx context.Context) ([]device.Device, error) {
+	return m.ListFn(ctx)
+}
+
+// mockAliasSetter implements device.AliasSetter for testing DeviceIdentify.
+type mockAliasSetter struct {
+	SetAliasFn func(ctx context.Context, fingerprint, alias string) error
+}
+
+func (m *mockAliasSetter) SetAlias(ctx context.Context, fingerprint, alias string) error {
+	return m.SetAliasFn(ctx, fingerprint, alias)
+}
+
+// mockUpserter implements device.Upserter for the middleware in integration-style tests.
+type mockUpserter struct {
+	UpsertFn func(ctx context.Context, fingerprint, appVersion string) (*device.Device, error)
+}
+
+func (m *mockUpserter) Upsert(ctx context.Context, fingerprint, appVersion string) (*device.Device, error) {
+	return m.UpsertFn(ctx, fingerprint, appVersion)
+}
+
+// newTestDevice creates a device with the given fingerprint for test assertions.
+func newTestDevice(fingerprint string) device.Device {
+	now := time.Date(2026, 4, 5, 12, 0, 0, 0, time.UTC)
+	alias := "test-alias"
+	version := "0.3.1"
+	return device.Device{
+		Fingerprint: fingerprint,
+		Alias:       &alias,
+		Role:        "user",
+		Banned:      false,
+		AppVersion:  &version,
+		FirstSeen:   now,
+		LastSeen:    now,
+	}
+}
+
+// adminRouter builds a chi router with the admin devices endpoint, matching the
+// production wiring in server.go.
+func adminRouter(repo device.Lister, secret string) http.Handler {
+	r := chi.NewRouter()
+	r.Get("/api/admin/devices", AdminDevices(repo, secret))
+	return r
+}
+
+// identifyRouter builds a chi router with device middleware and the identify
+// endpoint, matching the production wiring in server.go.
+func identifyRouter(upserter device.Upserter, setter device.AliasSetter) http.Handler {
+	r := chi.NewRouter()
+	r.Use(middleware.DeviceMiddleware(upserter))
+	r.Post("/api/device/identify", DeviceIdentify(setter))
+	return r
+}
+
+// --- AdminDevices tests ---
+
+func TestAdminDevices_WithoutInternalSecret_Returns401(t *testing.T) {
+	repo := &mockLister{
+		ListFn: func(_ context.Context) ([]device.Device, error) {
+			t.Error("List should not be called when auth fails")
+			return nil, nil
+		},
+	}
+
+	router := adminRouter(repo, "my-secret-token")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/devices", nil)
+	// No X-Internal-Token header.
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+func TestAdminDevices_WrongInternalSecret_Returns401(t *testing.T) {
+	repo := &mockLister{
+		ListFn: func(_ context.Context) ([]device.Device, error) {
+			t.Error("List should not be called when auth fails")
+			return nil, nil
+		},
+	}
+
+	router := adminRouter(repo, "correct-secret")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/devices", nil)
+	req.Header.Set("X-Internal-Token", "wrong-secret")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+func TestAdminDevices_WithInternalSecret_ReturnsList(t *testing.T) {
+	devices := []device.Device{
+		newTestDevice("fingerprint-aaa111"),
+		newTestDevice("fingerprint-bbb222"),
+	}
+
+	repo := &mockLister{
+		ListFn: func(_ context.Context) ([]device.Device, error) {
+			return devices, nil
+		},
+	}
+
+	secret := "test-secret-123"
+	router := adminRouter(repo, secret)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/devices", nil)
+	req.Header.Set("X-Internal-Token", secret)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var body struct {
+		Devices []device.Device `json:"devices"`
+		Count   int             `json:"count"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Count != 2 {
+		t.Errorf("count = %d, want 2", body.Count)
+	}
+	if len(body.Devices) != 2 {
+		t.Fatalf("devices length = %d, want 2", len(body.Devices))
+	}
+	if body.Devices[0].Fingerprint != "fingerprint-aaa111" {
+		t.Errorf("first device fingerprint = %q, want %q", body.Devices[0].Fingerprint, "fingerprint-aaa111")
+	}
+	if body.Devices[1].Fingerprint != "fingerprint-bbb222" {
+		t.Errorf("second device fingerprint = %q, want %q", body.Devices[1].Fingerprint, "fingerprint-bbb222")
+	}
+}
+
+func TestAdminDevices_EmptySecretConfig_NoAuth(t *testing.T) {
+	// When InternalSecret is empty, the handler should not enforce auth
+	// (used in dev mode).
+	repo := &mockLister{
+		ListFn: func(_ context.Context) ([]device.Device, error) {
+			return []device.Device{}, nil
+		},
+	}
+
+	router := adminRouter(repo, "")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/devices", nil)
+	// No auth header needed when secret is empty.
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var body struct {
+		Devices []device.Device `json:"devices"`
+		Count   int             `json:"count"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Count != 0 {
+		t.Errorf("count = %d, want 0", body.Count)
+	}
+}
+
+func TestAdminDevices_ListError_Returns500(t *testing.T) {
+	repo := &mockLister{
+		ListFn: func(_ context.Context) ([]device.Device, error) {
+			return nil, fmt.Errorf("database connection lost")
+		},
+	}
+
+	secret := "test-secret"
+	router := adminRouter(repo, secret)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/devices", nil)
+	req.Header.Set("X-Internal-Token", secret)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
+	}
+}
+
+// --- DeviceIdentify tests ---
+
+func TestDeviceIdentify_WithAlias_UpdatesDevice(t *testing.T) {
+	fingerprint := "abc123def456"
+	var capturedFingerprint, capturedAlias string
+
+	upserter := &mockUpserter{
+		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
+			return &device.Device{Fingerprint: fp, Role: "user"}, nil
+		},
+	}
+
+	setter := &mockAliasSetter{
+		SetAliasFn: func(_ context.Context, fp, alias string) error {
+			capturedFingerprint = fp
+			capturedAlias = alias
+			return nil
+		},
+	}
+
+	router := identifyRouter(upserter, setter)
+
+	body := `{"alias":"Seb's PC"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/device/identify", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Device-ID", fingerprint)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	if capturedFingerprint != fingerprint {
+		t.Errorf("SetAlias fingerprint = %q, want %q", capturedFingerprint, fingerprint)
+	}
+	if capturedAlias != "Seb's PC" {
+		t.Errorf("SetAlias alias = %q, want %q", capturedAlias, "Seb's PC")
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["status"] != "identified" {
+		t.Errorf("status = %q, want %q", resp["status"], "identified")
+	}
+	if resp["fingerprint"] != fingerprint {
+		t.Errorf("fingerprint = %q, want %q", resp["fingerprint"], fingerprint)
+	}
+	if resp["alias"] != "Seb's PC" {
+		t.Errorf("alias = %q, want %q", resp["alias"], "Seb's PC")
+	}
+}
+
+func TestDeviceIdentify_WithoutDeviceID_Returns400(t *testing.T) {
+	// When no X-Device-ID header is sent, the middleware does not set a device
+	// in context, so the handler returns 400.
+	upserter := &mockUpserter{
+		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
+			return &device.Device{Fingerprint: fp, Role: "user"}, nil
+		},
+	}
+
+	setter := &mockAliasSetter{
+		SetAliasFn: func(_ context.Context, _, _ string) error {
+			t.Error("SetAlias should not be called when device is missing from context")
+			return nil
+		},
+	}
+
+	router := identifyRouter(upserter, setter)
+
+	body := `{"alias":"My PC"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/device/identify", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	// No X-Device-ID header.
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["error"] != "X-Device-ID header required" {
+		t.Errorf("error = %q, want %q", resp["error"], "X-Device-ID header required")
+	}
+}
+
+func TestDeviceIdentify_EmptyAlias_Returns400(t *testing.T) {
+	fingerprint := "abc123def456"
+	upserter := &mockUpserter{
+		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
+			return &device.Device{Fingerprint: fp, Role: "user"}, nil
+		},
+	}
+
+	setter := &mockAliasSetter{
+		SetAliasFn: func(_ context.Context, _, _ string) error {
+			t.Error("SetAlias should not be called with empty alias")
+			return nil
+		},
+	}
+
+	router := identifyRouter(upserter, setter)
+
+	body := `{"alias":""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/device/identify", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Device-ID", fingerprint)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["error"] != "alias is required" {
+		t.Errorf("error = %q, want %q", resp["error"], "alias is required")
+	}
+}
+
+func TestDeviceIdentify_AliasTooLong_Returns400(t *testing.T) {
+	fingerprint := "abc123def456"
+	upserter := &mockUpserter{
+		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
+			return &device.Device{Fingerprint: fp, Role: "user"}, nil
+		},
+	}
+
+	setter := &mockAliasSetter{
+		SetAliasFn: func(_ context.Context, _, _ string) error {
+			t.Error("SetAlias should not be called with too-long alias")
+			return nil
+		},
+	}
+
+	router := identifyRouter(upserter, setter)
+
+	longAlias := strings.Repeat("a", 65) // 65 chars > 64 max
+	body := fmt.Sprintf(`{"alias":"%s"}`, longAlias)
+	req := httptest.NewRequest(http.MethodPost, "/api/device/identify", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Device-ID", fingerprint)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["error"] != "alias too long (max 64 characters)" {
+		t.Errorf("error = %q, want %q", resp["error"], "alias too long (max 64 characters)")
+	}
+}
+
+func TestDeviceIdentify_MaxLengthAlias_Accepted(t *testing.T) {
+	fingerprint := "abc123def456"
+	upserter := &mockUpserter{
+		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
+			return &device.Device{Fingerprint: fp, Role: "user"}, nil
+		},
+	}
+
+	setter := &mockAliasSetter{
+		SetAliasFn: func(_ context.Context, _, _ string) error {
+			return nil
+		},
+	}
+
+	router := identifyRouter(upserter, setter)
+
+	maxAlias := strings.Repeat("a", 64) // exactly 64 chars — should be accepted
+	body := fmt.Sprintf(`{"alias":"%s"}`, maxAlias)
+	req := httptest.NewRequest(http.MethodPost, "/api/device/identify", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Device-ID", fingerprint)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+}
+
+func TestDeviceIdentify_InvalidJSON_Returns400(t *testing.T) {
+	fingerprint := "abc123def456"
+	upserter := &mockUpserter{
+		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
+			return &device.Device{Fingerprint: fp, Role: "user"}, nil
+		},
+	}
+
+	setter := &mockAliasSetter{
+		SetAliasFn: func(_ context.Context, _, _ string) error {
+			t.Error("SetAlias should not be called with invalid JSON")
+			return nil
+		},
+	}
+
+	router := identifyRouter(upserter, setter)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"malformed JSON", `{not json`},
+		{"empty body", ``},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/device/identify", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Device-ID", fingerprint)
+			w := httptest.NewRecorder()
+
+			router.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+			}
+
+			var resp map[string]string
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if resp["error"] != "invalid JSON body" {
+				t.Errorf("error = %q, want %q", resp["error"], "invalid JSON body")
+			}
+		})
+	}
+}
+
+func TestDeviceIdentify_SetAliasError_Returns500(t *testing.T) {
+	fingerprint := "abc123def456"
+	upserter := &mockUpserter{
+		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
+			return &device.Device{Fingerprint: fp, Role: "user"}, nil
+		},
+	}
+
+	setter := &mockAliasSetter{
+		SetAliasFn: func(_ context.Context, _, _ string) error {
+			return fmt.Errorf("database timeout")
+		},
+	}
+
+	router := identifyRouter(upserter, setter)
+
+	body := `{"alias":"My PC"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/device/identify", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Device-ID", fingerprint)
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusInternalServerError, w.Body.String())
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["error"] != "failed to update alias" {
+		t.Errorf("error = %q, want %q", resp["error"], "failed to update alias")
+	}
+}

--- a/internal/server/handlers/device_test.go
+++ b/internal/server/handlers/device_test.go
@@ -231,7 +231,7 @@ func TestAdminDevices_ListError_Returns500(t *testing.T) {
 // --- DeviceIdentify tests ---
 
 func TestDeviceIdentify_WithAlias_UpdatesDevice(t *testing.T) {
-	fingerprint := "abc123def456"
+	fingerprint := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
 	var capturedFingerprint, capturedAlias string
 
 	upserter := &mockUpserter{
@@ -324,7 +324,7 @@ func TestDeviceIdentify_WithoutDeviceID_Returns400(t *testing.T) {
 }
 
 func TestDeviceIdentify_EmptyAlias_Returns400(t *testing.T) {
-	fingerprint := "abc123def456"
+	fingerprint := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
 	upserter := &mockUpserter{
 		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
 			return &device.Device{Fingerprint: fp, Role: "user"}, nil
@@ -362,7 +362,7 @@ func TestDeviceIdentify_EmptyAlias_Returns400(t *testing.T) {
 }
 
 func TestDeviceIdentify_AliasTooLong_Returns400(t *testing.T) {
-	fingerprint := "abc123def456"
+	fingerprint := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
 	upserter := &mockUpserter{
 		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
 			return &device.Device{Fingerprint: fp, Role: "user"}, nil
@@ -401,7 +401,7 @@ func TestDeviceIdentify_AliasTooLong_Returns400(t *testing.T) {
 }
 
 func TestDeviceIdentify_MaxLengthAlias_Accepted(t *testing.T) {
-	fingerprint := "abc123def456"
+	fingerprint := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
 	upserter := &mockUpserter{
 		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
 			return &device.Device{Fingerprint: fp, Role: "user"}, nil
@@ -436,7 +436,7 @@ func TestDeviceIdentify_MaxLengthAlias_Accepted(t *testing.T) {
 }
 
 func TestDeviceIdentify_InvalidJSON_Returns400(t *testing.T) {
-	fingerprint := "abc123def456"
+	fingerprint := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
 
 	tests := []struct {
 		name string
@@ -486,7 +486,7 @@ func TestDeviceIdentify_InvalidJSON_Returns400(t *testing.T) {
 }
 
 func TestDeviceIdentify_SetAliasError_Returns500(t *testing.T) {
-	fingerprint := "abc123def456"
+	fingerprint := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
 	upserter := &mockUpserter{
 		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
 			return &device.Device{Fingerprint: fp, Role: "user"}, nil

--- a/internal/server/middleware/device.go
+++ b/internal/server/middleware/device.go
@@ -23,7 +23,7 @@ func DeviceFromContext(ctx context.Context) *device.Device {
 // ID is present it upserts the device record (auto-registration), attaches it
 // to the request context, and enforces bans. Requests without X-Device-ID pass
 // through untracked.
-func DeviceMiddleware(repo *device.Repository) func(http.Handler) http.Handler {
+func DeviceMiddleware(repo device.Upserter) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fingerprint := r.Header.Get("X-Device-ID")

--- a/internal/server/middleware/device.go
+++ b/internal/server/middleware/device.go
@@ -1,0 +1,59 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"profitofexile/internal/device"
+)
+
+// deviceCtxKey is the context key for the device record set by DeviceMiddleware.
+type deviceCtxKey struct{}
+
+// DeviceFromContext returns the *device.Device from the request context, or nil
+// if no device header was provided (web/curl requests).
+func DeviceFromContext(ctx context.Context) *device.Device {
+	d, _ := ctx.Value(deviceCtxKey{}).(*device.Device)
+	return d
+}
+
+// DeviceMiddleware reads X-Device-ID and X-App-Version headers. When a device
+// ID is present it upserts the device record (auto-registration), attaches it
+// to the request context, and enforces bans. Requests without X-Device-ID pass
+// through untracked.
+func DeviceMiddleware(repo *device.Repository) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fingerprint := r.Header.Get("X-Device-ID")
+			if fingerprint == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			appVersion := r.Header.Get("X-App-Version")
+
+			d, err := repo.Upsert(r.Context(), fingerprint, appVersion)
+			if err != nil {
+				slog.Error("device middleware: upsert failed",
+					"fingerprint", fingerprint,
+					"error", err,
+				)
+				// Fail open — don't block the request if the DB is having issues.
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if d.Banned {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusForbidden)
+				json.NewEncoder(w).Encode(map[string]string{"error": "device is banned"})
+				return
+			}
+
+			ctx := context.WithValue(r.Context(), deviceCtxKey{}, d)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/internal/server/middleware/device.go
+++ b/internal/server/middleware/device.go
@@ -9,6 +9,22 @@ import (
 	"profitofexile/internal/device"
 )
 
+// validFingerprint checks that the fingerprint is either a 64-char lowercase
+// hex string (SHA-256 from desktop app) or a 36-char UUID (fallback format).
+// Only lowercase hex digits and hyphens are accepted.
+func validFingerprint(fp string) bool {
+	n := len(fp)
+	if n != 36 && n != 64 {
+		return false
+	}
+	for _, c := range fp {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || c == '-') {
+			return false
+		}
+	}
+	return true
+}
+
 // deviceCtxKey is the context key for the device record set by DeviceMiddleware.
 type deviceCtxKey struct{}
 
@@ -32,6 +48,13 @@ func DeviceMiddleware(repo device.Upserter) func(http.Handler) http.Handler {
 				return
 			}
 
+			if !validFingerprint(fingerprint) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusBadRequest)
+				json.NewEncoder(w).Encode(map[string]string{"error": "invalid device fingerprint format"})
+				return
+			}
+
 			appVersion := r.Header.Get("X-App-Version")
 
 			d, err := repo.Upsert(r.Context(), fingerprint, appVersion)
@@ -40,7 +63,11 @@ func DeviceMiddleware(repo device.Upserter) func(http.Handler) http.Handler {
 					"fingerprint", fingerprint,
 					"error", err,
 				)
-				// Fail open — don't block the request if the DB is having issues.
+				// Fail open: pass the request through WITHOUT attaching a device to
+				// context. This means banned-device checks can't fire (no record to
+				// inspect), but any handler that requires a device (e.g. DeviceIdentify)
+				// will get "no device" and return 400. Acceptable tradeoff: a DB outage
+				// is temporary and a banned device may slip through for seconds.
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/internal/server/middleware/device_test.go
+++ b/internal/server/middleware/device_test.go
@@ -1,0 +1,280 @@
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"profitofexile/internal/device"
+)
+
+// mockUpserter implements device.Upserter for unit testing.
+type mockUpserter struct {
+	UpsertFn func(ctx context.Context, fingerprint, appVersion string) (*device.Device, error)
+}
+
+func (m *mockUpserter) Upsert(ctx context.Context, fingerprint, appVersion string) (*device.Device, error) {
+	return m.UpsertFn(ctx, fingerprint, appVersion)
+}
+
+// testDevice returns a non-banned device with the given fingerprint.
+func testDevice(fingerprint string) *device.Device {
+	return &device.Device{
+		Fingerprint: fingerprint,
+		Role:        "user",
+		Banned:      false,
+	}
+}
+
+// testBannedDevice returns a banned device with the given fingerprint.
+func testBannedDevice(fingerprint string) *device.Device {
+	return &device.Device{
+		Fingerprint: fingerprint,
+		Role:        "user",
+		Banned:      true,
+	}
+}
+
+func TestDeviceMiddleware_WithDeviceID(t *testing.T) {
+	fingerprint := "abc123def456"
+	appVersion := "0.3.1"
+
+	var capturedFingerprint, capturedVersion string
+	repo := &mockUpserter{
+		UpsertFn: func(_ context.Context, fp, av string) (*device.Device, error) {
+			capturedFingerprint = fp
+			capturedVersion = av
+			return testDevice(fp), nil
+		},
+	}
+
+	var ctxDevice *device.Device
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctxDevice = DeviceFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := DeviceMiddleware(repo)(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	req.Header.Set("X-Device-ID", fingerprint)
+	req.Header.Set("X-App-Version", appVersion)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// Verify Upsert was called with correct arguments.
+	if capturedFingerprint != fingerprint {
+		t.Errorf("upsert fingerprint = %q, want %q", capturedFingerprint, fingerprint)
+	}
+	if capturedVersion != appVersion {
+		t.Errorf("upsert appVersion = %q, want %q", capturedVersion, appVersion)
+	}
+
+	// Verify device was attached to context.
+	if ctxDevice == nil {
+		t.Fatal("expected device in context, got nil")
+	}
+	if ctxDevice.Fingerprint != fingerprint {
+		t.Errorf("context device fingerprint = %q, want %q", ctxDevice.Fingerprint, fingerprint)
+	}
+}
+
+func TestDeviceMiddleware_WithoutDeviceID(t *testing.T) {
+	upsertCalled := false
+	repo := &mockUpserter{
+		UpsertFn: func(_ context.Context, _, _ string) (*device.Device, error) {
+			upsertCalled = true
+			return testDevice("should-not-be-called"), nil
+		},
+	}
+
+	var ctxDevice *device.Device
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctxDevice = DeviceFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := DeviceMiddleware(repo)(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	// No X-Device-ID header set.
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	if upsertCalled {
+		t.Error("Upsert should not be called when X-Device-ID is absent")
+	}
+
+	if ctxDevice != nil {
+		t.Errorf("expected nil device in context, got %+v", ctxDevice)
+	}
+}
+
+func TestDeviceMiddleware_AppVersionStored(t *testing.T) {
+	tests := []struct {
+		name       string
+		appVersion string
+	}{
+		{"with version", "0.3.1"},
+		{"without version header", ""},
+		{"with long version", "1.2.3-beta.4+build.567"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedVersion string
+			repo := &mockUpserter{
+				UpsertFn: func(_ context.Context, fp, av string) (*device.Device, error) {
+					capturedVersion = av
+					return testDevice(fp), nil
+				},
+			}
+
+			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			handler := DeviceMiddleware(repo)(inner)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+			req.Header.Set("X-Device-ID", "test-fingerprint")
+			if tt.appVersion != "" {
+				req.Header.Set("X-App-Version", tt.appVersion)
+			}
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			if capturedVersion != tt.appVersion {
+				t.Errorf("upsert appVersion = %q, want %q", capturedVersion, tt.appVersion)
+			}
+		})
+	}
+}
+
+func TestDeviceMiddleware_BannedDevice(t *testing.T) {
+	repo := &mockUpserter{
+		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
+			return testBannedDevice(fp), nil
+		},
+	}
+
+	innerCalled := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := DeviceMiddleware(repo)(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	req.Header.Set("X-Device-ID", "banned-device-fp")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+
+	if innerCalled {
+		t.Error("inner handler should not be called for banned devices")
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body["error"] != "device is banned" {
+		t.Errorf("error = %q, want %q", body["error"], "device is banned")
+	}
+}
+
+func TestDeviceMiddleware_NonBannedDevice(t *testing.T) {
+	repo := &mockUpserter{
+		UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
+			return testDevice(fp), nil
+		},
+	}
+
+	innerCalled := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := DeviceMiddleware(repo)(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	req.Header.Set("X-Device-ID", "good-device-fp")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	if !innerCalled {
+		t.Error("inner handler should be called for non-banned devices")
+	}
+}
+
+func TestDeviceMiddleware_UpsertError_FailsOpen(t *testing.T) {
+	repo := &mockUpserter{
+		UpsertFn: func(_ context.Context, _, _ string) (*device.Device, error) {
+			return nil, fmt.Errorf("database connection refused")
+		},
+	}
+
+	innerCalled := false
+	var ctxDevice *device.Device
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerCalled = true
+		ctxDevice = DeviceFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := DeviceMiddleware(repo)(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+	req.Header.Set("X-Device-ID", "some-fingerprint")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	// Middleware fails open — request passes through even when upsert fails.
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (fail-open)", w.Code, http.StatusOK)
+	}
+
+	if !innerCalled {
+		t.Error("inner handler should be called even when upsert fails (fail-open)")
+	}
+
+	// No device should be in context since upsert failed.
+	if ctxDevice != nil {
+		t.Errorf("expected nil device in context after upsert error, got %+v", ctxDevice)
+	}
+}
+
+func TestDeviceFromContext_NilWhenMissing(t *testing.T) {
+	ctx := context.Background()
+	d := DeviceFromContext(ctx)
+	if d != nil {
+		t.Errorf("expected nil from empty context, got %+v", d)
+	}
+}

--- a/internal/server/middleware/device_test.go
+++ b/internal/server/middleware/device_test.go
@@ -38,8 +38,97 @@ func testBannedDevice(fingerprint string) *device.Device {
 	}
 }
 
+func TestDeviceMiddleware_InvalidFingerprint_Returns400(t *testing.T) {
+	upsertCalled := false
+	repo := &mockUpserter{
+		UpsertFn: func(_ context.Context, _, _ string) (*device.Device, error) {
+			upsertCalled = true
+			return testDevice("x"), nil
+		},
+	}
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("inner handler should not be called for invalid fingerprint")
+	})
+
+	handler := DeviceMiddleware(repo)(inner)
+
+	tests := []struct {
+		name        string
+		fingerprint string
+	}{
+		{"too short", "abc123"},
+		{"too long", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, // 67 chars
+		{"wrong length between 36 and 64", "aabbccddeeff00112233445566778899aabbccddeeff"}, // 44 chars
+		{"uppercase hex", "AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00112233445566778899AA"}, // 64 uppercase
+		{"special characters", "abc!@#$%^&*()_+abc!@#$%^&*()_+abcabc"},                        // 37 chars with specials
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+			req.Header.Set("X-Device-ID", tt.fingerprint)
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+			}
+
+			var body map[string]string
+			if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if body["error"] != "invalid device fingerprint format" {
+				t.Errorf("error = %q, want %q", body["error"], "invalid device fingerprint format")
+			}
+		})
+	}
+
+	if upsertCalled {
+		t.Error("Upsert should not be called for invalid fingerprints")
+	}
+}
+
+func TestDeviceMiddleware_ValidFingerprints(t *testing.T) {
+	tests := []struct {
+		name        string
+		fingerprint string
+	}{
+		{"64-char hex (SHA-256)", "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"},
+		{"36-char UUID", "550e8400-e29b-41d4-a716-446655440000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &mockUpserter{
+				UpsertFn: func(_ context.Context, fp, _ string) (*device.Device, error) {
+					return testDevice(fp), nil
+				},
+			}
+
+			inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			handler := DeviceMiddleware(repo)(inner)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
+			req.Header.Set("X-Device-ID", tt.fingerprint)
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+			}
+		})
+	}
+}
+
 func TestDeviceMiddleware_WithDeviceID(t *testing.T) {
-	fingerprint := "abc123def456"
+	fingerprint := "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
 	appVersion := "0.3.1"
 
 	var capturedFingerprint, capturedVersion string
@@ -150,7 +239,7 @@ func TestDeviceMiddleware_AppVersionStored(t *testing.T) {
 			handler := DeviceMiddleware(repo)(inner)
 
 			req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
-			req.Header.Set("X-Device-ID", "test-fingerprint")
+			req.Header.Set("X-Device-ID", "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899")
 			if tt.appVersion != "" {
 				req.Header.Set("X-App-Version", tt.appVersion)
 			}
@@ -181,7 +270,7 @@ func TestDeviceMiddleware_BannedDevice(t *testing.T) {
 	handler := DeviceMiddleware(repo)(inner)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
-	req.Header.Set("X-Device-ID", "banned-device-fp")
+	req.Header.Set("X-Device-ID", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
@@ -219,7 +308,7 @@ func TestDeviceMiddleware_NonBannedDevice(t *testing.T) {
 	handler := DeviceMiddleware(repo)(inner)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
-	req.Header.Set("X-Device-ID", "good-device-fp")
+	req.Header.Set("X-Device-ID", "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)
@@ -251,7 +340,7 @@ func TestDeviceMiddleware_UpsertError_FailsOpen(t *testing.T) {
 	handler := DeviceMiddleware(repo)(inner)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/health", nil)
-	req.Header.Set("X-Device-ID", "some-fingerprint")
+	req.Header.Set("X-Device-ID", "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
 	w := httptest.NewRecorder()
 
 	handler.ServeHTTP(w, req)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,9 +10,11 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/jackc/pgx/v5/pgxpool"
 
+	"profitofexile/internal/device"
 	"profitofexile/internal/lab"
 	"profitofexile/internal/mercure"
 	"profitofexile/internal/server/handlers"
+	devmw "profitofexile/internal/server/middleware"
 	"profitofexile/internal/trade"
 )
 
@@ -54,6 +56,9 @@ type RouterConfig struct {
 	// AllowedOrigins for CORS (desktop app needs cross-origin access).
 	// Example: ["http://localhost:1420", "tauri://localhost"]
 	AllowedOrigins []string
+	// DeviceRepo is the device repository for fingerprint-based identity.
+	// May be nil — device middleware is skipped when nil.
+	DeviceRepo *device.Repository
 }
 
 // NewRouter creates a chi router with middleware and mounted routes.
@@ -70,10 +75,14 @@ func NewRouter(pinger handlers.Pinger, frontendFS fs.FS, cfg RouterConfig) http.
 		r.Use(cors.Handler(cors.Options{
 			AllowedOrigins:   cfg.AllowedOrigins,
 			AllowedMethods:   []string{"GET", "POST", "PATCH", "OPTIONS"},
-			AllowedHeaders:   []string{"Content-Type", "Authorization"},
+			AllowedHeaders:   []string{"Content-Type", "Authorization", "X-Device-ID", "X-App-Version"},
 			AllowCredentials: false,
 			MaxAge:           300,
 		}))
+	}
+
+	if cfg.DeviceRepo != nil {
+		r.Use(devmw.DeviceMiddleware(cfg.DeviceRepo))
 	}
 
 	r.Get("/api/health", handlers.Health(pinger))
@@ -108,6 +117,11 @@ func NewRouter(pinger handlers.Pinger, frontendFS fs.FS, cfg RouterConfig) http.
 		if cfg.Analyzer != nil {
 			r.Post("/api/internal/recalculate", handlers.AdminRecalculate(cfg.Analyzer, cfg.InternalSecret))
 		}
+	}
+
+	if cfg.DeviceRepo != nil {
+		r.Get("/api/admin/devices", handlers.AdminDevices(cfg.DeviceRepo, cfg.InternalSecret))
+		r.Post("/api/device/identify", handlers.DeviceIdentify(cfg.DeviceRepo))
 	}
 
 	if cfg.TradeGate != nil {


### PR DESCRIPTION
## Summary
- Device fingerprint computed from hardware (SHA-256 of machineGUID + cpuID + mobo serial + build-time secret)
- Recomputed every launch (tamper-proof), WMI failure fallback to random UUID
- Server middleware: auto-registers new devices, upserts last_seen + app_version on every request
- Ban enforcement: banned devices get 403
- Identify dialog (Ctrl+Shift+I): set alias, share prefix with admin for promotion
- Promote CLI: list identified devices, promote to user/editor/admin, stats subcommand
- X-Device-ID + X-App-Version headers on all desktop→server requests (Rust + SvelteKit)
- Admin device list endpoint (InternalSecret-protected)
- CI: APP_FINGERPRINT_SECRET wired into desktop build workflow

## Tracker
https://softsolution.youtrack.cloud/issue/POE-102

## Test Plan
- [ ] All Go tests pass (`make qa`)
- [ ] Desktop builds locally (`make desktop-dev`)
- [ ] Launch app → fingerprint computed (check logs)
- [ ] Ctrl+Shift+I → shows device ID prefix, set alias
- [ ] DB: `SELECT * FROM devices` shows registered device
- [ ] `/promote list` shows identified device
- [ ] `/promote stats` shows active user counts
- [ ] `/promote <prefix> editor` promotes device
- [ ] Web frontend works without X-Device-ID (no regression)
- [ ] Add `APP_FINGERPRINT_SECRET` to GitHub Secrets before desktop release

Generated with [Claude Code](https://claude.com/claude-code)