### PR TITLE
POE-65: Dedication Lab — Corrupted Gem Exchange Analysis

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -281,6 +281,10 @@ func main() {
 		if err := analyzer.RunFont(ctx); err != nil {
 			slog.Warn("startup font analysis failed (non-fatal)", "error", err)
 		}
+		// Dedication runs after V2 for risk-adjustment features.
+		if err := analyzer.RunDedication(ctx); err != nil {
+			slog.Warn("startup dedication analysis failed (non-fatal)", "error", err)
+		}
 	}()
 	go func() {
 		defer func() {
@@ -423,6 +427,10 @@ func main() {
 					// Font runs after V2 so it reads fresh GemFeatures with current tier classification.
 					if err := analyzer.RunFont(subCtx); err != nil {
 						slog.Warn("font analysis failed", "error", err)
+					}
+					// Dedication runs after V2 for risk-adjustment features.
+					if err := analyzer.RunDedication(subCtx); err != nil {
+						slog.Warn("dedication analysis failed", "error", err)
 					}
 				}()
 

--- a/desktop/src-tauri/src/font_parser.rs
+++ b/desktop/src-tauri/src/font_parser.rs
@@ -137,6 +137,7 @@ pub fn parse_font_panel(lines: &[String]) -> FontPanelState {
 
     // Dedication: corrupted transfigured reroll
     if full_lower.contains("corrupted transfigured") {
+        font_active = true;
         options.push(CraftOption {
             option_type: "corrupted_transfigured_reroll".to_string(),
             text: find_line_containing(lines, "Corrupted Transfigured").unwrap_or_default(),
@@ -144,13 +145,28 @@ pub fn parse_font_panel(lines: &[String]) -> FontPanelState {
         });
     }
 
-    // Dedication: corrupted skill gem reroll
-    if full_lower.contains("corrupted skill gem") && !full_lower.contains("transfigured") {
-        options.push(CraftOption {
-            option_type: "corrupted_gem_reroll".to_string(),
-            text: find_line_containing(lines, "Corrupted Skill Gem").unwrap_or_default(),
-            value: None,
+    // Dedication: corrupted skill gem reroll (non-transfigured pool).
+    // Check line-by-line: match lines containing "corrupted skill gem" but NOT "transfigured",
+    // so it works even when the transfigured option is present in the same panel.
+    {
+        let has_non_transfig_reroll = lines.iter().any(|line| {
+            let lower = line.to_lowercase();
+            lower.contains("corrupted skill gem") && !lower.contains("transfigured")
         });
+        if has_non_transfig_reroll {
+            font_active = true;
+            options.push(CraftOption {
+                option_type: "corrupted_gem_reroll".to_string(),
+                text: lines.iter()
+                    .find(|l| {
+                        let lower = l.to_lowercase();
+                        lower.contains("corrupted skill gem") && !lower.contains("transfigured")
+                    })
+                    .cloned()
+                    .unwrap_or_default(),
+                value: None,
+            });
+        }
     }
 
     // Crafts Remaining: N
@@ -414,6 +430,52 @@ mod tests {
         assert!(state.font_active);
         assert_eq!(state.options.len(), 4);
         assert_eq!(state.crafts_remaining, Some(6));
+    }
+
+    #[test]
+    fn detects_corrupted_gem_reroll() {
+        let lines = vec![
+            "Transform a Corrupted Skill Gem into a".to_string(),
+            "random Corrupted Skill Gem of the same colour".to_string(),
+        ];
+        let state = parse_font_panel(&lines);
+        assert!(state.font_active);
+        assert_eq!(state.options.len(), 1);
+        assert_eq!(state.options[0].option_type, "corrupted_gem_reroll");
+    }
+
+    #[test]
+    fn detects_corrupted_transfigured_reroll() {
+        let lines = vec![
+            "Transform a Corrupted Transfigured Skill Gem".to_string(),
+            "into a random Corrupted Transfigured Skill Gem".to_string(),
+            "of the same colour".to_string(),
+        ];
+        let state = parse_font_panel(&lines);
+        assert!(state.font_active);
+        assert_eq!(state.options.len(), 1);
+        assert_eq!(state.options[0].option_type, "corrupted_transfigured_reroll");
+    }
+
+    #[test]
+    fn detects_both_dedication_options() {
+        // Both options can appear in the same Dedication font panel.
+        let lines = vec![
+            "Transform a Corrupted Skill Gem into a random".to_string(),
+            "Corrupted Skill Gem of the same colour".to_string(),
+            "Transform a Corrupted Transfigured Skill Gem".to_string(),
+            "into a random Corrupted Transfigured Skill Gem".to_string(),
+            "of the same colour".to_string(),
+            "Crafts Remaining: 3".to_string(),
+        ];
+        let state = parse_font_panel(&lines);
+        assert!(state.font_active);
+        assert_eq!(state.crafts_remaining, Some(3));
+        // Both options detected — line-level check prevents the "transfigured" guard
+        // from suppressing the non-transfigured option when both are present.
+        let types: Vec<&str> = state.options.iter().map(|o| o.option_type.as_str()).collect();
+        assert!(types.contains(&"corrupted_transfigured_reroll"));
+        assert!(types.contains(&"corrupted_gem_reroll"));
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1746,6 +1746,8 @@ async fn fetch_gem_names(app: &AppHandle, server_url: &str, client: &reqwest::Cl
                                     }
                                 }
                                 app_log(app, format!("Dedication gem names ({}): {} loaded", label, count));
+                            } else {
+                                app_log(app, format!("Dedication gem names ({}): response missing 'names' field", label));
                             }
                         }
                         Err(e) => {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,5 @@
 mod capture;
 mod fingerprint;
-#[allow(dead_code)] // Font panel OCR — not yet wired into the scan pipeline
 mod font_parser;
 mod gem_matcher;
 mod lab_navigation;
@@ -136,6 +135,9 @@ pub struct AppState {
     pub shrine_warn_corner: Mutex<String>,
     pub shrine_warn_on_take: Mutex<String>,
     pub lab_overlays_enabled: Mutex<bool>,
+    /// Lab mode: "Normal" or "Dedication". Controls OCR vocabulary, font session
+    /// metadata, and comparator behaviour. Persisted to settings.
+    pub lab_mode: Mutex<String>,
 }
 
 /// Build the full AppStatus from current state. Used by get_status command and event emitting.
@@ -1169,6 +1171,20 @@ fn set_lab_overlays_enabled(enabled: bool, app: AppHandle) {
 }
 
 #[tauri::command]
+fn get_lab_mode(app: AppHandle) -> String {
+    let state = app.state::<AppState>();
+    let val = state.lab_mode.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    val
+}
+
+#[tauri::command]
+fn set_lab_mode(mode: String, app: AppHandle) {
+    let state = app.state::<AppState>();
+    *state.lab_mode.lock().unwrap_or_else(|e| e.into_inner()) = mode;
+    persist_settings(&app);
+}
+
+#[tauri::command]
 fn get_logs(state: tauri::State<AppState>) -> Vec<String> {
     state.logs.lock().unwrap_or_else(|e| e.into_inner()).clone()
 }
@@ -1290,7 +1306,8 @@ async fn test_ocr_on_image(path: String, app: AppHandle) -> Result<String, Strin
 
     let server = state.server_url.lock().unwrap_or_else(|e| e.into_inner()).clone();
     let http = state.server_http.clone();
-    let gem_names = fetch_gem_names(&app, &server, &http).await;
+    let lab_mode = state.lab_mode.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    let gem_names = fetch_gem_names(&app, &server, &http, &lab_mode).await;
     let matcher = gem_matcher::GemMatcher::new(gem_names);
 
     let mut best_match: Option<gem_matcher::GemMatch> = None;
@@ -1341,7 +1358,8 @@ fn gem_scan_loop(app: AppHandle, generation: u64) {
     // Load gem names for matching — abort early if server unreachable.
     let server = state.server_url.lock().unwrap_or_else(|e| e.into_inner()).clone();
     let http = state.server_http.clone();
-    let gem_names = tauri::async_runtime::block_on(fetch_gem_names(&app, &server, &http));
+    let lab_mode = state.lab_mode.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    let gem_names = tauri::async_runtime::block_on(fetch_gem_names(&app, &server, &http, &lab_mode));
     if gem_names.is_empty() {
         app_log(&app, "Gem scan aborted — no gem names loaded (server unreachable?)".to_string());
         if state.gem_scan_generation.load(Ordering::SeqCst) == generation {
@@ -1647,13 +1665,21 @@ fn send_font_session_data(app: &AppHandle) {
 
     let pair = state.pair_code.lock().unwrap_or_else(|e| e.into_inner()).clone();
     let server = state.server_url.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    let lab_mode = state.lab_mode.lock().unwrap_or_else(|e| e.into_inner()).clone();
 
     let device_id = state.device_id.clone();
 
+    // Map lab mode to session metadata.
+    let (lab_type, variant) = if lab_mode == "Dedication" {
+        ("Dedication", "21/23")
+    } else {
+        ("Unknown", "20/20")
+    };
+
     let session_data = serde_json::json!({
-        "lab_type": "Unknown",
+        "lab_type": lab_type,
         "total_crafts": session.rounds.len(),
-        "variant": "20/20",
+        "variant": variant,
         "device_id": device_id,
         "pair_code": pair,
         "rounds": session.rounds.iter().map(|r| serde_json::json!({
@@ -1690,34 +1716,86 @@ fn send_font_session_data(app: &AppHandle) {
 }
 
 /// Fetch gem names from the server API for fuzzy matching.
-async fn fetch_gem_names(app: &AppHandle, server_url: &str, client: &reqwest::Client) -> Vec<String> {
-    let url = format!("{}/api/analysis/gems/names?q=of+&limit=500", server_url);
-    match client.get(&url).send().await {
-        Ok(res) if res.status().is_success() => {
-            match res.json::<serde_json::Value>().await {
-                Ok(body) => {
-                    if let Some(names) = body.get("names").and_then(|n| n.as_array()) {
-                        return names
-                            .iter()
-                            .filter_map(|n| n.as_str().map(String::from))
-                            .collect();
+///
+/// In Normal mode: fetches transfigured gem names (contain "of").
+/// In Dedication mode: fetches BOTH corrupted skill gem names AND corrupted
+/// transfigured gem names, merged into a single vocabulary for the matcher
+/// (both font options are available per run).
+async fn fetch_gem_names(app: &AppHandle, server_url: &str, client: &reqwest::Client, lab_mode: &str) -> Vec<String> {
+    if lab_mode == "Dedication" {
+        // Fetch both pools in parallel and merge.
+        let url_skills = format!("{}/api/analysis/gems/names?q=+&limit=500&corrupted=true&transfigured=false", server_url);
+        let url_transfig = format!("{}/api/analysis/gems/names?q=+&limit=500&corrupted=true&transfigured=true", server_url);
+
+        let (skills_res, transfig_res) = tokio::join!(
+            client.get(&url_skills).send(),
+            client.get(&url_transfig).send(),
+        );
+
+        let mut all_names = Vec::new();
+        for (label, res) in [("skills", skills_res), ("transfigured", transfig_res)] {
+            match res {
+                Ok(resp) if resp.status().is_success() => {
+                    match resp.json::<serde_json::Value>().await {
+                        Ok(body) => {
+                            if let Some(names) = body.get("names").and_then(|n| n.as_array()) {
+                                let count = names.len();
+                                for n in names {
+                                    if let Some(s) = n.as_str() {
+                                        all_names.push(s.to_string());
+                                    }
+                                }
+                                app_log(app, format!("Dedication gem names ({}): {} loaded", label, count));
+                            }
+                        }
+                        Err(e) => {
+                            app_log(app, format!("Dedication gem names ({}): parse failed: {}", label, e));
+                        }
                     }
-                    app_log(app, "Gem names: response missing 'names' field".to_string());
-                    Vec::new()
+                }
+                Ok(resp) => {
+                    app_log(app, format!("Dedication gem names ({}): server returned {}", label, resp.status()));
                 }
                 Err(e) => {
-                    app_log(app, format!("Gem names: failed to parse response: {}", e));
-                    Vec::new()
+                    app_log(app, format!("Dedication gem names ({}): request failed: {}", label, e));
                 }
             }
         }
-        Ok(res) => {
-            app_log(app, format!("Gem names: server returned {}", res.status()));
-            Vec::new()
-        }
-        Err(e) => {
-            app_log(app, format!("Gem names: request failed: {}", e));
-            Vec::new()
+
+        // Deduplicate (transfigured names are a subset of all corrupted gems).
+        all_names.sort();
+        all_names.dedup();
+        all_names
+    } else {
+        // Normal mode: transfigured gem names only.
+        let url = format!("{}/api/analysis/gems/names?q=of+&limit=500", server_url);
+        match client.get(&url).send().await {
+            Ok(res) if res.status().is_success() => {
+                match res.json::<serde_json::Value>().await {
+                    Ok(body) => {
+                        if let Some(names) = body.get("names").and_then(|n| n.as_array()) {
+                            return names
+                                .iter()
+                                .filter_map(|n| n.as_str().map(String::from))
+                                .collect();
+                        }
+                        app_log(app, "Gem names: response missing 'names' field".to_string());
+                        Vec::new()
+                    }
+                    Err(e) => {
+                        app_log(app, format!("Gem names: failed to parse response: {}", e));
+                        Vec::new()
+                    }
+                }
+            }
+            Ok(res) => {
+                app_log(app, format!("Gem names: server returned {}", res.status()));
+                Vec::new()
+            }
+            Err(e) => {
+                app_log(app, format!("Gem names: request failed: {}", e));
+                Vec::new()
+            }
         }
     }
 }
@@ -2166,6 +2244,7 @@ pub fn run() {
         shrine_warn_corner: Mutex::new(String::from("bottom-right")),
         shrine_warn_on_take: Mutex::new(String::from("green")),
         lab_overlays_enabled: Mutex::new(true),
+        lab_mode: Mutex::new(String::from("Normal")),
     };
 
     tauri::Builder::default()
@@ -2227,6 +2306,8 @@ pub fn run() {
             set_compass_strategy,
             set_compass_difficulty,
             set_shrine_warn,
+            get_lab_mode,
+            set_lab_mode,
         ])
         .setup(|app| {
             let handle = app.handle().clone();

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -647,22 +647,25 @@ fn trade_cancel(app: AppHandle) {
 /// Direct trade API lookup against GGG from the desktop app.
 /// Each user has their own IP → own rate limits (no shared server bottleneck).
 /// Accepts optional divine rate for chaos normalization of divine-priced listings.
+/// When mode is "dedication", the query targets corrupted 21/23 skill gems.
 #[tauri::command]
 async fn trade_lookup(
     gem: String,
     variant: String,
     divine_rate: Option<f64>,
+    mode: Option<String>,
     app: AppHandle,
 ) -> Result<trade::TradeLookupResult, String> {
     let state = app.state::<AppState>();
     let rate = divine_rate.unwrap_or(0.0);
+    let dedication = mode.as_deref() == Some("dedication");
     if rate <= 0.0 {
         log::warn!("Trade lookup: divine_rate is 0 — divine-priced listings will NOT be normalized to chaos");
     }
-    app_log(&app, format!("Trade lookup: {} ({}) divine_rate={:.0}", gem, variant, rate));
+    app_log(&app, format!("Trade lookup: {} ({}) divine_rate={:.0} dedication={}", gem, variant, rate, dedication));
 
     let app_for_emit = app.clone();
-    let result = state.trade_client.lookup_gem(&gem, &variant, rate, |event| {
+    let result = state.trade_client.lookup_gem_with_mode(&gem, &variant, rate, dedication, |event| {
         use tauri::Emitter;
         if let Err(e) = app_for_emit.emit("trade-queue", &event) {
             log::warn!("emit trade-queue failed: {}", e);

--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -46,6 +46,14 @@ pub struct Settings {
     pub timer_bg_opacity: Option<f32>,
     /// Timer overlay text stroke/outline enabled (default true).
     pub timer_text_stroke: Option<bool>,
+    /// Lab mode: "Normal" (default) or "Dedication".
+    /// Controls OCR vocabulary, font session metadata, and comparator behaviour.
+    #[serde(default = "default_lab_mode")]
+    pub lab_mode: String,
+}
+
+fn default_lab_mode() -> String {
+    "Normal".to_string()
 }
 
 pub const DEFAULT_TRADE_STALE_WARN_SECS: u32 = 120;
@@ -97,6 +105,7 @@ impl Default for Settings {
             shrine_warn_on_take: String::from("green"),
             timer_bg_opacity: None,
             timer_text_stroke: None,
+            lab_mode: default_lab_mode(),
         }
     }
 }
@@ -196,6 +205,7 @@ pub fn from_state(state: &crate::AppState) -> Settings {
         shrine_warn_on_take: state.shrine_warn_on_take.lock().unwrap_or_else(|e| e.into_inner()).clone(),
         timer_bg_opacity: None,    // Appearance settings saved separately, not from AppState
         timer_text_stroke: None,   // Appearance settings saved separately, not from AppState
+        lab_mode: state.lab_mode.lock().unwrap_or_else(|e| e.into_inner()).clone(),
     }
 }
 
@@ -305,4 +315,5 @@ pub fn apply_to_state(settings: &Settings, state: &crate::AppState) {
     *state.shrine_warn_corner.lock().unwrap_or_else(|e| e.into_inner()) = settings.shrine_warn_corner.clone();
     *state.shrine_warn_on_take.lock().unwrap_or_else(|e| e.into_inner()) = settings.shrine_warn_on_take.clone();
     *state.lab_overlays_enabled.lock().unwrap_or_else(|e| e.into_inner()) = settings.lab_overlays_enabled;
+    *state.lab_mode.lock().unwrap_or_else(|e| e.into_inner()) = settings.lab_mode.clone();
 }

--- a/desktop/src-tauri/src/trade/client.rs
+++ b/desktop/src-tauri/src/trade/client.rs
@@ -14,7 +14,6 @@ use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
-use super::query::build_search_query;
 use super::rate_limiter::TradeRateLimiter;
 use super::signals::build_result;
 use super::types::{SearchResponse, TradeListingDetail, TradeLookupResult};
@@ -169,6 +168,17 @@ impl TradeApiClient {
         divine_chaos_rate: f64,
         emit: impl Fn(TradeQueueEvent),
     ) -> Result<TradeLookupResult, String> {
+        self.lookup_gem_with_mode(gem_name, variant, divine_chaos_rate, false, emit).await
+    }
+
+    pub async fn lookup_gem_with_mode(
+        &self,
+        gem_name: &str,
+        variant: &str,
+        divine_chaos_rate: f64,
+        dedication: bool,
+        emit: impl Fn(TradeQueueEvent),
+    ) -> Result<TradeLookupResult, String> {
         let pending = self.pending_count.fetch_add(1, Ordering::SeqCst) + 1;
         self.enqueued.fetch_add(1, Ordering::SeqCst);
         let position = pending - self.completed.load(Ordering::SeqCst);
@@ -217,7 +227,7 @@ impl TradeApiClient {
             total: current_pending,
         });
 
-        let search_result = self.execute_search(gem_name, variant).await;
+        let search_result = self.execute_search_with_mode(gem_name, variant, dedication).await;
         let search_response = match search_result {
             Ok(r) => r,
             Err(e) => {
@@ -310,12 +320,13 @@ impl TradeApiClient {
     }
 
     /// POST /api/trade/search/{league}
-    async fn execute_search(
+    async fn execute_search_with_mode(
         &self,
         gem_name: &str,
         variant: &str,
+        dedication: bool,
     ) -> Result<SearchResponse, String> {
-        let query_body = build_search_query(gem_name, variant);
+        let query_body = super::query::build_search_query_with_mode(gem_name, variant, dedication);
         let url = format!(
             "{}/api/trade/search/{}",
             TRADE_API_BASE_URL, self.league_name

--- a/desktop/src-tauri/src/trade/query.rs
+++ b/desktop/src-tauri/src/trade/query.rs
@@ -2,21 +2,40 @@
 ///
 /// Mirrors Go's buildSearchQuery in client.go. See that file for detailed
 /// field reference (type vs term, securable, collapse, etc.).
+///
+/// When `dedication` is true, the query targets corrupted 21/23 gems:
+/// - Removes `corrupted: false` (21/23 implies corrupted)
+/// - Sets `gem_level: min 21`, `quality: min 23`
+/// - Uses `gem.activegem` category (skills only, no supports)
 pub fn build_search_query(gem: &str, variant: &str) -> serde_json::Value {
+    build_search_query_with_mode(gem, variant, false)
+}
+
+pub fn build_search_query_with_mode(gem: &str, variant: &str, dedication: bool) -> serde_json::Value {
     let (gem_level, gem_quality) = parse_variant(variant);
 
-    let mut misc_filters = serde_json::json!({
-        "corrupted": {"option": "false"}
-    });
+    let misc_filters = if dedication {
+        // Dedication mode: no corrupted:false filter (21/23c are corrupted by definition),
+        // set min level 21 and min quality 23.
+        serde_json::json!({
+            "gem_level": {"min": 21},
+            "quality": {"min": 23}
+        })
+    } else {
+        let mut filters = serde_json::json!({
+            "corrupted": {"option": "false"}
+        });
 
-    // Level 20+ = exact filter (20/20 is a distinct market from 1/0)
-    if gem_level >= 20 {
-        misc_filters["gem_level"] = serde_json::json!({"min": gem_level, "max": gem_level});
-    }
-    // Quality 20 = exact 20%. Quality 0 = no filter (competes in full market).
-    if gem_quality == 20 {
-        misc_filters["quality"] = serde_json::json!({"min": 20, "max": 20});
-    }
+        // Level 20+ = exact filter (20/20 is a distinct market from 1/0)
+        if gem_level >= 20 {
+            filters["gem_level"] = serde_json::json!({"min": gem_level, "max": gem_level});
+        }
+        // Quality 20 = exact 20%. Quality 0 = no filter (competes in full market).
+        if gem_quality == 20 {
+            filters["quality"] = serde_json::json!({"min": 20, "max": 20});
+        }
+        filters
+    };
 
     // Transfigured gems (" of ") use "term" for fuzzy match.
     // Base gems use "type" for exact match (prevents cross-matching).
@@ -26,6 +45,9 @@ pub fn build_search_query(gem: &str, variant: &str) -> serde_json::Value {
         "type"
     };
 
+    // Dedication mode uses activegem category (skills only, excludes supports).
+    let category = if dedication { "gem.activegem" } else { "gem" };
+
     // Build query object, then insert gem name under the dynamic key.
     // serde_json::json! treats bare identifiers as literal string keys,
     // so we must insert the variable key separately.
@@ -34,7 +56,7 @@ pub fn build_search_query(gem: &str, variant: &str) -> serde_json::Value {
         "filters": {
             "type_filters": {
                 "filters": {
-                    "category": {"option": "gem"}
+                    "category": {"option": category}
                 }
             },
             "misc_filters": {
@@ -115,5 +137,41 @@ mod tests {
         let q = build_search_query("Empower Support", "1/0");
         let filters = &q["query"]["filters"]["misc_filters"]["filters"];
         assert!(filters.get("gem_level").is_none());
+    }
+
+    #[test]
+    fn dedication_query_no_corrupted_false() {
+        let q = build_search_query_with_mode("Earthquake of Fragility", "21/23", true);
+        let filters = &q["query"]["filters"]["misc_filters"]["filters"];
+        assert!(filters.get("corrupted").is_none(), "Dedication mode should not have corrupted:false");
+    }
+
+    #[test]
+    fn dedication_query_has_level_21_quality_23() {
+        let q = build_search_query_with_mode("Earthquake of Fragility", "21/23", true);
+        let filters = &q["query"]["filters"]["misc_filters"]["filters"];
+        assert_eq!(filters["gem_level"]["min"], 21);
+        assert_eq!(filters["quality"]["min"], 23);
+    }
+
+    #[test]
+    fn dedication_query_uses_activegem_category() {
+        let q = build_search_query_with_mode("Earthquake of Fragility", "21/23", true);
+        let category = &q["query"]["filters"]["type_filters"]["filters"]["category"]["option"];
+        assert_eq!(category, "gem.activegem");
+    }
+
+    #[test]
+    fn normal_query_uses_gem_category() {
+        let q = build_search_query("Earthquake of Fragility", "20/20");
+        let category = &q["query"]["filters"]["type_filters"]["filters"]["category"]["option"];
+        assert_eq!(category, "gem");
+    }
+
+    #[test]
+    fn dedication_query_base_gem_uses_type() {
+        let q = build_search_query_with_mode("Spark", "21/23", true);
+        assert!(q["query"]["type"].is_string());
+        assert!(q["query"].get("term").is_none());
     }
 }

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -423,19 +423,23 @@ export async function fetchMarketOverview(): Promise<MarketOverviewData> {
 	};
 }
 
-export async function fetchGemNames(query: string): Promise<string[]> {
+export async function fetchGemNames(query: string, mode?: string): Promise<string[]> {
 	if (query.length < 2) return [];
-	const resp = await get<{ names: string[] }>('/analysis/gems/names', {
-		q: query,
-		limit: '15',
-	});
+	const params: Record<string, string> = { q: query, limit: '15' };
+	if (mode === 'dedication') {
+		params.corrupted = 'true';
+	}
+	const resp = await get<{ names: string[] }>('/analysis/gems/names', params);
 	return resp.names || [];
 }
 
-export async function fetchCompare(gems: string[], variant: string, signal?: AbortSignal): Promise<CompareGem[]> {
+export async function fetchCompare(gems: string[], variant: string, signal?: AbortSignal, mode?: string): Promise<CompareGem[]> {
 	const url = new URL(`${getApiBase()}/analysis/compare`);
 	url.searchParams.set('gems', gems.join(','));
 	url.searchParams.set('variant', variant);
+	if (mode === 'dedication') {
+		url.searchParams.set('mode', 'dedication');
+	}
 	const resp = await fetch(url.toString(), { signal, headers: deviceHeaders() });
 	if (!resp.ok) {
 		throw new Error(`API /analysis/compare: ${resp.status} ${resp.statusText}`);

--- a/desktop/src/lib/pages/LabPage.svelte
+++ b/desktop/src/lib/pages/LabPage.svelte
@@ -27,6 +27,27 @@
 	type Tab = typeof TABS[number];
 	let activeTab = $state<Tab>('Session');
 
+	// --- Lab mode ---
+	const LAB_MODES = ['Normal', 'Dedication'] as const;
+	type LabMode = typeof LAB_MODES[number];
+	let labMode = $state<LabMode>('Normal');
+	let isDedication = $derived(labMode === 'Dedication');
+	let labModeForChild = $derived<'normal' | 'dedication'>(isDedication ? 'dedication' : 'normal');
+
+	// Load persisted lab mode from Rust on mount
+	$effect(() => {
+		invoke<string>('get_lab_mode').then((mode) => {
+			if (mode === 'Normal' || mode === 'Dedication') {
+				labMode = mode;
+			}
+		}).catch(e => console.warn('[LabPage] get_lab_mode failed:', e));
+	});
+
+	function handleLabModeChange(mode: LabMode) {
+		labMode = mode;
+		invoke('set_lab_mode', { mode }).catch(e => console.warn('[LabPage] set_lab_mode failed:', e));
+	}
+
 	let status = $state<StatusData | null>(null);
 	let bestPlays = $state<GemPlay[]>([]);
 	let marketOverview = $state<MarketOverviewData | null>(null);
@@ -233,13 +254,22 @@
 				</button>
 			{/each}
 		</div>
-		<div class="scan-controls">
-			<span class="scan-state" class:picking={store.status?.state === 'PickingGems'}>{store.status?.state || '...'}</span>
-			{#if store.status?.state === 'PickingGems'}
-				<button class="scan-btn scan-stop" onclick={() => invoke('stop_scanning').catch((e: any) => console.error('Stop scan failed:', e))}>Stop</button>
-			{:else}
-				<button class="scan-btn" onclick={() => invoke('start_scanning').catch((e: any) => console.error('Start scan failed:', e))}>Scan</button>
-			{/if}
+		<div class="bar-right">
+			<div class="lab-mode-selector">
+				{#each LAB_MODES as mode}
+					<button class="lab-mode-btn" class:active={labMode === mode} onclick={() => handleLabModeChange(mode)}>
+						{mode}
+					</button>
+				{/each}
+			</div>
+			<div class="scan-controls">
+				<span class="scan-state" class:picking={store.status?.state === 'PickingGems'}>{store.status?.state || '...'}</span>
+				{#if store.status?.state === 'PickingGems'}
+					<button class="scan-btn scan-stop" onclick={() => invoke('stop_scanning').catch((e: any) => console.error('Stop scan failed:', e))}>Stop</button>
+				{:else}
+					<button class="scan-btn" onclick={() => invoke('start_scanning').catch((e: any) => console.error('Start scan failed:', e))}>Scan</button>
+				{/if}
+			</div>
 		</div>
 	</div>
 
@@ -261,7 +291,10 @@
 		<!-- Comparator + SessionQueue always mounted (event listeners must stay active).
 		     Hidden via CSS when not on Session tab to avoid unmount/remount. -->
 		<div class:tab-hidden={activeTab !== 'Session'}>
-			<Comparator league={status?.league || ''} divineRate={status?.divinePrice || 0} onQueueGem={handleQueueGem} />
+			{#if isDedication}
+				<FontEVCompare {refreshKey} league={status?.league || ''} labMode="dedication" />
+			{/if}
+			<Comparator league={status?.league || ''} divineRate={status?.divinePrice || 0} onQueueGem={handleQueueGem} labMode={labModeForChild} />
 			<SessionQueue
 				queue={sessionQueue}
 				onRemove={handleRemoveFromQueue}
@@ -272,7 +305,7 @@
 		{#if activeTab === 'Rankings'}
 			<ByVariant allPlays={bestPlays} league={status?.league || ''} />
 		{:else if activeTab === 'Font EV'}
-			<FontEVCompare {refreshKey} league={status?.league || ''} />
+			<FontEVCompare {refreshKey} league={status?.league || ''} labMode={labModeForChild} />
 		{:else if activeTab === 'Market'}
 			{#if marketOverview}
 				<MarketOverview data={marketOverview} />
@@ -318,6 +351,37 @@
 	.tab.active {
 		color: var(--color-lab-text);
 		border-bottom-color: var(--color-lab-blue);
+	}
+	.bar-right {
+		display: flex;
+		align-items: center;
+		gap: 12px;
+	}
+	.lab-mode-selector {
+		display: flex;
+		gap: 0;
+		border: 1px solid var(--color-lab-border);
+		border-radius: 4px;
+		overflow: hidden;
+	}
+	.lab-mode-btn {
+		background: transparent;
+		border: none;
+		color: var(--color-lab-text-secondary);
+		padding: 4px 10px;
+		font-size: 0.6875rem;
+		font-weight: 600;
+		cursor: pointer;
+		font-family: inherit;
+		transition: background 0.15s, color 0.15s;
+	}
+	.lab-mode-btn:hover {
+		color: var(--color-lab-text);
+		background: rgba(255, 255, 255, 0.05);
+	}
+	.lab-mode-btn.active {
+		color: var(--color-lab-text);
+		background: rgba(99, 102, 241, 0.2);
 	}
 	.scan-controls {
 		display: flex;

--- a/desktop/src/routes/(app)/components/Comparator.svelte
+++ b/desktop/src/routes/(app)/components/Comparator.svelte
@@ -32,11 +32,15 @@
 		league = '',
 		divineRate = 0,
 		onQueueGem,
+		labMode = 'normal',
 	}: {
 		league?: string;
 		divineRate?: number;
 		onQueueGem?: (gem: string, variant: string, roi: number, tradeData: TradeLookupResult | null) => void;
+		labMode?: 'normal' | 'dedication';
 	} = $props();
+
+	let isDedication = $derived(labMode === 'dedication');
 
 	let selectedForQueue = $state<string | null>(null);
 
@@ -97,8 +101,21 @@
 		}).catch(e => console.warn('[comparator] push to overlay failed:', e));
 	});
 
-	const VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
-	const VARIANT_OPTIONS = VARIANTS.map((v) => ({ value: v, label: v }));
+	const NORMAL_VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
+	const DEDICATION_VARIANTS = ['21/23'];
+	let activeVariants = $derived(isDedication ? DEDICATION_VARIANTS : NORMAL_VARIANTS);
+	let VARIANT_OPTIONS = $derived(activeVariants.map((v) => ({ value: v, label: v })));
+
+	// Lock variant to 21/23 in dedication mode, restore to 20/20 in normal mode.
+	$effect(() => {
+		if (isDedication && variant !== '21/23') {
+			variant = '21/23';
+			loadResults();
+		} else if (!isDedication && variant === '21/23') {
+			variant = '20/20';
+			loadResults();
+		}
+	});
 
 	// Listen for gem-detected events from Rust OCR.
 	// Rust emits one gem at a time as a string. Accumulate up to 3, then auto-compare.
@@ -254,7 +271,7 @@
 		if (compareAbort) compareAbort.abort();
 		compareAbort = new AbortController();
 		try {
-			results = await fetchCompare(active, variant, compareAbort.signal);
+			results = await fetchCompare(active, variant, compareAbort.signal, isDedication ? 'dedication' : undefined);
 			// Populate tradeData from compare response (server-side cache enrichment)
 			for (const gem of results) {
 				if (gem.trade) {
@@ -283,6 +300,7 @@
 		try {
 			const result = await invoke<TradeLookupResult>('trade_lookup', {
 				gem, variant, divineRate: divineRate || undefined,
+				mode: isDedication ? 'dedication' : undefined,
 			});
 			tradeData[gem] = result;
 		} catch (err: any) {
@@ -308,7 +326,7 @@
 		searchDebounce = setTimeout(async () => {
 			// Guard: if query changed while waiting, skip stale fetch
 			if (searchQuery !== query) return;
-			const allNames = await fetchGemNames(query);
+			const allNames = await fetchGemNames(query, isDedication ? 'dedication' : undefined);
 			// Guard: if query changed during fetch, skip stale results
 			if (searchQuery !== query) return;
 			suggestions = allNames.filter((n) => !selectedGems.includes(n));

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -396,21 +396,21 @@ export async function fetchFontEV(variant: string): Promise<FontEVResponse> {
 
 function mapDedicationRows(rows: any[]): DedicationColor[] {
 	return rows.map((r: any) => ({
-		color: r.color || '',
-		gemType: r.gemType || '',
-		pool: r.pool || 0,
-		winners: r.winners || 0,
-		pWin: Math.round((r.pWin || 0) * 10000) / 100,
-		avgWinRaw: r.avgWinRaw ? Math.round(r.avgWinRaw) : 0,
-		evRaw: r.evRaw ? Math.round(r.evRaw) : 0,
-		inputCost: r.inputCost ? Math.round(r.inputCost) : 0,
-		profit: r.profit ? Math.round(r.profit) : 0,
-		fontsToHit: r.fontsToHit || 0,
-		jackpotGems: r.jackpotGems || [],
-		thinPoolGems: r.thinPoolGems || 0,
-		liquidityRisk: r.liquidityRisk || 'LOW',
-		poolBreakdown: r.poolBreakdown || [],
-		lowConfidenceGems: r.lowConfidenceGems || [],
+		color: r.color ?? '',
+		gemType: r.gemType ?? '',
+		pool: r.pool ?? 0,
+		winners: r.winners ?? 0,
+		pWin: Math.round((r.pWin ?? 0) * 10000) / 100,
+		avgWinRaw: Math.round(r.avgWinRaw ?? 0),
+		evRaw: Math.round(r.evRaw ?? 0),
+		inputCost: Math.round(r.inputCost ?? 0),
+		profit: Math.round(r.profit ?? 0),
+		fontsToHit: r.fontsToHit ?? 0,
+		jackpotGems: r.jackpotGems ?? [],
+		thinPoolGems: r.thinPoolGems ?? 0,
+		liquidityRisk: r.liquidityRisk ?? 'LOW',
+		poolBreakdown: r.poolBreakdown ?? [],
+		lowConfidenceGems: r.lowConfidenceGems ?? [],
 	}));
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -78,7 +78,7 @@ export interface FontColor {
 	avgWin?: number;
 	avgWinRaw?: number;
 	evRaw?: number;
-	jackpotGems?: { name: string; chaos: number }[];
+	jackpotGems?: { name: string; chaos: number; gcpRecipeCost?: number; gcpRecipeBase?: number; gcpRecipeSaves?: number }[];
 	thinPoolGems?: number;
 	liquidityRisk?: string;
 	mode?: string;
@@ -100,6 +100,38 @@ export interface FontEVResponse {
 	bestColorSafe: string;
 	bestColorPremium: string;
 	bestColorJackpot: string;
+}
+
+// --- Dedication types ---
+
+export interface DedicationColor {
+	color: 'RED' | 'GREEN' | 'BLUE';
+	gemType: string;
+	pool: number;
+	winners: number;
+	pWin: number;
+	avgWinRaw: number;
+	evRaw: number;
+	inputCost: number;
+	profit: number;
+	fontsToHit: number;
+	jackpotGems?: { name: string; chaos: number }[];
+	thinPoolGems: number;
+	liquidityRisk: string;
+	poolBreakdown?: { tier: string; count: number; minPrice: number; maxPrice: number }[];
+	lowConfidenceGems?: { name: string; chaos: number; listings: number }[];
+}
+
+export interface DedicationPoolResponse {
+	safe: DedicationColor[];
+	premium: DedicationColor[];
+	jackpot: DedicationColor[];
+}
+
+export interface DedicationEVResponse {
+	skills: DedicationPoolResponse;
+	transfigured: DedicationPoolResponse;
+	entryFee: number;
 }
 
 export interface MarketOverviewData {
@@ -359,6 +391,48 @@ export async function fetchFontEV(variant: string): Promise<FontEVResponse> {
 		bestColorSafe: resp.bestColorSafe || '',
 		bestColorPremium: resp.bestColorPremium || '',
 		bestColorJackpot: resp.bestColorJackpot || '',
+	};
+}
+
+function mapDedicationRows(rows: any[]): DedicationColor[] {
+	return rows.map((r: any) => ({
+		color: r.color || '',
+		gemType: r.gemType || '',
+		pool: r.pool || 0,
+		winners: r.winners || 0,
+		pWin: Math.round((r.pWin || 0) * 10000) / 100,
+		avgWinRaw: r.avgWinRaw ? Math.round(r.avgWinRaw) : 0,
+		evRaw: r.evRaw ? Math.round(r.evRaw) : 0,
+		inputCost: r.inputCost ? Math.round(r.inputCost) : 0,
+		profit: r.profit ? Math.round(r.profit) : 0,
+		fontsToHit: r.fontsToHit || 0,
+		jackpotGems: r.jackpotGems || [],
+		thinPoolGems: r.thinPoolGems || 0,
+		liquidityRisk: r.liquidityRisk || 'LOW',
+		poolBreakdown: r.poolBreakdown || [],
+		lowConfidenceGems: r.lowConfidenceGems || [],
+	}));
+}
+
+function mapDedicationPool(pool: any): DedicationPoolResponse {
+	return {
+		safe: mapDedicationRows(pool?.safe || []),
+		premium: mapDedicationRows(pool?.premium || []),
+		jackpot: mapDedicationRows(pool?.jackpot || []),
+	};
+}
+
+export async function fetchDedicationEV(): Promise<DedicationEVResponse> {
+	const resp = await get<{
+		skills: any;
+		transfigured: any;
+		entryFee: number;
+	}>('/analysis/dedication');
+
+	return {
+		skills: mapDedicationPool(resp.skills),
+		transfigured: mapDedicationPool(resp.transfigured),
+		entryFee: Math.round(resp.entryFee || 0),
 	};
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -467,20 +467,25 @@ export async function fetchMarketOverview(): Promise<MarketOverviewData> {
 	};
 }
 
-export async function fetchGemNames(query: string): Promise<string[]> {
+export async function fetchGemNames(query: string, mode?: string): Promise<string[]> {
 	if (query.length < 2) return [];
-	const resp = await get<{ names: string[] }>('/analysis/gems/names', {
-		q: query,
-		limit: '15',
-	});
+	const params: Record<string, string> = { q: query, limit: '15' };
+	if (mode === 'dedication') {
+		params.corrupted = 'true';
+	}
+	const resp = await get<{ names: string[] }>('/analysis/gems/names', params);
 	return resp.names || [];
 }
 
-export async function fetchCompare(gems: string[], variant: string): Promise<CompareGem[]> {
-	const resp = await get<{ count: number; data: any[] }>('/analysis/compare', {
+export async function fetchCompare(gems: string[], variant: string, mode?: string): Promise<CompareGem[]> {
+	const params: Record<string, string> = {
 		gems: gems.join(','),
 		variant,
-	});
+	};
+	if (mode === 'dedication') {
+		params.mode = 'dedication';
+	}
+	const resp = await get<{ count: number; data: any[] }>('/analysis/compare', params);
 	const results = (resp.data || []).map(mapCompareRow);
 
 	// Enrich with signal history in parallel

--- a/frontend/src/lib/trade-utils.ts
+++ b/frontend/src/lib/trade-utils.ts
@@ -13,6 +13,50 @@ export function baseGemName(name: string): string {
 }
 
 /**
+ * Build trade URL for cheapest corrupted 21/23 gems of a color, for Dedication lab input cost.
+ * Filters: gem_level >= 21, quality >= 23, category gem.activegem (skills only).
+ * Color filter via req_filters attribute caps (same pattern as FontEVCompare buyBaseUrl).
+ * isTransfigured: true = only transfigured gems, false = exclude transfigured gems.
+ */
+export function cheapestCorrupted2123TradeUrl(color: string, isTransfigured: boolean, league: string): string {
+	// Attribute caps to isolate pure-color gems (hybrids start at 98).
+	const reqFilters: Record<string, any> = {};
+	if (color === 'RED')   { reqFilters.dex = { max: 97 }; reqFilters.int = { max: 97 }; }
+	if (color === 'GREEN') { reqFilters.str = { max: 97 }; reqFilters.int = { max: 97 }; }
+	if (color === 'BLUE')  { reqFilters.str = { max: 97 }; reqFilters.dex = { max: 97 }; }
+
+	const miscFilters: Record<string, any> = {
+		gem_level: { min: 21 },
+		quality: { min: 23 },
+		corrupted: { option: 'true' },
+	};
+
+	// Transfigured gems have "alternate_art" = true on the trade site.
+	if (isTransfigured) {
+		miscFilters.gem_alternate_quality = { option: 'true' };
+	}
+
+	const q: any = {
+		query: {
+			status: { option: 'securable' },
+			filters: {
+				type_filters: { filters: { category: { option: 'gem.activegem' } } },
+				req_filters: { filters: reqFilters },
+				misc_filters: { filters: miscFilters },
+				trade_filters: { filters: { sale_type: { option: 'priced' }, collapse: { option: 'true' } } },
+			},
+		},
+		sort: { price: 'asc' },
+	};
+
+	// For non-transfigured, we cannot filter "not transfigured" directly on the trade site.
+	// The search will return all corrupted 21/23 skill gems of that color — users can manually
+	// skip transfigured entries. This is a known trade site limitation.
+
+	return `https://www.pathofexile.com/trade/search/${encodeURIComponent(league || 'Mirage')}?q=${encodeURIComponent(JSON.stringify(q))}`;
+}
+
+/**
  * Build GGG trade search URL for a base gem with variant filters.
  * Parameters: gem name (transfigured), variant string ("20/20"), league name.
  * Returns: full trade URL with query.

--- a/frontend/src/routes/lab/+page.svelte
+++ b/frontend/src/routes/lab/+page.svelte
@@ -22,7 +22,15 @@
 	import Legend from './components/Legend.svelte';
 	import FontEVCompare from './components/FontEVCompare.svelte';
 
-	let selectedLab = $state('Merciless');
+	// Restore lab mode from localStorage (default: "Normal").
+	// Migrate old "Merciless" value to "Normal".
+	function restoreLabMode(): string {
+		if (typeof window === 'undefined') return 'Normal';
+		const saved = localStorage.getItem('poe-lab-mode');
+		if (!saved || saved === 'Merciless') return 'Normal';
+		return saved;
+	}
+	let selectedLab = $state(restoreLabMode());
 	let status = $state<StatusData | null>(null);
 	let bestPlays = $state<GemPlay[]>([]);
 	let marketOverview = $state<MarketOverviewData | null>(null);
@@ -140,6 +148,9 @@
 
 	function handleLabChange(lab: string) {
 		selectedLab = lab;
+		if (typeof window !== 'undefined') {
+			localStorage.setItem('poe-lab-mode', lab);
+		}
 	}
 
 	$effect(() => {
@@ -184,10 +195,7 @@
 	{/if}
 
 	{#if isDedication}
-		<section class="section dedication">
-			<h2 class="section-title">Dedication Lab -- Corrupted Gem Exchange</h2>
-			<p class="coming-soon">Coming soon. Corrupted gem analyzer is a separate task.</p>
-		</section>
+		<FontEVCompare {refreshKey} league={status?.league || ''} labMode="dedication" />
 	{:else if !loading}
 		<Comparator league={status?.league || ''} {refreshKey} onQueueGem={handleQueueGem} {desktopPair} onDesktopDisconnect={() => { desktopPair = null; }} />
 
@@ -225,28 +233,6 @@
 		margin: 0 auto;
 		padding: 24px 40px;
 	}
-	.section {
-		background: var(--color-lab-surface);
-		border: 1px solid var(--color-lab-border);
-		padding: 28px;
-		margin-bottom: 32px;
-	}
-	.section-title {
-		font-size: 1.125rem;
-		font-weight: 700;
-		color: var(--color-lab-text);
-		margin: 0 0 14px 0;
-	}
-	.dedication {
-		text-align: center;
-		padding: 40px 20px;
-	}
-	.coming-soon {
-		color: var(--color-lab-text-secondary);
-		font-size: 0.875rem;
-		margin-top: 8px;
-	}
-
 	/* Loading */
 	.loading {
 		display: flex;

--- a/frontend/src/routes/lab/+page.svelte
+++ b/frontend/src/routes/lab/+page.svelte
@@ -196,6 +196,7 @@
 
 	{#if isDedication}
 		<FontEVCompare {refreshKey} league={status?.league || ''} labMode="dedication" />
+		<Comparator league={status?.league || ''} {refreshKey} onQueueGem={handleQueueGem} {desktopPair} onDesktopDisconnect={() => { desktopPair = null; }} labMode="dedication" />
 	{:else if !loading}
 		<Comparator league={status?.league || ''} {refreshKey} onQueueGem={handleQueueGem} {desktopPair} onDesktopDisconnect={() => { desktopPair = null; }} />
 

--- a/frontend/src/routes/lab/+page.svelte
+++ b/frontend/src/routes/lab/+page.svelte
@@ -197,6 +197,12 @@
 	{#if isDedication}
 		<FontEVCompare {refreshKey} league={status?.league || ''} labMode="dedication" />
 		<Comparator league={status?.league || ''} {refreshKey} onQueueGem={handleQueueGem} {desktopPair} onDesktopDisconnect={() => { desktopPair = null; }} labMode="dedication" />
+		<SessionQueue
+			queue={sessionQueue}
+			onRemove={handleRemoveFromQueue}
+			onClear={handleClearQueue}
+			onRefresh={handleRefreshQueue}
+		/>
 	{:else if !loading}
 		<Comparator league={status?.league || ''} {refreshKey} onQueueGem={handleQueueGem} {desktopPair} onDesktopDisconnect={() => { desktopPair = null; }} />
 

--- a/frontend/src/routes/lab/components/Comparator.svelte
+++ b/frontend/src/routes/lab/components/Comparator.svelte
@@ -15,13 +15,17 @@
 		onQueueGem,
 		desktopPair = null,
 		onDesktopDisconnect,
+		labMode = 'normal',
 	}: {
 		league?: string;
 		refreshKey?: number;
 		onQueueGem?: (gem: string, variant: string, roi: number, tradeData: TradeLookupResult | null) => void;
 		desktopPair?: string | null;
 		onDesktopDisconnect?: () => void;
+		labMode?: 'normal' | 'dedication';
 	} = $props();
+
+	let isDedication = $derived(labMode === 'dedication');
 
 	let selectedForQueue = $state<string | null>(null);
 
@@ -35,8 +39,21 @@
 		}
 	});
 
-	const VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
-	const VARIANT_OPTIONS = VARIANTS.map((v) => ({ value: v, label: v }));
+	const NORMAL_VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
+	const DEDICATION_VARIANTS = ['21/23'];
+	let activeVariants = $derived(isDedication ? DEDICATION_VARIANTS : NORMAL_VARIANTS);
+	let VARIANT_OPTIONS = $derived(activeVariants.map((v) => ({ value: v, label: v })));
+
+	// Lock variant to 21/23 in dedication mode, restore to 20/20 in normal mode.
+	$effect(() => {
+		if (isDedication && variant !== '21/23') {
+			variant = '21/23';
+			loadResults();
+		} else if (!isDedication && variant === '21/23') {
+			variant = '20/20';
+			loadResults();
+		}
+	});
 
 	// --- Desktop pairing state ---
 	let desktopConnected = $state(false);
@@ -49,7 +66,7 @@
 		const unsub = subscribeToDesktopGems(
 			(gems, detectedVariant) => {
 				// Set variant if different
-				if (VARIANTS.includes(detectedVariant) && detectedVariant !== variant) {
+				if (activeVariants.includes(detectedVariant) && detectedVariant !== variant) {
 					variant = detectedVariant;
 				}
 				// Replace selected gems with detected ones (up to 3)
@@ -198,7 +215,7 @@
 			return;
 		}
 		try {
-			results = await fetchCompare(active, variant);
+			results = await fetchCompare(active, variant, isDedication ? 'dedication' : undefined);
 		} catch (err) {
 			console.error('[Comparator] Failed to load results:', err);
 			results = [];
@@ -219,7 +236,7 @@
 		searchDebounce = setTimeout(async () => {
 			// Guard: if query changed while waiting, skip stale fetch
 			if (searchQuery !== query) return;
-			const allNames = await fetchGemNames(query);
+			const allNames = await fetchGemNames(query, isDedication ? 'dedication' : undefined);
 			// Guard: if query changed during fetch, skip stale results
 			if (searchQuery !== query) return;
 			suggestions = allNames.filter((n) => !selectedGems.includes(n));

--- a/frontend/src/routes/lab/components/FontEVCompare.svelte
+++ b/frontend/src/routes/lab/components/FontEVCompare.svelte
@@ -1,34 +1,53 @@
 <script lang="ts">
-	import { fetchFontEV, type FontEVResponse, type FontColor } from '$lib/api';
-	import { baseGemTradeUrl } from '$lib/trade-utils';
+	import { fetchFontEV, fetchDedicationEV, type FontEVResponse, type FontColor, type DedicationEVResponse, type DedicationColor } from '$lib/api';
+	import { baseGemTradeUrl, cheapestCorrupted2123TradeUrl } from '$lib/trade-utils';
 	import InfoTooltip from './InfoTooltip.svelte';
 	import Select from '$lib/components/Select.svelte';
 
-	let { refreshKey = 0, league = '' }: { refreshKey?: number; league?: string } = $props();
+	let { refreshKey = 0, league = '', labMode = 'normal' }: { refreshKey?: number; league?: string; labMode?: 'normal' | 'dedication' } = $props();
 
 	const VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
 	const COLORS = ['RED', 'GREEN', 'BLUE'] as const;
 
+	// --- Normal (Font) mode state ---
 	let data = $state<Record<string, FontEVResponse>>({});
+
+	// --- Dedication mode state ---
+	let dedicationData = $state<DedicationEVResponse | null>(null);
+
 	let loading = $state(true);
+
+	const isDedication = $derived(labMode === 'dedication');
+
+	// --- Dedication row definitions ---
+	const DEDICATION_ROWS = [
+		{ key: 'skills', label: '21/23 Skill Gems', poolKey: 'skills' as const },
+		{ key: 'transfigured', label: '21/23 Transfigured', poolKey: 'transfigured' as const },
+	];
 
 	async function loadAll() {
 		loading = true;
 		try {
-			const results = await Promise.all(
-				VARIANTS.map(async (v) => {
-					const d = await fetchFontEV(v);
-					return [v, d] as const;
-				})
-			);
-			for (const [v, d] of results) {
-				data[v] = d;
+			if (isDedication) {
+				dedicationData = await fetchDedicationEV();
+			} else {
+				const results = await Promise.all(
+					VARIANTS.map(async (v) => {
+						const d = await fetchFontEV(v);
+						return [v, d] as const;
+					})
+				);
+				for (const [v, d] of results) {
+					data[v] = d;
+				}
 			}
 		} catch (err) {
 			console.error('[FontEV] Failed to load:', err);
 		}
 		loading = false;
 	}
+
+	// --- Normal mode helpers ---
 
 	function getColorData(variant: string, color: string, mode: 'safe' | 'premium' | 'jackpot'): FontColor | null {
 		const vd = data[variant];
@@ -56,7 +75,47 @@
 		return best;
 	}
 
-	function tierLine(fc: FontColor | null): string {
+	// --- Dedication mode helpers ---
+
+	function getDedColorData(poolKey: 'skills' | 'transfigured', color: string, mode: 'safe' | 'premium' | 'jackpot'): DedicationColor | null {
+		if (!dedicationData) return null;
+		const pool = dedicationData[poolKey];
+		if (!pool) return null;
+		const rows = pool[mode];
+		return rows?.find((c) => c.color === color) || null;
+	}
+
+	function getDedEV(poolKey: 'skills' | 'transfigured', color: string): number {
+		const dc = getDedColorData(poolKey, color, 'safe');
+		return dc?.evRaw ?? 0;
+	}
+
+	function getDedInputCost(poolKey: 'skills' | 'transfigured', color: string): number {
+		const dc = getDedColorData(poolKey, color, 'safe');
+		return dc?.inputCost ?? 0;
+	}
+
+	function getDedProfit(poolKey: 'skills' | 'transfigured', color: string): number {
+		const dc = getDedColorData(poolKey, color, 'safe');
+		return dc?.profit ?? 0;
+	}
+
+	function dedWinner(): { poolKey: string; color: string; profit: number } {
+		let best = { poolKey: '', color: '', profit: -Infinity };
+		for (const row of DEDICATION_ROWS) {
+			for (const color of COLORS) {
+				const profit = getDedProfit(row.poolKey, color);
+				if (profit > best.profit) {
+					best = { poolKey: row.poolKey, color, profit };
+				}
+			}
+		}
+		return best;
+	}
+
+	// --- Shared helpers ---
+
+	function tierLine(fc: { winners: number; fontsToHit?: number; pWin: number; avgWinRaw?: number; avgWin?: number } | null): string {
 		if (!fc || fc.winners === 0 || !fc.fontsToHit) return '\u2014 none';
 		const raw = fc.avgWinRaw || fc.avgWin || 0;
 		const fth = fc.fontsToHit;
@@ -64,8 +123,8 @@
 		if (fth <= 1.05) {
 			ratio = 'every font';
 		} else if (fth < 2) {
-			// > 50% hit rate — show as "X in Y" reduced fraction
-			const pctFrac = fc.pWin / 100; // pWin is 0-100
+			// > 50% hit rate
+			const pctFrac = fc.pWin / 100;
 			const hits = Math.round(pctFrac * 10);
 			const gcd = (a: number, b: number): number => b === 0 ? a : gcd(b, a % b);
 			const d = hits > 0 ? gcd(hits, 10) : 1;
@@ -78,20 +137,15 @@
 	}
 
 	/**
-	 * Build trade URL for cheapest base gem of a color + variant.
-	 * Color filtering uses attribute requirement caps (max 97) to exclude hybrids (98+).
-	 * RED = STR gems: cap dex+int. GREEN = DEX: cap str+int. BLUE = INT: cap str+dex.
-	 * Level 1 gems have no attribute requirements — can't filter by color, returns null.
+	 * Build trade URL for cheapest base gem of a color + variant (Normal mode).
 	 */
 	function buyBaseUrl(variant: string, color: string): string | null {
 		const parts = variant.split('/');
 		const level = parseInt(parts[0]) || 0;
 		const quality = parts.length > 1 ? parseInt(parts[1]) : 0;
 
-		// Level 1 gems have no attribute requirements — no color filter possible.
 		if (level < 20) return null;
 
-		// Attribute caps to isolate pure-color gems (hybrids start at 98).
 		const reqFilters: Record<string, any> = {};
 		if (color === 'RED')   { reqFilters.dex = { max: 97 }; reqFilters.int = { max: 97 }; }
 		if (color === 'GREEN') { reqFilters.str = { max: 97 }; reqFilters.int = { max: 97 }; }
@@ -149,10 +203,16 @@
 
 	let showPool = $state(false);
 	let poolVariant = $state('20/20');
+	let dedPoolKey = $state<'skills' | 'transfigured'>('skills');
 
 	function getPoolBreakdown(variant: string, color: string): { tier: string; count: number; minPrice: number; maxPrice: number }[] {
 		const safe = getColorData(variant, color, 'safe');
 		return safe?.poolBreakdown || [];
+	}
+
+	function getDedPoolBreakdown(poolKey: 'skills' | 'transfigured', color: string): { tier: string; count: number; minPrice: number; maxPrice: number }[] {
+		const dc = getDedColorData(poolKey, color, 'safe');
+		return dc?.poolBreakdown || [];
 	}
 
 	const ALL_TIERS = ['TOP', 'HIGH', 'MID-HIGH', 'MID', 'LOW', 'FLOOR'];
@@ -161,13 +221,156 @@
 		MID: '#94a3b8', LOW: '#64748b', FLOOR: '#475569',
 	};
 
-	$effect(() => { refreshKey; loadAll(); });
+	$effect(() => { refreshKey; labMode; loadAll(); });
 </script>
 
 <section class="section">
 	{#if loading}
 		<span class="loading">Loading...</span>
-	{:else}
+	{:else if isDedication && dedicationData}
+		{@const best = dedWinner()}
+		{#if dedicationData.entryFee > 0}
+			<div class="dedication-header">
+				<span class="dedication-title">Dedication Lab — Corrupted 21/23 Gem Exchange</span>
+				<span class="entry-fee">
+					Entry fee: <strong>{dedicationData.entryFee}c</strong>
+					<InfoTooltip text="<b>Dedication to the Goddess offering price</b><br><br>This is the cost of the offering required to open a Dedication Lab run. It is displayed for reference but <b>NOT included</b> in the profit calculation — profit shows pure gem exchange value minus input gem cost." />
+				</span>
+			</div>
+		{/if}
+		<table class="ft">
+			<thead>
+				<tr>
+					<th class="var-header">Dedication EV<InfoTooltip text="<b>Dedication Lab — Corrupted Gem Exchange EV</b><br><br>Two font options available per run:<br>• <b>21/23 Skill Gems</b>: Non-transfigured corrupted skill gems<br>• <b>21/23 Transfigured</b>: Transfigured corrupted skill gems<br><br><b>Nc/font</b>: Expected income per font usage. Based on best-of-3 random draws from the corrupted pool of that color.<br><br><b>Input cost</b>: Average price of the 10 cheapest corrupted 21/23 gems in that color pool — this is what you feed into the font.<br><br><b>Profit</b>: EV minus input cost. Entry fee (Dedication offering) is NOT included.<br><br>Thin liquidity is expected for corrupted gems — fewer listings than normal font pools." /></th>
+					{#each COLORS as color}
+						<th><span class="c-{color.toLowerCase()}">{'\u25CF'} {color}</span></th>
+					{/each}
+					<th class="buy-header">Buy Input</th>
+				</tr>
+			</thead>
+			<tbody>
+				{#each DEDICATION_ROWS as row}
+					<tr>
+						<td class="var">{row.label}</td>
+						{#each COLORS as color}
+							{@const ev = getDedEV(row.poolKey, color)}
+							{@const inputCost = getDedInputCost(row.poolKey, color)}
+							{@const profit = getDedProfit(row.poolKey, color)}
+							{@const safe = getDedColorData(row.poolKey, color, 'safe')}
+							{@const premium = getDedColorData(row.poolKey, color, 'premium')}
+							{@const jackpot = getDedColorData(row.poolKey, color, 'jackpot')}
+							{@const isW = best.poolKey === row.poolKey && best.color === color}
+							<td class:w-red={isW && color === 'RED'} class:w-green={isW && color === 'GREEN'} class:w-blue={isW && color === 'BLUE'}>
+								{#if ev > 0}
+									<span class="ev" class:best-red={isW && color === 'RED'} class:best-green={isW && color === 'GREEN'} class:best-blue={isW && color === 'BLUE'}>{ev}c/font</span>
+									<div class="ded-cost-line">
+										<span class="ded-input">in: {inputCost}c</span>
+										<span class="ded-profit" class:ded-profit-positive={profit > 0} class:ded-profit-negative={profit <= 0}>
+											{profit > 0 ? '+' : ''}{profit}c
+										</span>
+									</div>
+									<div class="tier-lines">
+										<div class="tier-row">
+											<span class="tier-label t-safe">Safe</span>
+											<span class="tier-val t-safe">{tierLine(safe)}</span>
+										</div>
+										<div class="tier-row">
+											<span class="tier-label t-premium">Premium</span>
+											<span class="tier-val t-premium">{tierLine(premium)}</span>
+										</div>
+										{#if jackpot && jackpot.winners > 0}
+										{@const gemList = (jackpot.jackpotGems || []).map(g => {
+											return `<div style="padding:4px 0;border-bottom:1px solid rgba(255,255,255,0.06)"><b>${g.name}</b>: ${Math.round(g.chaos)}c</div>`;
+										}).join('')}
+										<div class="tier-row">
+											<span class="tier-label t-jackpot">Jackpot</span>
+											<span class="tier-val t-jackpot">{tierLine(jackpot)}</span>
+											<InfoTooltip text={gemList} />
+										</div>
+										{/if}
+									</div>
+								{:else}
+									<span class="nil">{'\u2014'}</span>
+								{/if}
+							</td>
+						{/each}
+						<td class="buy-col">
+							<div class="buy-buttons">
+								{#each COLORS as color}
+									{@const url = cheapestCorrupted2123TradeUrl(color, row.poolKey === 'transfigured', league || '')}
+									<a
+										class="buy-btn buy-{color.toLowerCase()}"
+										href={url}
+										target="_blank"
+										title="Buy cheapest corrupted 21/23 {color} {row.poolKey === 'transfigured' ? 'transfigured ' : ''}gems"
+									>{color}</a>
+								{/each}
+							</div>
+						</td>
+					</tr>
+				{/each}
+			</tbody>
+		</table>
+
+		<button class="pool-toggle" onclick={() => { showPool = !showPool; }}>
+			{showPool ? '\u25BC' : '\u25B6'} Pool Overview
+		</button>
+
+		{#if showPool}
+			<div class="pool-section">
+				<div class="pool-variant-select">
+					<span class="pool-select-label">Pool:</span>
+					<Select bind:value={dedPoolKey} options={DEDICATION_ROWS.map(r => ({ value: r.poolKey, label: r.label }))} />
+				</div>
+				<div class="pool-grid">
+					{#each COLORS as color}
+						{@const breakdown = getDedPoolBreakdown(dedPoolKey, color)}
+						{@const safe = getDedColorData(dedPoolKey, color, 'safe')}
+						{@const totalGems = safe?.pool || breakdown.reduce((s, t) => s + t.count, 0)}
+						<div class="pool-color-card">
+							<div class="pool-color-header c-{color.toLowerCase()}">{color} <span class="pool-count">{totalGems} gems</span></div>
+							{#each ALL_TIERS as tierName}
+								{@const tier = breakdown.find(t => t.tier === tierName)}
+								{@const tierPWin = tier ? Math.round(pWin3(tier.count, totalGems) * 100) : 0}
+								<div class="pool-tier-row" class:pool-tier-empty={!tier}>
+									<span class="pool-tier-name" style="color: {TIER_COLORS[tierName] || '#94a3b8'}">{tierName}</span>
+									{#if tier}
+										<span class="pool-tier-count">{tier.count}</span>
+										<span class="pool-tier-range">
+											{#if tier.minPrice === tier.maxPrice}
+												{tier.minPrice}c
+											{:else}
+												{tier.minPrice}c — {tier.maxPrice}c
+											{/if}
+										</span>
+										<span class="pool-tier-bar">
+											<span class="pool-tier-bar-fill" style="width: {tierPWin}%; background: {TIER_COLORS[tierName] || '#94a3b8'}"></span>
+										</span>
+										<span class="pool-tier-pwin">{tierPWin}%</span>
+									{:else}
+										<span class="pool-tier-count">—</span>
+										<span class="pool-tier-range"></span>
+										<span class="pool-tier-bar"></span>
+										<span class="pool-tier-pwin"></span>
+									{/if}
+								</div>
+							{/each}
+							{#if safe?.lowConfidenceGems?.length}
+								{@const lcGems = safe.lowConfidenceGems}
+								{@const lcTooltip = lcGems.map(g => `<b>${g.name}</b>: ${Math.round(g.chaos)}c (${g.listings} listings)`).join('<br>')}
+								<div class="pool-tier-row pool-risky-row">
+									<span class="pool-tier-name pool-risky-name">RISKY</span>
+									<span class="pool-tier-count">{lcGems.length}</span>
+									<span class="pool-tier-range">excluded from EV</span>
+									<InfoTooltip text="<b>Low confidence gems</b> — very few listings relative to normal. Could be a new meta build (demand spike) or price manipulation (buyout). Excluded from EV calculation.<br><br>{lcTooltip}" />
+								</div>
+							{/if}
+						</div>
+					{/each}
+				</div>
+			</div>
+		{/if}
+	{:else if !isDedication}
 		{@const best = winner()}
 		<table class="ft">
 			<thead>
@@ -204,11 +407,11 @@
 										{#if jackpot && jackpot.winners > 0}
 										{@const gemList = (jackpot.jackpotGems || []).map(g => {
 											let html = `<div style="padding:4px 0;border-bottom:1px solid rgba(255,255,255,0.06)"><b>${g.name}</b>: ${Math.round(g.chaos)}c &nbsp;&nbsp;<a href="${baseGemTradeUrl(g.name, variant, league || '')}" target="_blank" style="padding:1px 8px;font-size:0.75rem;font-weight:600;color:#5eead4;border:1px solid rgba(94,234,212,0.4);text-decoration:none;letter-spacing:0.03em">Buy Base</a>`;
-											if (g.gcpRecipeCost > 0) {
-												const saves = Math.round(g.gcpRecipeSaves);
+											if ((g.gcpRecipeCost || 0) > 0) {
+												const saves = Math.round(g.gcpRecipeSaves || 0);
 												const savesColor = saves >= 0 ? '#22c55e' : '#ef4444';
 												const savesText = saves >= 0 ? `saves ${saves}c` : `costs ${Math.abs(saves)}c more`;
-												html += `<div style="margin-top:3px;font-size:0.75rem;color:#94a3b8">GCP recipe: <b>${Math.round(g.gcpRecipeBase)}c</b> base + ${Math.round(g.gcpRecipeCost - g.gcpRecipeBase)}c GCPs = <b>${Math.round(g.gcpRecipeCost)}c</b> <span style="color:${savesColor}">(${savesText})</span> &nbsp;<a href="${baseGemNoQualityUrl(g.name)}" target="_blank" style="padding:1px 6px;font-size:0.6875rem;font-weight:600;color:#fbbf24;border:1px solid rgba(251,191,36,0.4);text-decoration:none">Buy 20/0</a></div>`;
+												html += `<div style="margin-top:3px;font-size:0.75rem;color:#94a3b8">GCP recipe: <b>${Math.round(g.gcpRecipeBase || 0)}c</b> base + ${Math.round((g.gcpRecipeCost || 0) - (g.gcpRecipeBase || 0))}c GCPs = <b>${Math.round(g.gcpRecipeCost || 0)}c</b> <span style="color:${savesColor}">(${savesText})</span> &nbsp;<a href="${baseGemNoQualityUrl(g.name)}" target="_blank" style="padding:1px 6px;font-size:0.6875rem;font-weight:600;color:#fbbf24;border:1px solid rgba(251,191,36,0.4);text-decoration:none">Buy 20/0</a></div>`;
 											}
 											html += `</div>`;
 											return html;
@@ -317,6 +520,49 @@
 	}
 	.loading { color: var(--color-lab-text-secondary); font-size: 0.875rem; }
 
+	/* Dedication header */
+	.dedication-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 16px;
+		padding: 0 4px;
+	}
+	.dedication-title {
+		font-size: 1.0625rem;
+		font-weight: 700;
+		color: var(--color-lab-text);
+	}
+	.entry-fee {
+		font-size: 0.9375rem;
+		color: var(--color-lab-text-secondary);
+	}
+	.entry-fee strong {
+		color: var(--color-lab-yellow, #eab308);
+	}
+
+	/* Dedication cost line */
+	.ded-cost-line {
+		display: flex;
+		align-items: baseline;
+		justify-content: center;
+		gap: 8px;
+		font-size: 0.8125rem;
+		margin-bottom: 4px;
+	}
+	.ded-input {
+		color: var(--color-lab-text-secondary);
+	}
+	.ded-profit {
+		font-weight: 600;
+	}
+	.ded-profit-positive {
+		color: var(--color-lab-green);
+	}
+	.ded-profit-negative {
+		color: var(--color-lab-red);
+	}
+
 	.ft { width: 100%; border-collapse: separate; border-spacing: 4px; }
 	.ft th {
 		text-align: center;
@@ -381,8 +627,6 @@
 	}
 	.tier-label {
 		font-weight: 600;
-	}
-	.tier-val {
 	}
 	.t-safe { color: #5eead4; }
 	.t-premium { color: #c084fc; }

--- a/frontend/src/routes/lab/components/FontEVCompare.svelte
+++ b/frontend/src/routes/lab/components/FontEVCompare.svelte
@@ -16,17 +16,19 @@
 	let dedicationData = $state<DedicationEVResponse | null>(null);
 
 	let loading = $state(true);
+	let loadError = $state(false);
 
 	const isDedication = $derived(labMode === 'dedication');
 
 	// --- Dedication row definitions ---
 	const DEDICATION_ROWS = [
-		{ key: 'skills', label: '21/23 Skill Gems', poolKey: 'skills' as const },
-		{ key: 'transfigured', label: '21/23 Transfigured', poolKey: 'transfigured' as const },
+		{ label: '21/23 Skill Gems', poolKey: 'skills' as const },
+		{ label: '21/23 Transfigured', poolKey: 'transfigured' as const },
 	];
 
 	async function loadAll() {
 		loading = true;
+		loadError = false;
 		try {
 			if (isDedication) {
 				dedicationData = await fetchDedicationEV();
@@ -43,6 +45,7 @@
 			}
 		} catch (err) {
 			console.error('[FontEV] Failed to load:', err);
+			loadError = true;
 		}
 		loading = false;
 	}
@@ -227,6 +230,8 @@
 <section class="section">
 	{#if loading}
 		<span class="loading">Loading...</span>
+	{:else if loadError}
+		<span class="loading">Failed to load data — check connection and refresh.</span>
 	{:else if isDedication && dedicationData}
 		{@const best = dedWinner()}
 		{#if dedicationData.entryFee > 0}

--- a/frontend/src/routes/lab/components/Header.svelte
+++ b/frontend/src/routes/lab/components/Header.svelte
@@ -11,7 +11,7 @@
 		onLabChange: (lab: string) => void;
 	} = $props();
 
-	const LABS = ['Merciless'];
+	const LABS = ['Normal', 'Dedication'];
 
 	// Tick every 1s to keep timers live
 	let now = $state(Date.now());

--- a/internal/db/migrations/20260412224254_create_dedication_snapshots.down.sql
+++ b/internal/db/migrations/20260412224254_create_dedication_snapshots.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS dedication_snapshots;

--- a/internal/db/migrations/20260412224254_create_dedication_snapshots.up.sql
+++ b/internal/db/migrations/20260412224254_create_dedication_snapshots.up.sql
@@ -1,0 +1,31 @@
+CREATE TABLE dedication_snapshots (
+    time               TIMESTAMPTZ NOT NULL,
+    color              TEXT        NOT NULL,
+    gem_type           TEXT        NOT NULL,  -- 'skill' or 'transfigured'
+    pool               INTEGER,
+    winners            INTEGER,
+    p_win              DOUBLE PRECISION,
+    avg_win_raw        DOUBLE PRECISION,
+    ev_raw             DOUBLE PRECISION,
+    input_cost         DOUBLE PRECISION,
+    profit             DOUBLE PRECISION,
+    fonts_to_hit       DOUBLE PRECISION,
+    mode               TEXT        NOT NULL DEFAULT 'safe',
+    thin_pool_gems     INTEGER     NOT NULL DEFAULT 0,
+    liquidity_risk     TEXT        NOT NULL DEFAULT 'LOW',
+    pool_breakdown     JSONB,
+    low_confidence_gems JSONB,
+    PRIMARY KEY (time, color, gem_type, mode)
+);
+
+SELECT create_hypertable('dedication_snapshots', 'time');
+
+ALTER TABLE dedication_snapshots
+    SET (timescaledb.compress,
+         timescaledb.compress_segmentby = 'color, gem_type, mode');
+
+SELECT add_compression_policy('dedication_snapshots', INTERVAL '7 days');
+SELECT add_retention_policy('dedication_snapshots', INTERVAL '90 days');
+
+CREATE INDEX idx_dedication_snapshots_color_gemtype_mode
+    ON dedication_snapshots (color, gem_type, mode, time DESC);

--- a/internal/lab/analyzer.go
+++ b/internal/lab/analyzer.go
@@ -20,6 +20,7 @@ type Analyzer struct {
 	muTransfigure  sync.Mutex
 	muFont         sync.Mutex
 	muQuality      sync.Mutex
+	muDedication   sync.Mutex
 	muV2           sync.Mutex
 }
 
@@ -132,6 +133,76 @@ func (a *Analyzer) RunFont(ctx context.Context) error {
 		"safe", len(analysis.Safe),
 		"premium", len(analysis.Premium),
 		"jackpot", len(analysis.Jackpot),
+		"inserted", inserted,
+	)
+	a.throttler.Signal()
+	return nil
+}
+
+// RunDedication fetches the latest gem snapshot and computes Dedication lab EV
+// for corrupted 21/23 gems (both skills and transfigured pools).
+// It requires GemFeature data for risk-adjustment (sell probability, stability discount).
+// It is safe to call from multiple goroutines; concurrent runs are serialized.
+func (a *Analyzer) RunDedication(ctx context.Context) error {
+	a.muDedication.Lock()
+	defer a.muDedication.Unlock()
+
+	gems, snapTime, err := a.repo.LatestGemPrices(ctx)
+	if err != nil {
+		a.logger.Error("dedication: failed to load gem prices", "error", err)
+		return err
+	}
+	if len(gems) == 0 {
+		a.logger.Info("dedication: no gem snapshots available yet, skipping")
+		return nil
+	}
+
+	// Load gem features: try cache first, fall back to DB.
+	var features []GemFeature
+	if a.cache != nil {
+		features = a.cache.GemFeatures()
+	}
+	if len(features) == 0 {
+		features, err = a.repo.LatestGemFeatures(ctx, "", "", 50000)
+		if err != nil {
+			a.logger.Error("dedication: failed to load gem features", "error", err)
+			return err
+		}
+	}
+	// Dedication can still run without features — risk adjustments use defaults.
+
+	analysis := AnalyzeDedication(snapTime, gems, features)
+
+	// Combine both pools for DB persistence.
+	allResults := make([]DedicationResult, 0, len(analysis.Skills)+len(analysis.Transfigured))
+	allResults = append(allResults, analysis.Skills...)
+	allResults = append(allResults, analysis.Transfigured...)
+
+	inserted, err := a.repo.SaveDedicationResults(ctx, allResults)
+	if err != nil {
+		a.logger.Error("dedication: failed to save results", "error", err)
+		return err
+	}
+
+	if a.cache != nil {
+		a.cache.SetDedication(analysis)
+
+		// Also populate corrupted gem name caches for autocomplete.
+		skillNames, err := a.repo.CorruptedGemNamesAutocomplete(ctx, false, 1000)
+		if err != nil {
+			a.logger.Warn("dedication: failed to load corrupted skill gem names", "error", err)
+		}
+		transfiguredNames, err := a.repo.CorruptedGemNamesAutocomplete(ctx, true, 1000)
+		if err != nil {
+			a.logger.Warn("dedication: failed to load corrupted transfigured gem names", "error", err)
+		}
+		a.cache.SetCorruptedGemNames(skillNames, transfiguredNames)
+	}
+
+	a.logger.Info("dedication analysis complete",
+		"snapTime", snapTime,
+		"skills", len(analysis.Skills),
+		"transfigured", len(analysis.Transfigured),
 		"inserted", inserted,
 	)
 	a.throttler.Signal()

--- a/internal/lab/analyzer.go
+++ b/internal/lab/analyzer.go
@@ -188,13 +188,17 @@ func (a *Analyzer) RunDedication(ctx context.Context) error {
 		a.cache.SetDedication(analysis)
 
 		// Also populate corrupted gem name caches for autocomplete.
+		// Preserve the existing cached slice for any pool whose query fails — a
+		// transient DB error must not wipe a previously valid cache entry.
 		skillNames, err := a.repo.CorruptedGemNamesAutocomplete(ctx, false, 1000)
 		if err != nil {
 			a.logger.Warn("dedication: failed to load corrupted skill gem names", "error", err)
+			skillNames = a.cache.CorruptedGemNames(false)
 		}
 		transfiguredNames, err := a.repo.CorruptedGemNamesAutocomplete(ctx, true, 1000)
 		if err != nil {
 			a.logger.Warn("dedication: failed to load corrupted transfigured gem names", "error", err)
+			transfiguredNames = a.cache.CorruptedGemNames(true)
 		}
 		a.cache.SetCorruptedGemNames(skillNames, transfiguredNames)
 	}

--- a/internal/lab/cache.go
+++ b/internal/lab/cache.go
@@ -26,6 +26,12 @@ type Cache struct {
 	gcpPrice        float64
 	offeringTiming  json.RawMessage // pre-computed offering timing JSON
 
+	// Dedication lab analysis results.
+	dedicationSkills       []DedicationResult
+	dedicationTransfigured []DedicationResult
+	corruptedGemNames            []string // corrupted non-transfigured gem names, sorted
+	corruptedTransfiguredGemNames []string // corrupted transfigured gem names, sorted
+
 	// V2 pre-computed results. These three fields are populated together by
 	// Analyzer.RunV2 from the same snapshot time, but may be nil independently
 	// during startup or if a pipeline stage fails.
@@ -242,6 +248,80 @@ func (c *Cache) GemFeatures() []GemFeature {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.gemFeatures
+}
+
+// SetDedication replaces the cached Dedication analysis results for both pools.
+func (c *Cache) SetDedication(analysis DedicationAnalysis) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.dedicationSkills = analysis.Skills
+	c.dedicationTransfigured = analysis.Transfigured
+	c.lastUpdated = time.Now()
+}
+
+// Dedication returns the cached Dedication analysis (nil slices if empty).
+func (c *Cache) Dedication() DedicationAnalysis {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return DedicationAnalysis{
+		Skills:       c.dedicationSkills,
+		Transfigured: c.dedicationTransfigured,
+	}
+}
+
+// SetCorruptedGemNames stores autocomplete names for corrupted gem pools.
+func (c *Cache) SetCorruptedGemNames(skills, transfigured []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.corruptedGemNames = skills
+	c.corruptedTransfiguredGemNames = transfigured
+}
+
+// CorruptedGemNames returns cached corrupted gem names for the given pool type.
+func (c *Cache) CorruptedGemNames(isTransfigured bool) []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if isTransfigured {
+		return c.corruptedTransfiguredGemNames
+	}
+	return c.corruptedGemNames
+}
+
+// CorruptedGemNamesSearch returns corrupted gem names matching all query words (case-insensitive).
+// Runs entirely in memory. Returns up to limit results.
+func (c *Cache) CorruptedGemNamesSearch(query string, isTransfigured bool, limit int) []string {
+	c.mu.RLock()
+	var names []string
+	if isTransfigured {
+		names = c.corruptedTransfiguredGemNames
+	} else {
+		names = c.corruptedGemNames
+	}
+	c.mu.RUnlock()
+
+	if len(names) == 0 || query == "" {
+		return nil
+	}
+
+	words := strings.Fields(strings.ToLower(query))
+	var results []string
+	for _, name := range names {
+		lower := strings.ToLower(name)
+		match := true
+		for _, w := range words {
+			if !strings.Contains(lower, w) {
+				match = false
+				break
+			}
+		}
+		if match {
+			results = append(results, name)
+			if len(results) >= limit {
+				break
+			}
+		}
+	}
+	return results
 }
 
 // SetGemSignals replaces the cached gem signals.

--- a/internal/lab/classification.go
+++ b/internal/lab/classification.go
@@ -389,6 +389,199 @@ func computeCleanTierBoundaries(gems []GemPrice, lowConf map[string]bool, tops m
 	return result
 }
 
+// ComputeDedicationClassification runs the tier pipeline for Dedication
+// corrupted 21/23 gems. It uses isDedicationGem as its filter (instead of
+// isAnalyzableGem) and further constrains to the given pool type.
+// isTransfigured = false → skills pool, true → transfigured pool.
+func ComputeDedicationClassification(gems []GemPrice, isTransfigured bool) ClassificationResult {
+	// Pre-filter to only the relevant Dedication pool.
+	var filtered []GemPrice
+	for _, g := range gems {
+		if isDedicationGem(g) && g.Variant == "21/23c" && g.IsTransfigured == isTransfigured {
+			filtered = append(filtered, g)
+		}
+	}
+
+	// Run the same classification pipeline with a pass-through filter
+	// (all gems already meet the criteria after pre-filtering above).
+	return classifyWithFilter(filtered, func(g GemPrice) bool { return true })
+}
+
+// classifyWithFilter runs the classification pipeline using a custom filter
+// predicate instead of isAnalyzableGem. This allows reuse for both the standard
+// Font pipeline (isAnalyzableGem) and Dedication pipeline (isDedicationGem).
+func classifyWithFilter(gems []GemPrice, filter func(GemPrice) bool) ClassificationResult {
+	lowConf := detectLowConfidenceFiltered(gems, filter)
+	tops := detectTopsFiltered(gems, lowConf, filter)
+	boundaries := computeCleanTierBoundariesFiltered(gems, lowConf, tops, filter)
+
+	result := ClassificationResult{
+		Gems:        make(GemClassificationMap),
+		Boundaries:  boundaries,
+		TopBoundary: make(map[string]float64),
+	}
+
+	for _, g := range gems {
+		if !filter(g) || g.Chaos <= 5 {
+			continue
+		}
+		key := GemClassificationKey{g.Name, g.Variant}
+		gemKey := g.Name + "|" + g.Variant
+
+		isLowConf := lowConf[gemKey]
+
+		var tier string
+		if tops[gemKey] {
+			tier = "TOP"
+		} else if tb, ok := boundaries[g.Variant]; ok {
+			tier = classifyTier(g.Chaos, tb)
+			if isLowConf && len(tb.Boundaries) > 0 && g.Chaos > tb.Boundaries[0] {
+				tier = "CHAOTIC"
+			}
+		} else {
+			tier = "FLOOR"
+		}
+
+		result.Gems[key] = GemClassification{
+			Tier:          tier,
+			LowConfidence: isLowConf,
+		}
+	}
+
+	return result
+}
+
+// detectLowConfidenceFiltered is like detectLowConfidence but uses a custom filter.
+func detectLowConfidenceFiltered(gems []GemPrice, filter func(GemPrice) bool) map[string]bool {
+	type gemInfo struct {
+		name     string
+		variant  string
+		listings int
+	}
+	byVariant := make(map[string][]gemInfo)
+	for _, g := range gems {
+		if !filter(g) || g.Chaos <= 5 {
+			continue
+		}
+		byVariant[g.Variant] = append(byVariant[g.Variant], gemInfo{g.Name, g.Variant, g.Listings})
+	}
+
+	result := make(map[string]bool)
+	for variant, vGems := range byVariant {
+		listings := make([]float64, len(vGems))
+		for i, g := range vGems {
+			listings[i] = float64(g.listings)
+		}
+		sort.Float64s(listings)
+		median := listings[len(listings)/2]
+		if median <= 0 {
+			median = 1
+		}
+		for _, g := range vGems {
+			depth := float64(g.listings) / median
+			if depth < 0.4 {
+				result[g.name+"|"+variant] = true
+			}
+		}
+	}
+	return result
+}
+
+// detectTopsFiltered is like detectTops but uses a custom filter.
+func detectTopsFiltered(gems []GemPrice, lowConf map[string]bool, filter func(GemPrice) bool) map[string]bool {
+	byVariant := make(map[string][]GemPrice)
+	for _, g := range gems {
+		if !filter(g) || g.Chaos <= 5 {
+			continue
+		}
+		key := g.Name + "|" + g.Variant
+		if lowConf[key] {
+			continue
+		}
+		byVariant[g.Variant] = append(byVariant[g.Variant], g)
+	}
+
+	tops := make(map[string]bool)
+	for variant, vGems := range byVariant {
+		var prices []float64
+		for _, g := range vGems {
+			prices = append(prices, g.Chaos)
+		}
+		sort.Sort(sort.Reverse(sort.Float64Slice(prices)))
+
+		if len(prices) < 4 {
+			continue
+		}
+
+		topCap := len(prices) / 10
+		if topCap < 3 {
+			topCap = 3
+		}
+		if topCap >= len(prices) {
+			continue
+		}
+
+		topPoolSize := topCap
+		if topPoolSize > len(prices)-1 {
+			topPoolSize = len(prices) - 1
+		}
+		topTotalGap := prices[0] - prices[topPoolSize]
+		avgGap := topTotalGap / float64(topPoolSize)
+
+		foundTop := false
+		topEnd := 0
+
+		for i := 0; i < topCap && i < len(prices)-1; i++ {
+			gap := prices[i] - prices[i+1]
+			if gap >= avgGap*2 {
+				topEnd = i + 1
+				foundTop = true
+			} else if foundTop {
+				break
+			}
+		}
+
+		if !foundTop || topEnd < 1 {
+			continue
+		}
+
+		topBoundary := prices[topEnd-1]
+		for _, g := range vGems {
+			if g.Chaos >= topBoundary {
+				tops[g.Name+"|"+variant] = true
+			}
+		}
+	}
+	return tops
+}
+
+// computeCleanTierBoundariesFiltered is like computeCleanTierBoundaries but uses a custom filter.
+func computeCleanTierBoundariesFiltered(gems []GemPrice, lowConf map[string]bool, tops map[string]bool, filter func(GemPrice) bool) map[string]TierBoundaries {
+	byVariant := make(map[string][]float64)
+	for _, g := range gems {
+		if !filter(g) || g.Chaos <= 5 {
+			continue
+		}
+		key := g.Name + "|" + g.Variant
+		if lowConf[key] || tops[key] {
+			continue
+		}
+		byVariant[g.Variant] = append(byVariant[g.Variant], g.Chaos)
+	}
+
+	result := make(map[string]TierBoundaries)
+	for variant, prices := range byVariant {
+		sort.Float64s(prices)
+		for i, j := 0, len(prices)-1; i < j; i, j = i+1, j-1 {
+			prices[i], prices[j] = prices[j], prices[i]
+		}
+
+		floorBound := math.Max(computeTop5Avg(prices)*FloorTopRatio, 1)
+		result[variant] = computeVariantTiers(prices, floorBound)
+	}
+	return result
+}
+
 // ComputeGemClassification is the unified tier pipeline entry point.
 // Per variant independently:
 //  1. Low Confidence detection (thin-market gems, depth < 0.4)

--- a/internal/lab/classification_test.go
+++ b/internal/lab/classification_test.go
@@ -428,7 +428,7 @@ func TestComputeDedicationClassification_ExcludesSupports(t *testing.T) {
 	}
 
 	// Skill gems should be in classification.
-	for _, name := range []string{"Arc", "Fireball", "Cleave"} {
+	for _, name := range []string{"Arc", "Fireball", "Cleave", "Slam"} {
 		key := GemClassificationKey{name, "21/23c"}
 		if _, ok := cls.Gems[key]; !ok {
 			t.Errorf("skill gem %q should be in Dedication classification", name)
@@ -529,8 +529,9 @@ func TestComputeDedicationClassification_TierDistribution(t *testing.T) {
 		tierCounts[gc.Tier]++
 	}
 
-	// With 12 gems and clear price gaps, we should have at least 2 distinct tiers.
-	if len(tierCounts) < 2 {
-		t.Errorf("expected at least 2 distinct tiers, got %d: %v", len(tierCounts), tierCounts)
+	// With 12 gems and clear price gaps (3000/2500 then 800/700 then 300/250/200 then 100/80 then 20/15/10),
+	// we should have at least 3 distinct tiers.
+	if len(tierCounts) < 3 {
+		t.Errorf("expected at least 3 distinct tiers, got %d: %v", len(tierCounts), tierCounts)
 	}
 }

--- a/internal/lab/classification_test.go
+++ b/internal/lab/classification_test.go
@@ -322,3 +322,215 @@ func TestComputeGemClassification_Integration(t *testing.T) {
 		}
 	}
 }
+
+// --- Dedication Classification Tests ---
+
+func TestComputeDedicationClassification_SkillPool(t *testing.T) {
+	// Build a pool of corrupted non-transfigured 21/23c skill gems.
+	gems := []GemPrice{
+		{Name: "Expensive Gem", Variant: "21/23c", Chaos: 1500, Listings: 40, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "High Gem", Variant: "21/23c", Chaos: 800, Listings: 50, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Mid Gem 1", Variant: "21/23c", Chaos: 300, Listings: 60, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Mid Gem 2", Variant: "21/23c", Chaos: 250, Listings: 55, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Mid Gem 3", Variant: "21/23c", Chaos: 200, Listings: 70, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Low Gem 1", Variant: "21/23c", Chaos: 100, Listings: 80, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Low Gem 2", Variant: "21/23c", Chaos: 50, Listings: 90, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Floor Gem 1", Variant: "21/23c", Chaos: 20, Listings: 100, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Floor Gem 2", Variant: "21/23c", Chaos: 10, Listings: 120, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+	}
+
+	cls := ComputeDedicationClassification(gems, false)
+
+	// All gems that pass isDedicationGem + are not transfigured + chaos > 5 should be classified.
+	for _, g := range gems {
+		if g.Chaos <= 5 {
+			continue
+		}
+		key := GemClassificationKey{g.Name, g.Variant}
+		if _, ok := cls.Gems[key]; !ok {
+			t.Errorf("gem %s missing from Dedication classification", g.Name)
+		}
+	}
+
+	// Boundaries should exist for "21/23c" variant.
+	if _, ok := cls.Boundaries["21/23c"]; !ok {
+		t.Error("expected Boundaries for 21/23c variant")
+	}
+}
+
+func TestComputeDedicationClassification_TransfiguredPool(t *testing.T) {
+	gems := []GemPrice{
+		{Name: "Trans Expensive", Variant: "21/23c", Chaos: 1200, Listings: 35, IsCorrupted: true, IsTransfigured: true, GemColor: "BLUE"},
+		{Name: "Trans High", Variant: "21/23c", Chaos: 600, Listings: 45, IsCorrupted: true, IsTransfigured: true, GemColor: "BLUE"},
+		{Name: "Trans Mid", Variant: "21/23c", Chaos: 200, Listings: 55, IsCorrupted: true, IsTransfigured: true, GemColor: "BLUE"},
+		{Name: "Trans Low 1", Variant: "21/23c", Chaos: 80, Listings: 70, IsCorrupted: true, IsTransfigured: true, GemColor: "BLUE"},
+		{Name: "Trans Low 2", Variant: "21/23c", Chaos: 50, Listings: 85, IsCorrupted: true, IsTransfigured: true, GemColor: "BLUE"},
+		{Name: "Trans Floor", Variant: "21/23c", Chaos: 10, Listings: 100, IsCorrupted: true, IsTransfigured: true, GemColor: "BLUE"},
+	}
+
+	cls := ComputeDedicationClassification(gems, true)
+
+	for _, g := range gems {
+		if g.Chaos <= 5 {
+			continue
+		}
+		key := GemClassificationKey{g.Name, g.Variant}
+		gc, ok := cls.Gems[key]
+		if !ok {
+			t.Errorf("gem %s missing from Dedication transfigured classification", g.Name)
+			continue
+		}
+		// Every classified gem should have a non-empty tier.
+		if gc.Tier == "" {
+			t.Errorf("gem %s has empty tier", g.Name)
+		}
+	}
+}
+
+func TestComputeDedicationClassification_ExcludesNonCorrupted(t *testing.T) {
+	gems := []GemPrice{
+		// Non-corrupted gem should be excluded by isDedicationGem.
+		{Name: "Non Corrupted", Variant: "21/23c", Chaos: 500, Listings: 50, IsCorrupted: false, IsTransfigured: false, GemColor: "RED"},
+		// Valid dedication gem.
+		{Name: "Valid Gem 1", Variant: "21/23c", Chaos: 300, Listings: 60, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Valid Gem 2", Variant: "21/23c", Chaos: 200, Listings: 70, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Valid Gem 3", Variant: "21/23c", Chaos: 100, Listings: 80, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Valid Gem 4", Variant: "21/23c", Chaos: 50, Listings: 90, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+	}
+
+	cls := ComputeDedicationClassification(gems, false)
+
+	// Non-corrupted gem should NOT be in classification.
+	key := GemClassificationKey{"Non Corrupted", "21/23c"}
+	if _, ok := cls.Gems[key]; ok {
+		t.Error("non-corrupted gem should not be in Dedication classification")
+	}
+}
+
+func TestComputeDedicationClassification_ExcludesSupports(t *testing.T) {
+	gems := []GemPrice{
+		{Name: "Lifetap Support", Variant: "21/23c", Chaos: 500, Listings: 50, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Empower Support", Variant: "21/23c", Chaos: 800, Listings: 40, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Arc", Variant: "21/23c", Chaos: 300, Listings: 60, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Fireball", Variant: "21/23c", Chaos: 200, Listings: 70, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Cleave", Variant: "21/23c", Chaos: 100, Listings: 80, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Slam", Variant: "21/23c", Chaos: 50, Listings: 90, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+	}
+
+	cls := ComputeDedicationClassification(gems, false)
+
+	// Support gems should NOT be in classification.
+	for _, name := range []string{"Lifetap Support", "Empower Support"} {
+		key := GemClassificationKey{name, "21/23c"}
+		if _, ok := cls.Gems[key]; ok {
+			t.Errorf("support gem %q should not be in Dedication classification", name)
+		}
+	}
+
+	// Skill gems should be in classification.
+	for _, name := range []string{"Arc", "Fireball", "Cleave"} {
+		key := GemClassificationKey{name, "21/23c"}
+		if _, ok := cls.Gems[key]; !ok {
+			t.Errorf("skill gem %q should be in Dedication classification", name)
+		}
+	}
+}
+
+func TestComputeDedicationClassification_ExcludesTrarthus(t *testing.T) {
+	gems := []GemPrice{
+		{Name: "Trarthus Ire", Variant: "21/23c", Chaos: 5000, Listings: 30, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Arc", Variant: "21/23c", Chaos: 300, Listings: 60, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Fireball", Variant: "21/23c", Chaos: 200, Listings: 70, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Cleave", Variant: "21/23c", Chaos: 100, Listings: 80, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Slam", Variant: "21/23c", Chaos: 50, Listings: 90, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+	}
+
+	cls := ComputeDedicationClassification(gems, false)
+
+	key := GemClassificationKey{"Trarthus Ire", "21/23c"}
+	if _, ok := cls.Gems[key]; ok {
+		t.Error("Trarthus should not be in Dedication classification")
+	}
+}
+
+func TestComputeDedicationClassification_PoolIsolation(t *testing.T) {
+	// Both skill and transfigured gems present. Classification for skills
+	// should NOT include transfigured gems and vice versa.
+	gems := []GemPrice{
+		// Skills
+		{Name: "Arc", Variant: "21/23c", Chaos: 300, Listings: 60, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Fireball", Variant: "21/23c", Chaos: 200, Listings: 70, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Cleave", Variant: "21/23c", Chaos: 100, Listings: 80, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Slam", Variant: "21/23c", Chaos: 50, Listings: 90, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		// Transfigured
+		{Name: "Arc of Surging", Variant: "21/23c", Chaos: 800, Listings: 35, IsCorrupted: true, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Fireball of Volatility", Variant: "21/23c", Chaos: 600, Listings: 45, IsCorrupted: true, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Cleave of Rage", Variant: "21/23c", Chaos: 400, Listings: 55, IsCorrupted: true, IsTransfigured: true, GemColor: "RED"},
+		{Name: "Slam of Magnitude", Variant: "21/23c", Chaos: 250, Listings: 65, IsCorrupted: true, IsTransfigured: true, GemColor: "RED"},
+	}
+
+	skillCls := ComputeDedicationClassification(gems, false)
+	transCls := ComputeDedicationClassification(gems, true)
+
+	// Skills classification should contain only non-transfigured gems.
+	for _, name := range []string{"Arc of Surging", "Fireball of Volatility", "Cleave of Rage", "Slam of Magnitude"} {
+		key := GemClassificationKey{name, "21/23c"}
+		if _, ok := skillCls.Gems[key]; ok {
+			t.Errorf("transfigured gem %q should not be in skills classification", name)
+		}
+	}
+
+	// Transfigured classification should contain only transfigured gems.
+	for _, name := range []string{"Arc", "Fireball", "Cleave"} {
+		key := GemClassificationKey{name, "21/23c"}
+		if _, ok := transCls.Gems[key]; ok {
+			t.Errorf("non-transfigured gem %q should not be in transfigured classification", name)
+		}
+	}
+}
+
+func TestComputeDedicationClassification_TierDistribution(t *testing.T) {
+	// Create a pool with clear tier separation.
+	gems := []GemPrice{
+		{Name: "Top 1", Variant: "21/23c", Chaos: 3000, Listings: 40, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Top 2", Variant: "21/23c", Chaos: 2500, Listings: 35, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "High 1", Variant: "21/23c", Chaos: 800, Listings: 60, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "High 2", Variant: "21/23c", Chaos: 700, Listings: 55, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Mid 1", Variant: "21/23c", Chaos: 300, Listings: 70, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Mid 2", Variant: "21/23c", Chaos: 250, Listings: 65, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Mid 3", Variant: "21/23c", Chaos: 200, Listings: 80, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Low 1", Variant: "21/23c", Chaos: 100, Listings: 90, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Low 2", Variant: "21/23c", Chaos: 80, Listings: 85, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Floor 1", Variant: "21/23c", Chaos: 20, Listings: 100, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Floor 2", Variant: "21/23c", Chaos: 15, Listings: 110, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+		{Name: "Floor 3", Variant: "21/23c", Chaos: 10, Listings: 120, IsCorrupted: true, IsTransfigured: false, GemColor: "RED"},
+	}
+
+	cls := ComputeDedicationClassification(gems, false)
+
+	// Verify valid tiers are assigned.
+	validTiers := map[string]bool{
+		"TOP": true, "HIGH": true, "MID-HIGH": true,
+		"MID": true, "LOW": true, "FLOOR": true, "CHAOTIC": true,
+	}
+	tierCounts := make(map[string]int)
+	for _, g := range gems {
+		if g.Chaos <= 5 {
+			continue
+		}
+		key := GemClassificationKey{g.Name, g.Variant}
+		gc, ok := cls.Gems[key]
+		if !ok {
+			continue
+		}
+		if !validTiers[gc.Tier] {
+			t.Errorf("gem %s has invalid tier %q", g.Name, gc.Tier)
+		}
+		tierCounts[gc.Tier]++
+	}
+
+	// With 12 gems and clear price gaps, we should have at least 2 distinct tiers.
+	if len(tierCounts) < 2 {
+		t.Errorf("expected at least 2 distinct tiers, got %d: %v", len(tierCounts), tierCounts)
+	}
+}

--- a/internal/lab/collective.go
+++ b/internal/lab/collective.go
@@ -2,6 +2,7 @@ package lab
 
 import (
 	"sort"
+	"strings"
 )
 
 // CollectiveResult is a cross-analyzer "what to farm now" entry combining
@@ -427,3 +428,131 @@ func BuildCompareResults(
 	return results
 }
 
+// BuildDedicationCompareResults builds compare results for Dedication lab mode.
+// Each gem is scored against the corrupted 21/23c pool. The pool type (skill vs
+// transfigured) is auto-detected from the gem name: names containing " of " are
+// transfigured, others are non-transfigured skills.
+// dedicationResults provides per-color input costs and pool context.
+func BuildDedicationCompareResults(
+	names []string,
+	gemPrices []GemPrice,
+	dedicationResults []DedicationResult,
+	sparklines map[string][]SparklinePoint,
+) []CompareResult {
+	// Index gem prices by name. For corrupted 21/23c there should be at most one
+	// entry per name, but if duplicates exist we keep the last (highest chaos).
+	priceIndex := make(map[string]*GemPrice, len(gemPrices))
+	for i := range gemPrices {
+		g := &gemPrices[i]
+		priceIndex[g.Name] = g
+	}
+
+	// Index Dedication results by (color, gemType) for input cost lookup.
+	// Use the first mode encountered as the baseline — input cost is the same
+	// across all modes (safe/premium/jackpot).
+	type dedKey struct{ color, gemType string }
+	inputCosts := make(map[dedKey]float64)
+	for _, dr := range dedicationResults {
+		k := dedKey{dr.Color, dr.GemType}
+		if _, exists := inputCosts[k]; !exists {
+			inputCosts[k] = dr.InputCost
+		}
+	}
+
+	var results []CompareResult
+
+	for _, name := range names {
+		cr := CompareResult{
+			TransfiguredName: name,
+			Variant:          "21/23c",
+			Signal:           "STABLE",
+			Confidence:       "LOW",
+		}
+
+		// Auto-detect pool type from gem name.
+		isTransfigured := strings.Contains(name, " of ")
+		gemType := "skill"
+		if isTransfigured {
+			gemType = "transfigured"
+		}
+
+		g, found := priceIndex[name]
+		if found {
+			cr.GemColor = g.GemColor
+			cr.TransfiguredPrice = g.Chaos
+			cr.TransListings = g.Listings
+
+			// Confidence based on listings.
+			switch {
+			case g.Listings >= 5:
+				cr.Confidence = "HIGH"
+			case g.Listings >= 2:
+				cr.Confidence = "MEDIUM"
+			default:
+				cr.Confidence = "LOW"
+			}
+
+			// Look up the input cost for this color/pool.
+			inputCost := inputCosts[dedKey{g.GemColor, gemType}]
+			cr.BasePrice = inputCost
+			cr.BaseName = gemType // "skill" or "transfigured" (pool label, not a specific base gem)
+
+			if inputCost > 0 {
+				cr.ROI = g.Chaos - inputCost
+				cr.ROIPct = (cr.ROI / inputCost) * 100
+			} else {
+				cr.ROI = g.Chaos
+			}
+		}
+
+		// Attach sparkline.
+		if pts, ok := sparklines[name]; ok {
+			cr.Sparkline = pts
+		}
+		if cr.Sparkline == nil {
+			cr.Sparkline = []SparklinePoint{}
+		}
+
+		results = append(results, cr)
+	}
+
+	// Assign recommendations based on ROI ranking.
+	if len(results) > 0 {
+		type ranked struct {
+			idx   int
+			score float64
+		}
+		ranks := make([]ranked, len(results))
+		for i, cr := range results {
+			// For Dedication, weight by ROI and confidence.
+			confMultiplier := 0.5
+			switch cr.Confidence {
+			case "HIGH":
+				confMultiplier = 1.0
+			case "MEDIUM":
+				confMultiplier = 0.75
+			}
+			score := cr.ROI * confMultiplier
+			ranks[i] = ranked{idx: i, score: score}
+			results[i].WeightedROI = score
+		}
+		sort.Slice(ranks, func(i, j int) bool {
+			return ranks[i].score > ranks[j].score
+		})
+
+		for pos, r := range ranks {
+			cr := results[r.idx]
+			if cr.Confidence == "LOW" && cr.TransListings < 2 {
+				results[r.idx].Recommendation = "AVOID"
+			} else if cr.ROI < 0 {
+				results[r.idx].Recommendation = "AVOID"
+			} else if pos == 0 {
+				results[r.idx].Recommendation = "BEST"
+			} else {
+				results[r.idx].Recommendation = "OK"
+			}
+		}
+	}
+
+	return results
+}

--- a/internal/lab/collective.go
+++ b/internal/lab/collective.go
@@ -74,6 +74,7 @@ type CompareResult struct {
 	TransListings        int              `json:"transListings"`
 	// Risk-adjusted display fields (from features/signals)
 	WeightedROI          float64 `json:"weightedRoi"`
+	WeightedROIPct       float64 `json:"weightedRoiPct"`
 	Low7Days                float64 `json:"low7d"`
 	High7Days               float64 `json:"high7d"`
 	SellConfidence       string  `json:"sellConfidence"`
@@ -403,6 +404,7 @@ func BuildCompareResults(
 			score := cr.ROI * w * (sell / 100)
 			ranks[i] = ranked{idx: i, score: score}
 			results[i].WeightedROI = score
+			results[i].WeightedROIPct = cr.ROIPct * w * (sell / 100)
 		}
 		sort.Slice(ranks, func(i, j int) bool {
 			return ranks[i].score > ranks[j].score
@@ -535,6 +537,7 @@ func BuildDedicationCompareResults(
 			score := cr.ROI * confMultiplier
 			ranks[i] = ranked{idx: i, score: score}
 			results[i].WeightedROI = score
+			results[i].WeightedROIPct = cr.ROIPct * confMultiplier
 		}
 		sort.Slice(ranks, func(i, j int) bool {
 			return ranks[i].score > ranks[j].score

--- a/internal/lab/dedication.go
+++ b/internal/lab/dedication.go
@@ -43,25 +43,23 @@ func isDedicationGem(g GemPrice) bool {
 	return g.IsCorrupted && !strings.Contains(g.Name, "Support") && !strings.Contains(g.Name, "Trarthus")
 }
 
-// dedicationInputCost computes the average chaos of the 10 cheapest gems in the pool.
-// If the pool has fewer than 10 gems, averages all of them.
-func dedicationInputCost(gems []GemPrice) float64 {
-	if len(gems) == 0 {
+// dedicationInputCostFromPrices computes the average of the 10 cheapest prices in the pool.
+// If the pool has fewer than 10 entries, averages all of them.
+func dedicationInputCostFromPrices(prices []float64) float64 {
+	if len(prices) == 0 {
 		return 0
 	}
-	prices := make([]float64, len(gems))
-	for i, g := range gems {
-		prices[i] = g.Chaos
-	}
-	sort.Float64s(prices)
+	sorted := make([]float64, len(prices))
+	copy(sorted, prices)
+	sort.Float64s(sorted)
 
 	n := 10
-	if n > len(prices) {
-		n = len(prices)
+	if n > len(sorted) {
+		n = len(sorted)
 	}
 	sum := 0.0
 	for i := 0; i < n; i++ {
-		sum += prices[i]
+		sum += sorted[i]
 	}
 	return sum / float64(n)
 }
@@ -91,7 +89,6 @@ func AnalyzeDedication(snapTime time.Time, gems []GemPrice, features []GemFeatur
 	}
 	poolNames := make(map[poolKey]map[string]struct{})
 	poolGems := make(map[poolKey][]gemEntry)
-	poolRawGems := make(map[poolKey][]GemPrice)
 
 	colors := []string{"RED", "GREEN", "BLUE"}
 	gemTypes := []string{"skill", "transfigured"}
@@ -127,7 +124,12 @@ func AnalyzeDedication(snapTime time.Time, gems []GemPrice, features []GemFeatur
 			chaos:    g.Chaos,
 			listings: g.Listings,
 		})
-		poolRawGems[k] = append(poolRawGems[k], g)
+	}
+
+	// Precompute classification once per pool type (not once per color).
+	classificationByType := map[string]ClassificationResult{
+		"skill":        ComputeDedicationClassification(gems, false),
+		"transfigured": ComputeDedicationClassification(gems, true),
 	}
 
 	var analysis DedicationAnalysis
@@ -142,10 +144,14 @@ func AnalyzeDedication(snapTime time.Time, gems []GemPrice, features []GemFeatur
 				continue
 			}
 
-			inputCost := dedicationInputCost(poolRawGems[k])
+			poolPrices := make([]float64, len(entries))
+			for i, e := range entries {
+				poolPrices[i] = e.chaos
+			}
+			inputCost := dedicationInputCostFromPrices(poolPrices)
 
-			// Compute classification for this pool.
-			classification := ComputeDedicationClassification(gems, gemType == "transfigured")
+			// Use precomputed classification for this pool type.
+			classification := classificationByType[gemType]
 
 			// Count winners and thin-market gems for each mode.
 			var safeWinnerCount, premiumWinnerCount, jackpotWinnerCount int

--- a/internal/lab/dedication.go
+++ b/internal/lab/dedication.go
@@ -233,13 +233,23 @@ func AnalyzeDedication(snapTime time.Time, gems []GemPrice, features []GemFeatur
 				}
 			}
 
-			// Build pool value arrays — one value per pool gem name.
+			// Build pool value arrays — only for gems that passed the low-confidence
+			// filter (i.e. have an entry in gemAdjustedPrice). Low-confidence gems
+			// were skipped above so their map lookup would return 0, inflating pool
+			// size and deflating EV.
 			poolValues := make([]float64, 0, pool)
 			poolValuesRaw := make([]float64, 0, pool)
 			for name := range names {
-				poolValues = append(poolValues, gemAdjustedPrice[name])
-				poolValuesRaw = append(poolValuesRaw, gemRawPrice[name])
+				if adj, ok := gemAdjustedPrice[name]; ok {
+					poolValues = append(poolValues, adj)
+				}
+				if raw, ok := gemRawPrice[name]; ok {
+					poolValuesRaw = append(poolValuesRaw, raw)
+				}
 			}
+			// confidencePool is the effective pool size after excluding low-confidence
+			// gems; pWin3Picks must use this count, not len(names).
+			confidencePool := len(poolValues)
 
 			// Sort descending for expectedBestOf3.
 			sort.Float64s(poolValues)
@@ -303,7 +313,7 @@ func AnalyzeDedication(snapTime time.Time, gems []GemPrice, features []GemFeatur
 			}
 
 			// Safe mode result.
-			safePWin := pWin3Picks(safeWinnerCount, pool)
+			safePWin := pWin3Picks(safeWinnerCount, confidencePool)
 			var safeAvgWin, safeAvgWinRaw float64
 			if safeWinnerCount > 0 {
 				safeAvgWin = safeWinnerSum / float64(safeWinnerCount)
@@ -317,7 +327,7 @@ func AnalyzeDedication(snapTime time.Time, gems []GemPrice, features []GemFeatur
 				Time:              snapTime,
 				Color:             color,
 				GemType:           gemType,
-				Pool:              pool,
+				Pool:              confidencePool,
 				Winners:           safeWinnerCount,
 				PWin:              safePWin,
 				AvgWin:            safeAvgWin,
@@ -335,7 +345,7 @@ func AnalyzeDedication(snapTime time.Time, gems []GemPrice, features []GemFeatur
 			}
 
 			// Premium mode result.
-			premiumPWin := pWin3Picks(premiumWinnerCount, pool)
+			premiumPWin := pWin3Picks(premiumWinnerCount, confidencePool)
 			var premiumAvgWin, premiumAvgWinRaw float64
 			if premiumWinnerCount > 0 {
 				premiumAvgWin = premiumWinnerSum / float64(premiumWinnerCount)
@@ -349,7 +359,7 @@ func AnalyzeDedication(snapTime time.Time, gems []GemPrice, features []GemFeatur
 				Time:          snapTime,
 				Color:         color,
 				GemType:       gemType,
-				Pool:          pool,
+				Pool:          confidencePool,
 				Winners:       premiumWinnerCount,
 				PWin:          premiumPWin,
 				AvgWin:        premiumAvgWin,
@@ -365,7 +375,7 @@ func AnalyzeDedication(snapTime time.Time, gems []GemPrice, features []GemFeatur
 			}
 
 			// Jackpot mode result.
-			jackpotPWin := pWin3Picks(jackpotWinnerCount, pool)
+			jackpotPWin := pWin3Picks(jackpotWinnerCount, confidencePool)
 			var jackpotAvgWin, jackpotAvgWinRaw float64
 			if jackpotWinnerCount > 0 {
 				jackpotAvgWin = jackpotWinnerSum / float64(jackpotWinnerCount)
@@ -379,7 +389,7 @@ func AnalyzeDedication(snapTime time.Time, gems []GemPrice, features []GemFeatur
 				Time:          snapTime,
 				Color:         color,
 				GemType:       gemType,
-				Pool:          pool,
+				Pool:          confidencePool,
 				Winners:       jackpotWinnerCount,
 				PWin:          jackpotPWin,
 				AvgWin:        jackpotAvgWin,

--- a/internal/lab/dedication.go
+++ b/internal/lab/dedication.go
@@ -1,0 +1,401 @@
+package lab
+
+import (
+	"math"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DedicationResult holds the computed EV for a single (color, gemType) Dedication lab analysis.
+// GemType is "skill" (non-transfigured corrupted 21/23) or "transfigured" (transfigured corrupted 21/23).
+type DedicationResult struct {
+	Time              time.Time
+	Color             string  // RED, GREEN, BLUE
+	GemType           string  // "skill" or "transfigured"
+	Pool              int     // total unique gem names of that color in the pool
+	Winners           int     // count of tier-qualifying gems
+	PWin              float64 // probability of seeing at least 1 winner in 3 picks
+	AvgWin            float64 // average risk-adjusted value when you hit
+	AvgWinRaw         float64 // average RAW listed price when you hit
+	EV                float64 // expected income per font (risk-adjusted)
+	EVRaw             float64 // expected income per font using raw listed prices
+	InputCost         float64 // avg of 10 cheapest per color per pool
+	Profit            float64 // EVRaw - InputCost
+	FontsToHit        float64          // expected fonts until hitting a winner (1/pWin)
+	JackpotGems       []JackpotGemInfo // TOP gem names+prices (only for jackpot mode)
+	Mode              string           // "safe", "premium", or "jackpot"
+	ThinPoolGems      int              // count of winners with < 5 listings
+	LiquidityRisk     string           // "LOW", "MEDIUM", "HIGH"
+	PoolBreakdown     []TierPoolInfo         `json:"poolBreakdown,omitempty"`
+	LowConfidenceGems []LowConfidenceGemInfo `json:"lowConfidenceGems,omitempty"`
+}
+
+// DedicationAnalysis holds the results of Dedication lab analysis for both pools.
+type DedicationAnalysis struct {
+	Skills       []DedicationResult
+	Transfigured []DedicationResult
+}
+
+// isDedicationGem returns true if the gem belongs to the Dedication corrupted 21/23 pool:
+// corrupted, not a support gem, not Trarthus.
+func isDedicationGem(g GemPrice) bool {
+	return g.IsCorrupted && !strings.Contains(g.Name, "Support") && !strings.Contains(g.Name, "Trarthus")
+}
+
+// dedicationInputCost computes the average chaos of the 10 cheapest gems in the pool.
+// If the pool has fewer than 10 gems, averages all of them.
+func dedicationInputCost(gems []GemPrice) float64 {
+	if len(gems) == 0 {
+		return 0
+	}
+	prices := make([]float64, len(gems))
+	for i, g := range gems {
+		prices[i] = g.Chaos
+	}
+	sort.Float64s(prices)
+
+	n := 10
+	if n > len(prices) {
+		n = len(prices)
+	}
+	sum := 0.0
+	for i := 0; i < n; i++ {
+		sum += prices[i]
+	}
+	return sum / float64(n)
+}
+
+// AnalyzeDedication computes Dedication lab EV per (color, gemType) in three modes.
+// The gems slice must be the full latest snapshot. Features are used for risk-adjustment.
+func AnalyzeDedication(snapTime time.Time, gems []GemPrice, features []GemFeature) DedicationAnalysis {
+	// Build feature lookup: "name|variant" -> *GemFeature
+	type featureKey struct{ name, variant string }
+	featureLookup := make(map[featureKey]*GemFeature, len(features))
+	for i := range features {
+		f := &features[i]
+		featureLookup[featureKey{f.Name, f.Variant}] = f
+	}
+
+	// Separate dedication gems into two pools by color.
+	type gemEntry struct {
+		name     string
+		chaos    float64
+		listings int
+	}
+
+	// Pool: unique gem names per color per pool type (for pool size counting).
+	type poolKey struct {
+		color   string
+		gemType string
+	}
+	poolNames := make(map[poolKey]map[string]struct{})
+	poolGems := make(map[poolKey][]gemEntry)
+	poolRawGems := make(map[poolKey][]GemPrice)
+
+	colors := []string{"RED", "GREEN", "BLUE"}
+	gemTypes := []string{"skill", "transfigured"}
+
+	for _, c := range colors {
+		for _, gt := range gemTypes {
+			k := poolKey{c, gt}
+			poolNames[k] = make(map[string]struct{})
+		}
+	}
+
+	for _, g := range gems {
+		if !isDedicationGem(g) {
+			continue
+		}
+		if g.Variant != "21/23c" {
+			continue
+		}
+		color := g.GemColor
+		if color != "RED" && color != "GREEN" && color != "BLUE" {
+			continue
+		}
+
+		gt := "skill"
+		if g.IsTransfigured {
+			gt = "transfigured"
+		}
+		k := poolKey{color, gt}
+
+		poolNames[k][g.Name] = struct{}{}
+		poolGems[k] = append(poolGems[k], gemEntry{
+			name:     g.Name,
+			chaos:    g.Chaos,
+			listings: g.Listings,
+		})
+		poolRawGems[k] = append(poolRawGems[k], g)
+	}
+
+	var analysis DedicationAnalysis
+
+	for _, color := range colors {
+		for _, gemType := range gemTypes {
+			k := poolKey{color, gemType}
+			names := poolNames[k]
+			entries := poolGems[k]
+			pool := len(names)
+			if pool == 0 {
+				continue
+			}
+
+			inputCost := dedicationInputCost(poolRawGems[k])
+
+			// Compute classification for this pool.
+			classification := ComputeDedicationClassification(gems, gemType == "transfigured")
+
+			// Count winners and thin-market gems for each mode.
+			var safeWinnerCount, premiumWinnerCount, jackpotWinnerCount int
+			var safeThinCount, premiumThinCount, jackpotThinCount int
+			var jackpotGems []JackpotGemInfo
+			var lowConfGems []LowConfidenceGemInfo
+
+			tierStats := make(map[string]*TierPoolInfo)
+			gemAdjustedPrice := make(map[string]float64)
+			gemRawPrice := make(map[string]float64)
+
+			for _, e := range entries {
+				feat := featureLookup[featureKey{e.name, "21/23c"}]
+
+				// Get classification from the dedication-specific classification.
+				classKey := GemClassificationKey{e.name, "21/23c"}
+				gc, hasClass := classification.Gems[classKey]
+
+				if gc.LowConfidence {
+					lowConfGems = append(lowConfGems, LowConfidenceGemInfo{
+						Name: e.name, Chaos: e.chaos, Listings: e.listings,
+					})
+					continue
+				}
+
+				tier := "FLOOR"
+				if hasClass {
+					tier = gc.Tier
+				}
+
+				// Risk-adjusted price.
+				var sellProb, stabDisc float64
+				if feat != nil {
+					sellProb = sellProbabilityFactor(e.listings, feat.Low7Days, e.chaos)
+					stabDisc = stabilityDiscount(feat.CVShort)
+				} else {
+					// No feature data — use reasonable defaults for corrupted gems.
+					sellProb = sellProbabilityFactor(e.listings, 0, e.chaos)
+					stabDisc = 1.0
+				}
+				adjustedPrice := e.chaos * sellProb * stabDisc
+				gemAdjustedPrice[e.name] = adjustedPrice
+				gemRawPrice[e.name] = e.chaos
+
+				isThin := e.listings < 5
+
+				// Track pool breakdown per tier.
+				ts, ok := tierStats[tier]
+				if !ok {
+					ts = &TierPoolInfo{Tier: tier, MinPrice: e.chaos, MaxPrice: e.chaos}
+					tierStats[tier] = ts
+				}
+				ts.Count++
+				if e.chaos < ts.MinPrice {
+					ts.MinPrice = e.chaos
+				}
+				if e.chaos > ts.MaxPrice {
+					ts.MaxPrice = e.chaos
+				}
+
+				if isSafeTierWinner(tier) {
+					safeWinnerCount++
+					if isThin {
+						safeThinCount++
+					}
+				}
+				if isPremiumTierWinner(tier) {
+					premiumWinnerCount++
+					if isThin {
+						premiumThinCount++
+					}
+				}
+				if isJackpotTierWinner(tier) {
+					jackpotWinnerCount++
+					jackpotGems = append(jackpotGems, JackpotGemInfo{Name: e.name, Chaos: e.chaos})
+					if isThin {
+						jackpotThinCount++
+					}
+				}
+			}
+
+			// Build pool value arrays — one value per pool gem name.
+			poolValues := make([]float64, 0, pool)
+			poolValuesRaw := make([]float64, 0, pool)
+			for name := range names {
+				poolValues = append(poolValues, gemAdjustedPrice[name])
+				poolValuesRaw = append(poolValuesRaw, gemRawPrice[name])
+			}
+
+			// Sort descending for expectedBestOf3.
+			sort.Float64s(poolValues)
+			for i, j := 0, len(poolValues)-1; i < j; i, j = i+1, j-1 {
+				poolValues[i], poolValues[j] = poolValues[j], poolValues[i]
+			}
+			sort.Float64s(poolValuesRaw)
+			for i, j := 0, len(poolValuesRaw)-1; i < j; i, j = i+1, j-1 {
+				poolValuesRaw[i], poolValuesRaw[j] = poolValuesRaw[j], poolValuesRaw[i]
+			}
+
+			ev := expectedBestOf3(poolValues)
+			evRaw := expectedBestOf3(poolValuesRaw)
+			profit := evRaw - inputCost
+
+			// Per-mode average winner value.
+			var safeWinnerSum, premiumWinnerSum, jackpotWinnerSum float64
+			var safeWinnerRawSum, premiumWinnerRawSum, jackpotWinnerRawSum float64
+			for _, e := range entries {
+				classKey := GemClassificationKey{e.name, "21/23c"}
+				gc := classification.Gems[classKey]
+				if gc.LowConfidence {
+					continue
+				}
+
+				feat := featureLookup[featureKey{e.name, "21/23c"}]
+				var sellProb, stabDisc float64
+				if feat != nil {
+					sellProb = sellProbabilityFactor(e.listings, feat.Low7Days, e.chaos)
+					stabDisc = stabilityDiscount(feat.CVShort)
+				} else {
+					sellProb = sellProbabilityFactor(e.listings, 0, e.chaos)
+					stabDisc = 1.0
+				}
+				adjPrice := e.chaos * sellProb * stabDisc
+				tier := gc.Tier
+
+				if isSafeTierWinner(tier) {
+					safeWinnerSum += adjPrice
+					safeWinnerRawSum += e.chaos
+				}
+				if isPremiumTierWinner(tier) {
+					premiumWinnerSum += adjPrice
+					premiumWinnerRawSum += e.chaos
+				}
+				if isJackpotTierWinner(tier) {
+					jackpotWinnerSum += adjPrice
+					jackpotWinnerRawSum += e.chaos
+				}
+			}
+
+			// Build sorted pool breakdown (TOP -> FLOOR).
+			tierOrder := []string{"TOP", "HIGH", "MID-HIGH", "MID", "LOW", "FLOOR"}
+			var poolBreakdown []TierPoolInfo
+			for _, tier := range tierOrder {
+				if ts, ok := tierStats[tier]; ok {
+					ts.MinPrice = math.Round(ts.MinPrice)
+					ts.MaxPrice = math.Round(ts.MaxPrice)
+					poolBreakdown = append(poolBreakdown, *ts)
+				}
+			}
+
+			// Safe mode result.
+			safePWin := pWin3Picks(safeWinnerCount, pool)
+			var safeAvgWin, safeAvgWinRaw float64
+			if safeWinnerCount > 0 {
+				safeAvgWin = safeWinnerSum / float64(safeWinnerCount)
+				safeAvgWinRaw = safeWinnerRawSum / float64(safeWinnerCount)
+			}
+			var safeFontsToHit float64
+			if safePWin > 0 {
+				safeFontsToHit = 1.0 / safePWin
+			}
+			safeResult := DedicationResult{
+				Time:              snapTime,
+				Color:             color,
+				GemType:           gemType,
+				Pool:              pool,
+				Winners:           safeWinnerCount,
+				PWin:              safePWin,
+				AvgWin:            safeAvgWin,
+				AvgWinRaw:         safeAvgWinRaw,
+				EV:                ev,
+				EVRaw:             evRaw,
+				InputCost:         inputCost,
+				Profit:            profit,
+				FontsToHit:        safeFontsToHit,
+				Mode:              "safe",
+				ThinPoolGems:      safeThinCount,
+				LiquidityRisk:     computeLiquidityRisk(safeThinCount, safeWinnerCount),
+				PoolBreakdown:     poolBreakdown,
+				LowConfidenceGems: lowConfGems,
+			}
+
+			// Premium mode result.
+			premiumPWin := pWin3Picks(premiumWinnerCount, pool)
+			var premiumAvgWin, premiumAvgWinRaw float64
+			if premiumWinnerCount > 0 {
+				premiumAvgWin = premiumWinnerSum / float64(premiumWinnerCount)
+				premiumAvgWinRaw = premiumWinnerRawSum / float64(premiumWinnerCount)
+			}
+			var premiumFontsToHit float64
+			if premiumPWin > 0 {
+				premiumFontsToHit = 1.0 / premiumPWin
+			}
+			premiumResult := DedicationResult{
+				Time:          snapTime,
+				Color:         color,
+				GemType:       gemType,
+				Pool:          pool,
+				Winners:       premiumWinnerCount,
+				PWin:          premiumPWin,
+				AvgWin:        premiumAvgWin,
+				AvgWinRaw:     premiumAvgWinRaw,
+				EV:            ev,
+				EVRaw:         evRaw,
+				InputCost:     inputCost,
+				Profit:        profit,
+				FontsToHit:    premiumFontsToHit,
+				Mode:          "premium",
+				ThinPoolGems:  premiumThinCount,
+				LiquidityRisk: computeLiquidityRisk(premiumThinCount, premiumWinnerCount),
+			}
+
+			// Jackpot mode result.
+			jackpotPWin := pWin3Picks(jackpotWinnerCount, pool)
+			var jackpotAvgWin, jackpotAvgWinRaw float64
+			if jackpotWinnerCount > 0 {
+				jackpotAvgWin = jackpotWinnerSum / float64(jackpotWinnerCount)
+				jackpotAvgWinRaw = jackpotWinnerRawSum / float64(jackpotWinnerCount)
+			}
+			var jackpotFontsToHit float64
+			if jackpotPWin > 0 {
+				jackpotFontsToHit = 1.0 / jackpotPWin
+			}
+			jackpotResult := DedicationResult{
+				Time:          snapTime,
+				Color:         color,
+				GemType:       gemType,
+				Pool:          pool,
+				Winners:       jackpotWinnerCount,
+				PWin:          jackpotPWin,
+				AvgWin:        jackpotAvgWin,
+				AvgWinRaw:     jackpotAvgWinRaw,
+				EV:            ev,
+				EVRaw:         evRaw,
+				InputCost:     inputCost,
+				Profit:        profit,
+				FontsToHit:    jackpotFontsToHit,
+				JackpotGems:   jackpotGems,
+				Mode:          "jackpot",
+				ThinPoolGems:  jackpotThinCount,
+				LiquidityRisk: computeLiquidityRisk(jackpotThinCount, jackpotWinnerCount),
+			}
+
+			if gemType == "skill" {
+				analysis.Skills = append(analysis.Skills, safeResult, premiumResult, jackpotResult)
+			} else {
+				analysis.Transfigured = append(analysis.Transfigured, safeResult, premiumResult, jackpotResult)
+			}
+		}
+	}
+
+	return analysis
+}

--- a/internal/lab/dedication_test.go
+++ b/internal/lab/dedication_test.go
@@ -387,7 +387,7 @@ func TestAnalyzeDedication_WinnerHierarchy(t *testing.T) {
 
 func TestAnalyzeDedication_ThinLiquidity(t *testing.T) {
 	now := time.Now()
-	// All gems have < 15 listings (thin market).
+	// All gems have < 5 listings (thin market — below the isThin threshold).
 	gems := []GemPrice{
 		makeDedicationGem("Thin 1", "RED", 500, 3, false),
 		makeDedicationGem("Thin 2", "RED", 400, 4, false),

--- a/internal/lab/dedication_test.go
+++ b/internal/lab/dedication_test.go
@@ -1,0 +1,680 @@
+package lab
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+// makeDedicationGem creates a corrupted 21/23c GemPrice for Dedication pool tests.
+func makeDedicationGem(name, color string, chaos float64, listings int, isTransfigured bool) GemPrice {
+	return GemPrice{
+		Name:           name,
+		Variant:        "21/23c",
+		Chaos:          chaos,
+		Listings:       listings,
+		IsTransfigured: isTransfigured,
+		IsCorrupted:    true,
+		GemColor:       color,
+	}
+}
+
+func TestIsDedicationGem_IncludesCorruptedSkills(t *testing.T) {
+	g := GemPrice{Name: "Arc", IsCorrupted: true}
+	if !isDedicationGem(g) {
+		t.Error("corrupted skill gem 'Arc' should pass isDedicationGem")
+	}
+}
+
+func TestIsDedicationGem_ExcludesNonCorrupted(t *testing.T) {
+	g := GemPrice{Name: "Arc", IsCorrupted: false}
+	if isDedicationGem(g) {
+		t.Error("non-corrupted gem should NOT pass isDedicationGem")
+	}
+}
+
+func TestIsDedicationGem_ExcludesSupports(t *testing.T) {
+	tests := []struct {
+		name string
+		gem  GemPrice
+	}{
+		{"Lifetap Support", GemPrice{Name: "Lifetap Support", IsCorrupted: true}},
+		{"Added Fire Support", GemPrice{Name: "Added Fire Damage Support", IsCorrupted: true}},
+		{"Empower Support", GemPrice{Name: "Empower Support", IsCorrupted: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if isDedicationGem(tt.gem) {
+				t.Errorf("support gem %q should NOT pass isDedicationGem", tt.gem.Name)
+			}
+		})
+	}
+}
+
+func TestIsDedicationGem_ExcludesTrarthus(t *testing.T) {
+	g := GemPrice{Name: "Trarthus Ire", IsCorrupted: true}
+	if isDedicationGem(g) {
+		t.Error("Trarthus should NOT pass isDedicationGem")
+	}
+}
+
+func TestDedicationInputCost_AvgOf10Cheapest(t *testing.T) {
+	prices := make([]float64, 15)
+	for i := 0; i < 15; i++ {
+		prices[i] = float64(10 + i*5) // 10, 15, 20, ..., 80
+	}
+	got := dedicationInputCostFromPrices(prices)
+	// 10 cheapest: 10, 15, 20, 25, 30, 35, 40, 45, 50, 55 => avg = 32.5
+	want := 32.5
+	if math.Abs(got-want) > 0.01 {
+		t.Errorf("dedicationInputCostFromPrices = %f, want %f", got, want)
+	}
+}
+
+func TestDedicationInputCost_FewerThan10Gems(t *testing.T) {
+	prices := []float64{10, 20, 30}
+	got := dedicationInputCostFromPrices(prices)
+	want := 20.0 // (10+20+30)/3
+	if math.Abs(got-want) > 0.01 {
+		t.Errorf("dedicationInputCostFromPrices = %f, want %f", got, want)
+	}
+}
+
+func TestDedicationInputCost_EmptyPool(t *testing.T) {
+	got := dedicationInputCostFromPrices(nil)
+	if got != 0 {
+		t.Errorf("dedicationInputCostFromPrices(nil) = %f, want 0", got)
+	}
+}
+
+func TestAnalyzeDedication_EmptyPool(t *testing.T) {
+	now := time.Now()
+	// No corrupted gems at all.
+	analysis := AnalyzeDedication(now, nil, nil)
+	if len(analysis.Skills) != 0 {
+		t.Errorf("Skills = %d results, want 0 for empty pool", len(analysis.Skills))
+	}
+	if len(analysis.Transfigured) != 0 {
+		t.Errorf("Transfigured = %d results, want 0 for empty pool", len(analysis.Transfigured))
+	}
+}
+
+func TestAnalyzeDedication_EmptyColorPool(t *testing.T) {
+	now := time.Now()
+	// Only GREEN gems; RED and BLUE are empty.
+	gems := []GemPrice{
+		makeDedicationGem("Arc", "GREEN", 100, 20, false),
+		makeDedicationGem("Fireball", "GREEN", 50, 30, false),
+		makeDedicationGem("Ice Shot", "GREEN", 200, 15, false),
+		makeDedicationGem("Cleave", "GREEN", 75, 25, false),
+		makeDedicationGem("Slam", "GREEN", 30, 40, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	// RED and BLUE should produce no results.
+	for _, r := range analysis.Skills {
+		if r.Color == "RED" || r.Color == "BLUE" {
+			t.Errorf("unexpected %s skill result for color with 0 gems", r.Color)
+		}
+	}
+	// GREEN should produce 3 mode results (safe, premium, jackpot).
+	greenCount := 0
+	for _, r := range analysis.Skills {
+		if r.Color == "GREEN" {
+			greenCount++
+		}
+	}
+	if greenCount != 3 {
+		t.Errorf("GREEN skill results = %d, want 3 (safe+premium+jackpot)", greenCount)
+	}
+}
+
+func TestAnalyzeDedication_PoolLessThan3(t *testing.T) {
+	now := time.Now()
+	// Only 2 gems in RED skill pool.
+	gems := []GemPrice{
+		makeDedicationGem("Arc", "RED", 500, 20, false),
+		makeDedicationGem("Fireball", "RED", 100, 30, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	var found *DedicationResult
+	for i := range analysis.Skills {
+		if analysis.Skills[i].Color == "RED" && analysis.Skills[i].Mode == "safe" {
+			found = &analysis.Skills[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected RED skill safe result")
+	}
+	if found.Pool != 2 {
+		t.Errorf("Pool = %d, want 2", found.Pool)
+	}
+	// With pool < 3, pWin3Picks returns 1.0 for any positive winner count.
+	if found.Winners > 0 && found.PWin != 1.0 {
+		t.Errorf("PWin = %f, want 1.0 (pool < 3 with winners)", found.PWin)
+	}
+	// EV should be the best gem's price (expectedBestOf3 with n<3 returns values[0]).
+	// Since pool values include risk-adjusted prices, just verify EV > 0.
+	if found.EV <= 0 {
+		t.Errorf("EV = %f, want > 0", found.EV)
+	}
+}
+
+func TestAnalyzeDedication_SupportFiltering(t *testing.T) {
+	now := time.Now()
+	// Mix of skill gems and support gems in RED pool.
+	gems := []GemPrice{
+		makeDedicationGem("Arc", "RED", 100, 20, false),
+		makeDedicationGem("Lifetap Support", "RED", 500, 10, false),
+		makeDedicationGem("Fireball", "RED", 200, 30, false),
+		makeDedicationGem("Added Fire Damage Support", "RED", 300, 15, false),
+		makeDedicationGem("Cleave", "RED", 50, 25, false),
+		makeDedicationGem("Slam", "RED", 75, 35, false),
+		makeDedicationGem("Ice Shot", "RED", 60, 40, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	var found *DedicationResult
+	for i := range analysis.Skills {
+		if analysis.Skills[i].Color == "RED" && analysis.Skills[i].Mode == "safe" {
+			found = &analysis.Skills[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected RED skill safe result")
+	}
+	// Only non-support gems: Arc, Fireball, Cleave, Slam, Ice Shot = 5
+	if found.Pool != 5 {
+		t.Errorf("Pool = %d, want 5 (supports excluded)", found.Pool)
+	}
+}
+
+func TestAnalyzeDedication_TwoPoolSeparation(t *testing.T) {
+	now := time.Now()
+	// Mix of transfigured and non-transfigured corrupted gems.
+	gems := []GemPrice{
+		// Non-transfigured skills (skill pool)
+		makeDedicationGem("Arc", "RED", 100, 20, false),
+		makeDedicationGem("Fireball", "RED", 200, 30, false),
+		makeDedicationGem("Cleave", "RED", 50, 25, false),
+		makeDedicationGem("Slam", "RED", 75, 35, false),
+		makeDedicationGem("Ice Shot", "RED", 60, 40, false),
+		// Transfigured skills (transfigured pool)
+		makeDedicationGem("Arc of Surging", "RED", 300, 15, true),
+		makeDedicationGem("Fireball of Volatility", "RED", 400, 10, true),
+		makeDedicationGem("Cleave of Rage", "RED", 150, 20, true),
+		makeDedicationGem("Slam of Magnitude", "RED", 250, 25, true),
+		makeDedicationGem("Ice Shot of Shattering", "RED", 180, 30, true),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	// Skills pool: 5 gems.
+	var skillResult *DedicationResult
+	for i := range analysis.Skills {
+		if analysis.Skills[i].Color == "RED" && analysis.Skills[i].Mode == "safe" {
+			skillResult = &analysis.Skills[i]
+			break
+		}
+	}
+	if skillResult == nil {
+		t.Fatal("expected RED skill safe result")
+	}
+	if skillResult.Pool != 5 {
+		t.Errorf("Skills Pool = %d, want 5", skillResult.Pool)
+	}
+	if skillResult.GemType != "skill" {
+		t.Errorf("Skills GemType = %q, want %q", skillResult.GemType, "skill")
+	}
+
+	// Transfigured pool: 5 gems.
+	var transfigResult *DedicationResult
+	for i := range analysis.Transfigured {
+		if analysis.Transfigured[i].Color == "RED" && analysis.Transfigured[i].Mode == "safe" {
+			transfigResult = &analysis.Transfigured[i]
+			break
+		}
+	}
+	if transfigResult == nil {
+		t.Fatal("expected RED transfigured safe result")
+	}
+	if transfigResult.Pool != 5 {
+		t.Errorf("Transfigured Pool = %d, want 5", transfigResult.Pool)
+	}
+	if transfigResult.GemType != "transfigured" {
+		t.Errorf("Transfigured GemType = %q, want %q", transfigResult.GemType, "transfigured")
+	}
+}
+
+func TestAnalyzeDedication_DynamicInputCost(t *testing.T) {
+	now := time.Now()
+	// GREEN skill pool with known prices.
+	gems := []GemPrice{
+		makeDedicationGem("Gem 1", "GREEN", 5, 20, false),
+		makeDedicationGem("Gem 2", "GREEN", 7, 25, false),
+		makeDedicationGem("Gem 3", "GREEN", 8, 30, false),
+		makeDedicationGem("Gem 4", "GREEN", 9, 15, false),
+		makeDedicationGem("Gem 5", "GREEN", 10, 40, false),
+		makeDedicationGem("Gem 6", "GREEN", 12, 35, false),
+		makeDedicationGem("Gem 7", "GREEN", 15, 20, false),
+		makeDedicationGem("Gem 8", "GREEN", 20, 50, false),
+		makeDedicationGem("Gem 9", "GREEN", 50, 30, false),
+		makeDedicationGem("Gem 10", "GREEN", 100, 45, false),
+		makeDedicationGem("Gem 11", "GREEN", 200, 10, false),
+		makeDedicationGem("Gem 12", "GREEN", 500, 60, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	var found *DedicationResult
+	for i := range analysis.Skills {
+		if analysis.Skills[i].Color == "GREEN" && analysis.Skills[i].Mode == "safe" {
+			found = &analysis.Skills[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected GREEN skill safe result")
+	}
+
+	// 10 cheapest: 5, 7, 8, 9, 10, 12, 15, 20, 50, 100 => avg = 23.6
+	wantInputCost := 23.6
+	if math.Abs(found.InputCost-wantInputCost) > 0.01 {
+		t.Errorf("InputCost = %f, want %f", found.InputCost, wantInputCost)
+	}
+}
+
+func TestAnalyzeDedication_ProfitCalculation(t *testing.T) {
+	now := time.Now()
+	gems := []GemPrice{
+		makeDedicationGem("Gem 1", "BLUE", 10, 30, false),
+		makeDedicationGem("Gem 2", "BLUE", 20, 40, false),
+		makeDedicationGem("Gem 3", "BLUE", 50, 25, false),
+		makeDedicationGem("Gem 4", "BLUE", 100, 50, false),
+		makeDedicationGem("Gem 5", "BLUE", 200, 20, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	var found *DedicationResult
+	for i := range analysis.Skills {
+		if analysis.Skills[i].Color == "BLUE" && analysis.Skills[i].Mode == "safe" {
+			found = &analysis.Skills[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected BLUE skill safe result")
+	}
+
+	// Profit = EVRaw - InputCost (no offering cost).
+	expectedProfit := found.EVRaw - found.InputCost
+	if math.Abs(found.Profit-expectedProfit) > 0.01 {
+		t.Errorf("Profit = %f, want EVRaw(%f) - InputCost(%f) = %f",
+			found.Profit, found.EVRaw, found.InputCost, expectedProfit)
+	}
+}
+
+func TestAnalyzeDedication_ThreeModesPerPoolColor(t *testing.T) {
+	now := time.Now()
+	// Create enough RED skill gems for meaningful tier separation.
+	gems := []GemPrice{
+		makeDedicationGem("Expensive 1", "RED", 1500, 50, false),
+		makeDedicationGem("Expensive 2", "RED", 1200, 40, false),
+		makeDedicationGem("High 1", "RED", 500, 60, false),
+		makeDedicationGem("High 2", "RED", 400, 55, false),
+		makeDedicationGem("Mid 1", "RED", 200, 70, false),
+		makeDedicationGem("Mid 2", "RED", 150, 65, false),
+		makeDedicationGem("Mid 3", "RED", 100, 80, false),
+		makeDedicationGem("Low 1", "RED", 50, 90, false),
+		makeDedicationGem("Low 2", "RED", 30, 100, false),
+		makeDedicationGem("Floor 1", "RED", 10, 120, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	modes := map[string]bool{}
+	for _, r := range analysis.Skills {
+		if r.Color == "RED" {
+			modes[r.Mode] = true
+		}
+	}
+	for _, mode := range []string{"safe", "premium", "jackpot"} {
+		if !modes[mode] {
+			t.Errorf("missing %s mode for RED skill pool", mode)
+		}
+	}
+}
+
+func TestAnalyzeDedication_WinnerHierarchy(t *testing.T) {
+	now := time.Now()
+	// Large enough pool for tier classification.
+	gems := []GemPrice{
+		makeDedicationGem("Top 1", "RED", 2000, 30, false),
+		makeDedicationGem("Top 2", "RED", 1800, 25, false),
+		makeDedicationGem("High 1", "RED", 500, 60, false),
+		makeDedicationGem("High 2", "RED", 450, 55, false),
+		makeDedicationGem("Mid 1", "RED", 200, 70, false),
+		makeDedicationGem("Mid 2", "RED", 180, 65, false),
+		makeDedicationGem("Mid 3", "RED", 150, 80, false),
+		makeDedicationGem("Low 1", "RED", 50, 90, false),
+		makeDedicationGem("Low 2", "RED", 40, 100, false),
+		makeDedicationGem("Floor 1", "RED", 10, 120, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	var safeWinners, premiumWinners, jackpotWinners int
+	for _, r := range analysis.Skills {
+		if r.Color == "RED" {
+			switch r.Mode {
+			case "safe":
+				safeWinners = r.Winners
+			case "premium":
+				premiumWinners = r.Winners
+			case "jackpot":
+				jackpotWinners = r.Winners
+			}
+		}
+	}
+
+	// Safe >= Premium >= Jackpot (each mode is stricter).
+	if safeWinners < premiumWinners {
+		t.Errorf("Safe winners (%d) should be >= Premium winners (%d)", safeWinners, premiumWinners)
+	}
+	if premiumWinners < jackpotWinners {
+		t.Errorf("Premium winners (%d) should be >= Jackpot winners (%d)", premiumWinners, jackpotWinners)
+	}
+}
+
+func TestAnalyzeDedication_ThinLiquidity(t *testing.T) {
+	now := time.Now()
+	// All gems have < 15 listings (thin market).
+	gems := []GemPrice{
+		makeDedicationGem("Thin 1", "RED", 500, 3, false),
+		makeDedicationGem("Thin 2", "RED", 400, 4, false),
+		makeDedicationGem("Thin 3", "RED", 300, 2, false),
+		makeDedicationGem("Thin 4", "RED", 200, 4, false),
+		makeDedicationGem("Thin 5", "RED", 100, 3, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	for _, r := range analysis.Skills {
+		if r.Color == "RED" && r.Mode == "safe" {
+			// With all listings < 5, ThinPoolGems should == Winners.
+			if r.Winners > 0 && r.ThinPoolGems != r.Winners {
+				t.Errorf("ThinPoolGems = %d, want %d (all gems have < 5 listings)", r.ThinPoolGems, r.Winners)
+			}
+			// LiquidityRisk should be HIGH when all winners are thin.
+			if r.Winners > 0 && r.LiquidityRisk != "HIGH" {
+				t.Errorf("LiquidityRisk = %q, want HIGH (all winners thin)", r.LiquidityRisk)
+			}
+			return
+		}
+	}
+	t.Error("expected RED skill safe result")
+}
+
+func TestAnalyzeDedication_FontsToHitCalculation(t *testing.T) {
+	now := time.Now()
+	gems := []GemPrice{
+		makeDedicationGem("Gem 1", "BLUE", 500, 50, false),
+		makeDedicationGem("Gem 2", "BLUE", 400, 40, false),
+		makeDedicationGem("Gem 3", "BLUE", 300, 60, false),
+		makeDedicationGem("Gem 4", "BLUE", 200, 55, false),
+		makeDedicationGem("Gem 5", "BLUE", 100, 70, false),
+		makeDedicationGem("Gem 6", "BLUE", 50, 80, false),
+		makeDedicationGem("Gem 7", "BLUE", 30, 90, false),
+		makeDedicationGem("Gem 8", "BLUE", 20, 100, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	for _, r := range analysis.Skills {
+		if r.Color == "BLUE" && r.Mode == "safe" {
+			if r.PWin > 0 {
+				expected := 1.0 / r.PWin
+				if math.Abs(r.FontsToHit-expected) > 0.001 {
+					t.Errorf("FontsToHit = %f, want 1/PWin = %f", r.FontsToHit, expected)
+				}
+			}
+			return
+		}
+	}
+	t.Error("expected BLUE skill safe result")
+}
+
+func TestAnalyzeDedication_SkipsNon2123Variant(t *testing.T) {
+	now := time.Now()
+	gems := []GemPrice{
+		// Non 21/23c variants should be ignored.
+		{Name: "Arc", Variant: "20/20", Chaos: 500, Listings: 50, IsCorrupted: true, GemColor: "RED"},
+		{Name: "Fireball", Variant: "1", Chaos: 200, Listings: 30, IsCorrupted: true, GemColor: "RED"},
+		// This one is the only valid entry.
+		makeDedicationGem("Cleave", "RED", 100, 25, false),
+		makeDedicationGem("Slam", "RED", 75, 35, false),
+		makeDedicationGem("Ice Shot", "RED", 60, 40, false),
+		makeDedicationGem("Bash", "RED", 50, 20, false),
+		makeDedicationGem("Strike", "RED", 45, 30, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	for _, r := range analysis.Skills {
+		if r.Color == "RED" && r.Mode == "safe" {
+			// Only 21/23c gems should be in pool.
+			if r.Pool != 5 {
+				t.Errorf("Pool = %d, want 5 (non-21/23c variants excluded)", r.Pool)
+			}
+			return
+		}
+	}
+	t.Error("expected RED skill safe result")
+}
+
+func TestAnalyzeDedication_SkipsInvalidColors(t *testing.T) {
+	now := time.Now()
+	gems := []GemPrice{
+		makeDedicationGem("Unknown Gem", "PURPLE", 100, 20, false),
+		makeDedicationGem("Another", "", 200, 30, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	if len(analysis.Skills) != 0 {
+		t.Errorf("Skills = %d, want 0 (invalid colors should produce no results)", len(analysis.Skills))
+	}
+}
+
+func TestAnalyzeDedication_EVSharedAcrossModes(t *testing.T) {
+	now := time.Now()
+	gems := []GemPrice{
+		makeDedicationGem("Gem 1", "GREEN", 800, 50, false),
+		makeDedicationGem("Gem 2", "GREEN", 400, 40, false),
+		makeDedicationGem("Gem 3", "GREEN", 200, 60, false),
+		makeDedicationGem("Gem 4", "GREEN", 100, 55, false),
+		makeDedicationGem("Gem 5", "GREEN", 50, 70, false),
+		makeDedicationGem("Gem 6", "GREEN", 30, 80, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	var safeEV, premiumEV, jackpotEV float64
+	for _, r := range analysis.Skills {
+		if r.Color == "GREEN" {
+			switch r.Mode {
+			case "safe":
+				safeEV = r.EV
+			case "premium":
+				premiumEV = r.EV
+			case "jackpot":
+				jackpotEV = r.EV
+			}
+		}
+	}
+
+	// EV is computed from the full pool (expectedBestOf3), so it should be
+	// the same across all three modes for a given (color, gemType).
+	if safeEV != premiumEV || premiumEV != jackpotEV {
+		t.Errorf("EV should be identical across modes: safe=%f, premium=%f, jackpot=%f",
+			safeEV, premiumEV, jackpotEV)
+	}
+}
+
+func TestAnalyzeDedication_WithFeatures(t *testing.T) {
+	now := time.Now()
+	gems := []GemPrice{
+		makeDedicationGem("Gem A", "RED", 500, 50, false),
+		makeDedicationGem("Gem B", "RED", 300, 30, false),
+		makeDedicationGem("Gem C", "RED", 100, 60, false),
+		makeDedicationGem("Gem D", "RED", 50, 80, false),
+		makeDedicationGem("Gem E", "RED", 20, 90, false),
+	}
+
+	features := []GemFeature{
+		{Name: "Gem A", Variant: "21/23c", Chaos: 500, Listings: 50, Low7Days: 450, CVShort: 10},
+		{Name: "Gem B", Variant: "21/23c", Chaos: 300, Listings: 30, Low7Days: 280, CVShort: 15},
+		{Name: "Gem C", Variant: "21/23c", Chaos: 100, Listings: 60, Low7Days: 90, CVShort: 5},
+	}
+
+	analysisWithFeats := AnalyzeDedication(now, gems, features)
+	analysisWithout := AnalyzeDedication(now, gems, nil)
+
+	// Both should produce results.
+	if len(analysisWithFeats.Skills) == 0 {
+		t.Fatal("expected skill results with features")
+	}
+	if len(analysisWithout.Skills) == 0 {
+		t.Fatal("expected skill results without features")
+	}
+
+	// With features vs without should produce different risk-adjusted EV
+	// (features enable CVShort-based stability discount).
+	var evWith, evWithout float64
+	for _, r := range analysisWithFeats.Skills {
+		if r.Color == "RED" && r.Mode == "safe" {
+			evWith = r.EV
+		}
+	}
+	for _, r := range analysisWithout.Skills {
+		if r.Color == "RED" && r.Mode == "safe" {
+			evWithout = r.EV
+		}
+	}
+	// Both should be > 0. The exact values differ based on feature presence.
+	if evWith <= 0 {
+		t.Errorf("EV with features = %f, want > 0", evWith)
+	}
+	if evWithout <= 0 {
+		t.Errorf("EV without features = %f, want > 0", evWithout)
+	}
+}
+
+func TestAnalyzeDedication_JackpotGemsPopulated(t *testing.T) {
+	now := time.Now()
+	// Create a pool with a clear TOP gem (huge gap).
+	gems := []GemPrice{
+		makeDedicationGem("Mega Gem", "BLUE", 5000, 30, false),
+		makeDedicationGem("High 1", "BLUE", 500, 60, false),
+		makeDedicationGem("High 2", "BLUE", 450, 55, false),
+		makeDedicationGem("Mid 1", "BLUE", 200, 70, false),
+		makeDedicationGem("Mid 2", "BLUE", 150, 65, false),
+		makeDedicationGem("Mid 3", "BLUE", 100, 80, false),
+		makeDedicationGem("Low 1", "BLUE", 50, 90, false),
+		makeDedicationGem("Low 2", "BLUE", 30, 100, false),
+		makeDedicationGem("Floor 1", "BLUE", 10, 120, false),
+		makeDedicationGem("Floor 2", "BLUE", 8, 110, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	for _, r := range analysis.Skills {
+		if r.Color == "BLUE" && r.Mode == "jackpot" {
+			// Jackpot mode should have JackpotGems populated if there are TOP winners.
+			if r.Winners > 0 && len(r.JackpotGems) == 0 {
+				t.Error("JackpotGems should be populated when jackpot has winners")
+			}
+			// JackpotGems should only be in jackpot mode.
+			return
+		}
+	}
+	t.Error("expected BLUE skill jackpot result")
+}
+
+func TestAnalyzeDedication_SafeAndPremiumHaveNoJackpotGems(t *testing.T) {
+	now := time.Now()
+	gems := []GemPrice{
+		makeDedicationGem("Gem 1", "RED", 500, 50, false),
+		makeDedicationGem("Gem 2", "RED", 300, 40, false),
+		makeDedicationGem("Gem 3", "RED", 200, 60, false),
+		makeDedicationGem("Gem 4", "RED", 100, 70, false),
+		makeDedicationGem("Gem 5", "RED", 50, 80, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	for _, r := range analysis.Skills {
+		if r.Color == "RED" && (r.Mode == "safe" || r.Mode == "premium") {
+			if len(r.JackpotGems) != 0 {
+				t.Errorf("%s mode should not have JackpotGems (has %d)", r.Mode, len(r.JackpotGems))
+			}
+		}
+	}
+}
+
+func TestAnalyzeDedication_PoolBreakdownInSafeModeOnly(t *testing.T) {
+	now := time.Now()
+	gems := []GemPrice{
+		makeDedicationGem("Gem 1", "GREEN", 500, 50, false),
+		makeDedicationGem("Gem 2", "GREEN", 300, 40, false),
+		makeDedicationGem("Gem 3", "GREEN", 200, 60, false),
+		makeDedicationGem("Gem 4", "GREEN", 100, 70, false),
+		makeDedicationGem("Gem 5", "GREEN", 50, 80, false),
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	for _, r := range analysis.Skills {
+		if r.Color == "GREEN" {
+			if r.Mode == "safe" {
+				// PoolBreakdown should be present on safe mode.
+				if r.PoolBreakdown == nil {
+					t.Error("safe mode should have PoolBreakdown")
+				}
+			} else {
+				// Other modes should not have PoolBreakdown.
+				if len(r.PoolBreakdown) > 0 {
+					t.Errorf("%s mode should not have PoolBreakdown", r.Mode)
+				}
+			}
+		}
+	}
+}
+
+func TestAnalyzeDedication_LowConfidenceGemsInSafeMode(t *testing.T) {
+	now := time.Now()
+	// Create a mix: most gems have many listings, one has very few (thin market).
+	gems := []GemPrice{
+		makeDedicationGem("Normal 1", "RED", 500, 80, false),
+		makeDedicationGem("Normal 2", "RED", 400, 70, false),
+		makeDedicationGem("Normal 3", "RED", 300, 60, false),
+		makeDedicationGem("Normal 4", "RED", 200, 90, false),
+		makeDedicationGem("Normal 5", "RED", 100, 75, false),
+		makeDedicationGem("Thin Spike", "RED", 3000, 2, false), // very thin market vs median ~75
+	}
+	analysis := AnalyzeDedication(now, gems, nil)
+
+	for _, r := range analysis.Skills {
+		if r.Color == "RED" && r.Mode == "safe" {
+			// LowConfidenceGems should include Thin Spike.
+			if len(r.LowConfidenceGems) == 0 {
+				t.Error("expected at least 1 low-confidence gem (Thin Spike)")
+			}
+			found := false
+			for _, lcg := range r.LowConfidenceGems {
+				if lcg.Name == "Thin Spike" {
+					found = true
+					if lcg.Chaos != 3000 {
+						t.Errorf("Thin Spike chaos = %f, want 3000", lcg.Chaos)
+					}
+				}
+			}
+			if !found {
+				t.Error("Thin Spike should be in LowConfidenceGems")
+			}
+			return
+		}
+	}
+	t.Error("expected RED skill safe result")
+}

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -1201,14 +1201,15 @@ func (r *Repository) LatestDedicationResults(ctx context.Context, gemType, mode 
 			&poolBreakdownJSON, &lowConfJSON); err != nil {
 			return nil, fmt.Errorf("lab repo: scan dedication result: %w", err)
 		}
-		if dr.PWin > 0 {
-			dr.FontsToHit = 1.0 / dr.PWin
-		}
 		if len(poolBreakdownJSON) > 0 {
-			json.Unmarshal(poolBreakdownJSON, &dr.PoolBreakdown)
+			if err := json.Unmarshal(poolBreakdownJSON, &dr.PoolBreakdown); err != nil {
+				return nil, fmt.Errorf("lab repo: unmarshal pool_breakdown: %w", err)
+			}
 		}
 		if len(lowConfJSON) > 0 {
-			json.Unmarshal(lowConfJSON, &dr.LowConfidenceGems)
+			if err := json.Unmarshal(lowConfJSON, &dr.LowConfidenceGems); err != nil {
+				return nil, fmt.Errorf("lab repo: unmarshal low_confidence_gems: %w", err)
+			}
 		}
 		results = append(results, dr)
 	}
@@ -1222,6 +1223,7 @@ func (r *Repository) LatestDedicationResults(ctx context.Context, gemType, mode 
 // CorruptedGemNamesAutocomplete returns distinct corrupted gem names for autocomplete.
 // When isTransfigured is true, returns only transfigured corrupted gems; when false,
 // returns only non-transfigured corrupted gems. Excludes support gems.
+// Restricts to the last 2 hours to avoid full hypertable scans.
 func (r *Repository) CorruptedGemNamesAutocomplete(ctx context.Context, isTransfigured bool, limit int) ([]string, error) {
 	rows, err := r.pool.Query(ctx, `
 		SELECT DISTINCT name FROM gem_snapshots
@@ -1229,6 +1231,7 @@ func (r *Repository) CorruptedGemNamesAutocomplete(ctx context.Context, isTransf
 		  AND is_transfigured = $1
 		  AND name NOT LIKE '%Support%'
 		  AND name NOT LIKE '%Trarthus%'
+		  AND time > NOW() - INTERVAL '2 hours'
 		ORDER BY name
 		LIMIT $2`, isTransfigured, limit)
 	if err != nil {
@@ -1249,4 +1252,89 @@ func (r *Repository) CorruptedGemNamesAutocomplete(ctx context.Context, isTransf
 	}
 
 	return names, nil
+}
+
+// CorruptedGemPricesByNames returns the latest snapshot prices for specific corrupted gems.
+// Only returns gems matching variant "21/23c". Used by the Dedication compare endpoint.
+func (r *Repository) CorruptedGemPricesByNames(ctx context.Context, names []string) ([]GemPrice, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	rows, err := r.pool.Query(ctx, `
+		SELECT name, variant, COALESCE(chaos, 0), COALESCE(listings, 0),
+		       is_transfigured, is_corrupted, COALESCE(gem_color, '')
+		FROM gem_snapshots
+		WHERE time = (SELECT MAX(time) FROM gem_snapshots)
+		  AND is_corrupted = true
+		  AND variant = '21/23c'
+		  AND name = ANY($1)`, names)
+	if err != nil {
+		return nil, fmt.Errorf("lab repo: query corrupted gem prices by names: %w", err)
+	}
+	defer rows.Close()
+
+	var gems []GemPrice
+	for rows.Next() {
+		var g GemPrice
+		if err := rows.Scan(&g.Name, &g.Variant, &g.Chaos, &g.Listings,
+			&g.IsTransfigured, &g.IsCorrupted, &g.GemColor); err != nil {
+			return nil, fmt.Errorf("lab repo: scan corrupted gem price: %w", err)
+		}
+		gems = append(gems, g)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("lab repo: corrupted gem prices rows iteration: %w", err)
+	}
+
+	return gems, nil
+}
+
+// SparklineDataCorrupted returns sparkline data for corrupted gems (is_corrupted = true).
+// Same shape as SparklineData but filters for corrupted gems instead.
+func (r *Repository) SparklineDataCorrupted(ctx context.Context, names []string, variant string, hours int) (map[string][]SparklinePoint, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	query := `
+		SELECT name, time, COALESCE(chaos, 0), COALESCE(listings, 0)
+		FROM gem_snapshots
+		WHERE name = ANY($1) AND is_corrupted = true
+		  AND time > NOW() - make_interval(hours => $2)`
+	args := []any{names, hours}
+
+	if variant != "" {
+		query += ` AND variant = $3`
+		args = append(args, variant)
+	}
+
+	query += ` ORDER BY name, time ASC LIMIT 10000`
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("lab repo: query corrupted sparkline data: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string][]SparklinePoint)
+	for rows.Next() {
+		var name string
+		var t time.Time
+		var chaos float64
+		var listings int
+		if err := rows.Scan(&name, &t, &chaos, &listings); err != nil {
+			return nil, fmt.Errorf("lab repo: scan corrupted sparkline point: %w", err)
+		}
+		result[name] = append(result[name], SparklinePoint{
+			Time:     t.UTC().Format(time.RFC3339),
+			Price:    chaos,
+			Listings: listings,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("lab repo: corrupted sparkline rows iteration: %w", err)
+	}
+
+	return result, nil
 }

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -1118,8 +1119,16 @@ func (r *Repository) SaveDedicationResults(ctx context.Context, results []Dedica
 
 	batch := &pgx.Batch{}
 	for _, dr := range results {
-		poolBreakdownJSON, _ := json.Marshal(dr.PoolBreakdown)
-		lowConfJSON, _ := json.Marshal(dr.LowConfidenceGems)
+		poolBreakdownJSON, err := json.Marshal(dr.PoolBreakdown)
+		if err != nil {
+			slog.Warn("lab repo: marshal pool breakdown failed, using empty array", "error", err)
+			poolBreakdownJSON = []byte("[]")
+		}
+		lowConfJSON, err := json.Marshal(dr.LowConfidenceGems)
+		if err != nil {
+			slog.Warn("lab repo: marshal low confidence gems failed, using empty array", "error", err)
+			lowConfJSON = []byte("[]")
+		}
 
 		batch.Queue(
 			`INSERT INTO dedication_snapshots

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -1099,3 +1099,154 @@ func (r *Repository) SnapshotPricesInRange(ctx context.Context, hours int) ([]Sn
 
 	return results, nil
 }
+
+// ---------------------------------------------------------------------------
+// Dedication Lab Analysis
+// ---------------------------------------------------------------------------
+
+// SaveDedicationResults batch-inserts Dedication lab analysis results.
+func (r *Repository) SaveDedicationResults(ctx context.Context, results []DedicationResult) (int, error) {
+	if len(results) == 0 {
+		return 0, nil
+	}
+
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("lab repo: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	batch := &pgx.Batch{}
+	for _, dr := range results {
+		poolBreakdownJSON, _ := json.Marshal(dr.PoolBreakdown)
+		lowConfJSON, _ := json.Marshal(dr.LowConfidenceGems)
+
+		batch.Queue(
+			`INSERT INTO dedication_snapshots
+			 (time, color, gem_type, pool, winners, p_win, avg_win_raw, ev_raw,
+			  input_cost, profit, fonts_to_hit, mode, thin_pool_gems, liquidity_risk,
+			  pool_breakdown, low_confidence_gems)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+			 ON CONFLICT DO NOTHING`,
+			dr.Time, dr.Color, dr.GemType, dr.Pool, dr.Winners,
+			dr.PWin, dr.AvgWinRaw, dr.EVRaw,
+			dr.InputCost, dr.Profit, dr.FontsToHit,
+			dr.Mode, dr.ThinPoolGems, dr.LiquidityRisk,
+			poolBreakdownJSON, lowConfJSON,
+		)
+	}
+
+	br := tx.SendBatch(ctx, batch)
+	inserted := 0
+	for range results {
+		ct, err := br.Exec()
+		if err != nil {
+			br.Close()
+			return 0, fmt.Errorf("lab repo: insert dedication result: %w", err)
+		}
+		inserted += int(ct.RowsAffected())
+	}
+	if err := br.Close(); err != nil {
+		return 0, fmt.Errorf("lab repo: close batch: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("lab repo: commit dedication results: %w", err)
+	}
+
+	return inserted, nil
+}
+
+// LatestDedicationResults returns the most recent Dedication analysis results,
+// optionally filtered by gemType and/or mode.
+func (r *Repository) LatestDedicationResults(ctx context.Context, gemType, mode string, limit int) ([]DedicationResult, error) {
+	query := `
+		SELECT time, color, gem_type, pool, winners, p_win, avg_win_raw, ev_raw,
+		       input_cost, profit, fonts_to_hit,
+		       COALESCE(mode, 'safe'), COALESCE(thin_pool_gems, 0), COALESCE(liquidity_risk, 'LOW'),
+		       COALESCE(pool_breakdown, '[]'::jsonb), COALESCE(low_confidence_gems, '[]'::jsonb)
+		FROM dedication_snapshots
+		WHERE time = (SELECT MAX(time) FROM dedication_snapshots)`
+	args := []any{}
+	argIdx := 1
+
+	if gemType != "" {
+		query += fmt.Sprintf(` AND gem_type = $%d`, argIdx)
+		args = append(args, gemType)
+		argIdx++
+	}
+	if mode != "" {
+		query += fmt.Sprintf(` AND mode = $%d`, argIdx)
+		args = append(args, mode)
+		argIdx++
+	}
+
+	query += fmt.Sprintf(` ORDER BY profit DESC LIMIT $%d`, argIdx)
+	args = append(args, limit)
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("lab repo: query dedication results: %w", err)
+	}
+	defer rows.Close()
+
+	var results []DedicationResult
+	for rows.Next() {
+		var dr DedicationResult
+		var poolBreakdownJSON, lowConfJSON []byte
+		if err := rows.Scan(&dr.Time, &dr.Color, &dr.GemType, &dr.Pool, &dr.Winners,
+			&dr.PWin, &dr.AvgWinRaw, &dr.EVRaw,
+			&dr.InputCost, &dr.Profit, &dr.FontsToHit,
+			&dr.Mode, &dr.ThinPoolGems, &dr.LiquidityRisk,
+			&poolBreakdownJSON, &lowConfJSON); err != nil {
+			return nil, fmt.Errorf("lab repo: scan dedication result: %w", err)
+		}
+		if dr.PWin > 0 {
+			dr.FontsToHit = 1.0 / dr.PWin
+		}
+		if len(poolBreakdownJSON) > 0 {
+			json.Unmarshal(poolBreakdownJSON, &dr.PoolBreakdown)
+		}
+		if len(lowConfJSON) > 0 {
+			json.Unmarshal(lowConfJSON, &dr.LowConfidenceGems)
+		}
+		results = append(results, dr)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("lab repo: dedication rows iteration: %w", err)
+	}
+
+	return results, nil
+}
+
+// CorruptedGemNamesAutocomplete returns distinct corrupted gem names for autocomplete.
+// When isTransfigured is true, returns only transfigured corrupted gems; when false,
+// returns only non-transfigured corrupted gems. Excludes support gems.
+func (r *Repository) CorruptedGemNamesAutocomplete(ctx context.Context, isTransfigured bool, limit int) ([]string, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT DISTINCT name FROM gem_snapshots
+		WHERE is_corrupted = true
+		  AND is_transfigured = $1
+		  AND name NOT LIKE '%Support%'
+		  AND name NOT LIKE '%Trarthus%'
+		ORDER BY name
+		LIMIT $2`, isTransfigured, limit)
+	if err != nil {
+		return nil, fmt.Errorf("lab repo: corrupted gem names autocomplete: %w", err)
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("lab repo: scan corrupted gem name: %w", err)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("lab repo: corrupted gem names rows iteration: %w", err)
+	}
+
+	return names, nil
+}

--- a/internal/server/handlers/admin.go
+++ b/internal/server/handlers/admin.go
@@ -37,6 +37,9 @@ func AdminRecalculate(analyzer *lab.Analyzer, internalSecret string) http.Handle
 			if err := analyzer.RunFont(ctx); err != nil {
 				slog.Error("admin recalculate: font failed", "error", err)
 			}
+			if err := analyzer.RunDedication(ctx); err != nil {
+				slog.Error("admin recalculate: dedication failed", "error", err)
+			}
 
 			slog.Info("admin: recalculate complete")
 		}()

--- a/internal/server/handlers/collective.go
+++ b/internal/server/handlers/collective.go
@@ -502,6 +502,7 @@ type compareRow struct {
 	TransListings        int                 `json:"transListings"`
 	TransfiguredListings int                 `json:"transfiguredListings"`
 	WeightedROI          float64             `json:"weightedRoi"`
+	WeightedROIPct       float64             `json:"weightedRoiPct"`
 	Low7Days             float64             `json:"low7d"`
 	High7Days            float64             `json:"high7d"`
 	SellConfidence       string              `json:"sellConfidence"`
@@ -545,6 +546,7 @@ func buildCompareRows(results []lab.CompareResult, tradeCache *trade.TradeCache)
 			TransListings:        cr.TransListings,
 			TransfiguredListings: cr.TransListings,
 			WeightedROI:          cr.WeightedROI,
+			WeightedROIPct:       cr.WeightedROIPct,
 			Low7Days:             cr.Low7Days,
 			High7Days:            cr.High7Days,
 			SellConfidence:       cr.SellConfidence,

--- a/internal/server/handlers/collective.go
+++ b/internal/server/handlers/collective.go
@@ -507,19 +507,39 @@ func GemNamesAutocomplete(repo *lab.Repository, cache *lab.Cache) http.HandlerFu
 			limit = n
 		}
 
-		// Fast path: in-memory search over cached gem names (~200 entries).
-		// Falls back to DB query only if cache is empty (cold start).
+		// When corrupted=true, use corrupted gem name pools instead of transfigured.
+		corrupted := r.URL.Query().Get("corrupted") == "true"
+		isTransfigured := r.URL.Query().Get("transfigured") != "false" // default true
+
 		var names []string
-		if cache != nil {
-			names = cache.GemNamesSearch(q, limit)
-		}
-		if names == nil {
-			var err error
-			names, err = repo.GemNamesAutocomplete(r.Context(), q, limit)
-			if err != nil {
-				slog.Error("gem names autocomplete: query failed", "error", err, "q", q)
-				http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
-				return
+		if corrupted {
+			// Corrupted gem name autocomplete (for Dedication lab).
+			if cache != nil {
+				names = cache.CorruptedGemNamesSearch(q, isTransfigured, limit)
+			}
+			if names == nil {
+				var err error
+				names, err = repo.CorruptedGemNamesAutocomplete(r.Context(), isTransfigured, limit)
+				if err != nil {
+					slog.Error("gem names autocomplete: corrupted query failed", "error", err, "q", q)
+					http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+					return
+				}
+			}
+		} else {
+			// Fast path: in-memory search over cached gem names (~200 entries).
+			// Falls back to DB query only if cache is empty (cold start).
+			if cache != nil {
+				names = cache.GemNamesSearch(q, limit)
+			}
+			if names == nil {
+				var err error
+				names, err = repo.GemNamesAutocomplete(r.Context(), q, limit)
+				if err != nil {
+					slog.Error("gem names autocomplete: query failed", "error", err, "q", q)
+					http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+					return
+				}
 			}
 		}
 

--- a/internal/server/handlers/collective.go
+++ b/internal/server/handlers/collective.go
@@ -518,12 +518,29 @@ func GemNamesAutocomplete(repo *lab.Repository, cache *lab.Cache) http.HandlerFu
 				names = cache.CorruptedGemNamesSearch(q, isTransfigured, limit)
 			}
 			if names == nil {
-				var err error
-				names, err = repo.CorruptedGemNamesAutocomplete(r.Context(), isTransfigured, limit)
+				all, err := repo.CorruptedGemNamesAutocomplete(r.Context(), isTransfigured, limit*10)
 				if err != nil {
 					slog.Error("gem names autocomplete: corrupted query failed", "error", err, "q", q)
 					http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
 					return
+				}
+				// Filter in memory to match cache search behaviour.
+				words := strings.Fields(strings.ToLower(q))
+				for _, name := range all {
+					lower := strings.ToLower(name)
+					match := true
+					for _, w := range words {
+						if !strings.Contains(lower, w) {
+							match = false
+							break
+						}
+					}
+					if match {
+						names = append(names, name)
+						if len(names) >= limit {
+							break
+						}
+					}
 				}
 			}
 		} else {

--- a/internal/server/handlers/collective.go
+++ b/internal/server/handlers/collective.go
@@ -284,7 +284,8 @@ func CollectiveAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc
 }
 
 // CompareAnalysis returns side-by-side comparison of 1-5 specific gems.
-// Query params: gems (comma-separated, required, max 5), variant (optional).
+// Query params: gems (comma-separated, required, max 5), variant (optional),
+// mode (optional: "dedication" for corrupted 21/23c pool scoring).
 // tradeCache may be nil — trade enrichment is skipped when unavailable.
 func CompareAnalysis(repo *lab.Repository, cache *lab.Cache, tradeCache *trade.TradeCache) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -318,6 +319,14 @@ func CompareAnalysis(repo *lab.Repository, cache *lab.Cache, tradeCache *trade.T
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{"error": "at least one gem name is required"})
+			return
+		}
+
+		mode := r.URL.Query().Get("mode")
+
+		// Dedication mode: score gems against the corrupted 21/23c pool.
+		if mode == "dedication" {
+			serveDedicationCompare(w, r, repo, cache, names)
 			return
 		}
 
@@ -379,92 +388,7 @@ func CompareAnalysis(repo *lab.Repository, cache *lab.Cache, tradeCache *trade.T
 
 		results := lab.BuildCompareResults(names, transfigure, signals, features, sparklines, variant)
 
-		type row struct {
-			TransfiguredName     string              `json:"transfiguredName"`
-			BaseName             string              `json:"baseName"`
-			Variant              string              `json:"variant"`
-			GemColor             string              `json:"gemColor"`
-			ROI                  float64             `json:"roi"`
-			ROIPct               float64             `json:"roiPct"`
-			BasePrice            float64             `json:"basePrice"`
-			TransfiguredPrice    float64             `json:"transfiguredPrice"`
-			Confidence           string              `json:"confidence"`
-			Signal               string              `json:"signal"`
-			CV                   float64             `json:"cv"`
-			PriceVelocity        float64             `json:"priceVelocity"`
-			ListingVelocity      float64             `json:"listingVelocity"`
-			HistPosition         float64             `json:"histPosition"`
-			Sparkline            []lab.SparklinePoint `json:"sparkline"`
-			Recommendation       string              `json:"recommendation"`
-			SellUrgency          string              `json:"sellUrgency"`
-			SellReason           string              `json:"sellReason"`
-			Sellability          int                 `json:"sellability"`
-			SellabilityLabel     string              `json:"sellabilityLabel"`
-			PriceTier            string              `json:"priceTier"`
-			TierAction           string              `json:"tierAction"`
-			WindowSignal         string              `json:"windowSignal"`
-			BaseListings         int                 `json:"baseListings"`
-			LiquidityTier        string              `json:"liquidityTier"`
-			TransListings        int                 `json:"transListings"`
-			TransfiguredListings int                 `json:"transfiguredListings"`
-			WeightedROI          float64             `json:"weightedRoi"`
-			Low7Days                float64             `json:"low7d"`
-			High7Days               float64             `json:"high7d"`
-			SellConfidence       string              `json:"sellConfidence"`
-			SellConfidenceReason string              `json:"sellConfidenceReason"`
-			QuickSellPrice       float64             `json:"quickSellPrice"`
-			RiskAdjustedPrice    float64             `json:"riskAdjustedPrice"`
-			Trade                *trade.TradeLookupResult `json:"trade,omitempty"`
-		}
-
-		rows := make([]row, 0, len(results))
-		for _, cr := range results {
-			rw := row{
-				TransfiguredName:     cr.TransfiguredName,
-				BaseName:             cr.BaseName,
-				Variant:              cr.Variant,
-				GemColor:             cr.GemColor,
-				ROI:                  cr.ROI,
-				ROIPct:               cr.ROIPct,
-				BasePrice:            cr.BasePrice,
-				TransfiguredPrice:    cr.TransfiguredPrice,
-				Confidence:           cr.Confidence,
-				Signal:               cr.Signal,
-				CV:                   cr.CV,
-				PriceVelocity:        cr.PriceVelocity,
-				ListingVelocity:      cr.ListingVelocity,
-				HistPosition:         cr.HistPosition,
-				Sparkline:            cr.Sparkline,
-				Recommendation:       cr.Recommendation,
-				SellUrgency:          cr.SellUrgency,
-				SellReason:           cr.SellReason,
-				Sellability:          cr.Sellability,
-				SellabilityLabel:     cr.SellabilityLabel,
-				PriceTier:            cr.PriceTier,
-				TierAction:           cr.TierAction,
-				WindowSignal:         cr.WindowSignal,
-				BaseListings:         cr.BaseListings,
-				LiquidityTier:        cr.LiquidityTier,
-				TransListings:        cr.TransListings,
-				TransfiguredListings: cr.TransListings,
-				WeightedROI:          cr.WeightedROI,
-				Low7Days:                cr.Low7Days,
-				High7Days:               cr.High7Days,
-				SellConfidence:       cr.SellConfidence,
-				SellConfidenceReason: cr.SellConfidenceReason,
-				QuickSellPrice:       cr.QuickSellPrice,
-				RiskAdjustedPrice:    cr.RiskAdjustedPrice,
-			}
-
-			// Enrich with cached trade data when available.
-			if tradeCache != nil {
-				if tradeResult, ok := tradeCache.Get(trade.CacheKey(cr.TransfiguredName, cr.Variant)); ok {
-					rw.Trade = tradeResult
-				}
-			}
-
-			rows = append(rows, rw)
-		}
+		rows := buildCompareRows(results, tradeCache)
 
 		resp := map[string]any{
 			"count": len(rows),
@@ -479,6 +403,166 @@ func CompareAnalysis(repo *lab.Repository, cache *lab.Cache, tradeCache *trade.T
 			slog.Error("compare analysis: encode response", "error", err)
 		}
 	}
+}
+
+// serveDedicationCompare handles the Dedication lab compare path.
+// Queries corrupted 21/23c gem prices, loads Dedication analysis for input costs,
+// and auto-detects pool (skill vs transfigured) from gem names.
+func serveDedicationCompare(w http.ResponseWriter, r *http.Request, repo *lab.Repository, cache *lab.Cache, names []string) {
+	// Load corrupted gem prices for the requested names.
+	gemPrices, err := repo.CorruptedGemPricesByNames(r.Context(), names)
+	if err != nil {
+		slog.Error("compare analysis (dedication): corrupted gem prices query failed", "error", err)
+		http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Load Dedication analysis results for input cost context.
+	// Fast path: cache.
+	var dedicationResults []lab.DedicationResult
+	if cache != nil {
+		ded := cache.Dedication()
+		dedicationResults = append(dedicationResults, ded.Skills...)
+		dedicationResults = append(dedicationResults, ded.Transfigured...)
+	}
+
+	// Slow path: fall back to DB if cache is empty.
+	if len(dedicationResults) == 0 {
+		skills, err := repo.LatestDedicationResults(r.Context(), "skill", "", 100)
+		if err != nil {
+			slog.Error("compare analysis (dedication): dedication skills query failed", "error", err)
+			http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+			return
+		}
+		trans, err := repo.LatestDedicationResults(r.Context(), "transfigured", "", 100)
+		if err != nil {
+			slog.Error("compare analysis (dedication): dedication transfigured query failed", "error", err)
+			http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+			return
+		}
+		dedicationResults = append(skills, trans...)
+	}
+
+	// Load sparkline data for corrupted gems (last 12 hours).
+	var warnings []string
+	sparklines, err := repo.SparklineDataCorrupted(r.Context(), names, "21/23c", 12)
+	if err != nil {
+		slog.Error("compare analysis (dedication): sparkline query failed", "error", err)
+		sparklines = make(map[string][]lab.SparklinePoint)
+		warnings = append(warnings, "Sparkline data temporarily unavailable")
+	}
+
+	results := lab.BuildDedicationCompareResults(names, gemPrices, dedicationResults, sparklines)
+
+	rows := buildCompareRows(results, nil) // no trade enrichment for Dedication mode
+
+	resp := map[string]any{
+		"count": len(rows),
+		"data":  rows,
+		"mode":  "dedication",
+	}
+	if len(warnings) > 0 {
+		resp["warnings"] = warnings
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		slog.Error("compare analysis (dedication): encode response", "error", err)
+	}
+}
+
+// compareRow is the JSON response shape for the compare endpoint (shared between
+// normal and dedication modes).
+type compareRow struct {
+	TransfiguredName     string              `json:"transfiguredName"`
+	BaseName             string              `json:"baseName"`
+	Variant              string              `json:"variant"`
+	GemColor             string              `json:"gemColor"`
+	ROI                  float64             `json:"roi"`
+	ROIPct               float64             `json:"roiPct"`
+	BasePrice            float64             `json:"basePrice"`
+	TransfiguredPrice    float64             `json:"transfiguredPrice"`
+	Confidence           string              `json:"confidence"`
+	Signal               string              `json:"signal"`
+	CV                   float64             `json:"cv"`
+	PriceVelocity        float64             `json:"priceVelocity"`
+	ListingVelocity      float64             `json:"listingVelocity"`
+	HistPosition         float64             `json:"histPosition"`
+	Sparkline            []lab.SparklinePoint `json:"sparkline"`
+	Recommendation       string              `json:"recommendation"`
+	SellUrgency          string              `json:"sellUrgency"`
+	SellReason           string              `json:"sellReason"`
+	Sellability          int                 `json:"sellability"`
+	SellabilityLabel     string              `json:"sellabilityLabel"`
+	PriceTier            string              `json:"priceTier"`
+	TierAction           string              `json:"tierAction"`
+	WindowSignal         string              `json:"windowSignal"`
+	BaseListings         int                 `json:"baseListings"`
+	LiquidityTier        string              `json:"liquidityTier"`
+	TransListings        int                 `json:"transListings"`
+	TransfiguredListings int                 `json:"transfiguredListings"`
+	WeightedROI          float64             `json:"weightedRoi"`
+	Low7Days             float64             `json:"low7d"`
+	High7Days            float64             `json:"high7d"`
+	SellConfidence       string              `json:"sellConfidence"`
+	SellConfidenceReason string              `json:"sellConfidenceReason"`
+	QuickSellPrice       float64             `json:"quickSellPrice"`
+	RiskAdjustedPrice    float64             `json:"riskAdjustedPrice"`
+	Trade                *trade.TradeLookupResult `json:"trade,omitempty"`
+}
+
+// buildCompareRows converts CompareResult slices into the JSON-serializable row format.
+// tradeCache may be nil — trade enrichment is skipped when unavailable.
+func buildCompareRows(results []lab.CompareResult, tradeCache *trade.TradeCache) []compareRow {
+	rows := make([]compareRow, 0, len(results))
+	for _, cr := range results {
+		rw := compareRow{
+			TransfiguredName:     cr.TransfiguredName,
+			BaseName:             cr.BaseName,
+			Variant:              cr.Variant,
+			GemColor:             cr.GemColor,
+			ROI:                  cr.ROI,
+			ROIPct:               cr.ROIPct,
+			BasePrice:            cr.BasePrice,
+			TransfiguredPrice:    cr.TransfiguredPrice,
+			Confidence:           cr.Confidence,
+			Signal:               cr.Signal,
+			CV:                   cr.CV,
+			PriceVelocity:        cr.PriceVelocity,
+			ListingVelocity:      cr.ListingVelocity,
+			HistPosition:         cr.HistPosition,
+			Sparkline:            cr.Sparkline,
+			Recommendation:       cr.Recommendation,
+			SellUrgency:          cr.SellUrgency,
+			SellReason:           cr.SellReason,
+			Sellability:          cr.Sellability,
+			SellabilityLabel:     cr.SellabilityLabel,
+			PriceTier:            cr.PriceTier,
+			TierAction:           cr.TierAction,
+			WindowSignal:         cr.WindowSignal,
+			BaseListings:         cr.BaseListings,
+			LiquidityTier:        cr.LiquidityTier,
+			TransListings:        cr.TransListings,
+			TransfiguredListings: cr.TransListings,
+			WeightedROI:          cr.WeightedROI,
+			Low7Days:             cr.Low7Days,
+			High7Days:            cr.High7Days,
+			SellConfidence:       cr.SellConfidence,
+			SellConfidenceReason: cr.SellConfidenceReason,
+			QuickSellPrice:       cr.QuickSellPrice,
+			RiskAdjustedPrice:    cr.RiskAdjustedPrice,
+		}
+
+		// Enrich with cached trade data when available.
+		if tradeCache != nil {
+			if tradeResult, ok := tradeCache.Get(trade.CacheKey(cr.TransfiguredName, cr.Variant)); ok {
+				rw.Trade = tradeResult
+			}
+		}
+
+		rows = append(rows, rw)
+	}
+	return rows
 }
 
 // GemNamesAutocomplete returns distinct transfigured gem names matching a query.

--- a/internal/server/handlers/dedication.go
+++ b/internal/server/handlers/dedication.go
@@ -90,7 +90,9 @@ func DedicationAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc
 					Name         string  `json:"name"`
 					CurrentPrice float64 `json:"currentPrice"`
 				}
-				if err := json.Unmarshal(offeringJSON, &offerings); err == nil {
+				if err := json.Unmarshal(offeringJSON, &offerings); err != nil {
+					slog.Warn("dedication handler: failed to unmarshal offering timing cache", "error", err)
+				} else {
 					for _, o := range offerings {
 						if o.Name == "Dedication to the Goddess" {
 							entryFee = o.CurrentPrice

--- a/internal/server/handlers/dedication.go
+++ b/internal/server/handlers/dedication.go
@@ -1,0 +1,186 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sort"
+	"time"
+
+	"profitofexile/internal/lab"
+)
+
+// DedicationAnalysis returns pre-computed Dedication lab EV for corrupted 21/23 gems.
+// Response splits results into skills (non-transfigured) and transfigured pools,
+// each with safe/premium/jackpot modes. Includes entryFee from offering timing cache.
+// GET /api/analysis/dedication
+func DedicationAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		limit, ok := parseLimit(w, r, 50, 500)
+		if !ok {
+			return
+		}
+
+		var skillResults, transfiguredResults []lab.DedicationResult
+		cacheHit := false
+
+		// Fast path: serve from cache.
+		if cache != nil {
+			analysis := cache.Dedication()
+			if len(analysis.Skills) > 0 || len(analysis.Transfigured) > 0 {
+				skillResults = analysis.Skills
+				transfiguredResults = analysis.Transfigured
+				cacheHit = true
+			}
+		}
+
+		// Slow path: fall back to DB query.
+		if !cacheHit {
+			var err error
+			skillResults, err = repo.LatestDedicationResults(r.Context(), "skill", "", limit)
+			if err != nil {
+				slog.Error("dedication analysis: query skills failed", "error", err)
+				http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+				return
+			}
+			transfiguredResults, err = repo.LatestDedicationResults(r.Context(), "transfigured", "", limit)
+			if err != nil {
+				slog.Error("dedication analysis: query transfigured failed", "error", err)
+				http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+				return
+			}
+		}
+
+		// Split by mode.
+		splitByMode := func(results []lab.DedicationResult) (safe, premium, jackpot []dedicationRow) {
+			for _, dr := range results {
+				row := toDedicationRow(dr)
+				switch dr.Mode {
+				case "safe":
+					safe = append(safe, row)
+				case "premium":
+					premium = append(premium, row)
+				case "jackpot":
+					jackpot = append(jackpot, row)
+				}
+			}
+			sortDedicationRows(safe)
+			sortDedicationRows(premium)
+			sortDedicationRows(jackpot)
+			if len(safe) > limit {
+				safe = safe[:limit]
+			}
+			if len(premium) > limit {
+				premium = premium[:limit]
+			}
+			if len(jackpot) > limit {
+				jackpot = jackpot[:limit]
+			}
+			return
+		}
+
+		skillSafe, skillPremium, skillJackpot := splitByMode(skillResults)
+		transSafe, transPremium, transJackpot := splitByMode(transfiguredResults)
+
+		// Extract entry fee from offering timing cache.
+		var entryFee float64
+		if cache != nil {
+			if offeringJSON := cache.OfferingTiming(); len(offeringJSON) > 0 {
+				var offerings []struct {
+					Name         string  `json:"name"`
+					CurrentPrice float64 `json:"currentPrice"`
+				}
+				if err := json.Unmarshal(offeringJSON, &offerings); err == nil {
+					for _, o := range offerings {
+						if o.Name == "Dedication to the Goddess" {
+							entryFee = o.CurrentPrice
+							break
+						}
+					}
+				}
+			}
+		}
+
+		resp := struct {
+			Skills struct {
+				Safe    []dedicationRow `json:"safe"`
+				Premium []dedicationRow `json:"premium"`
+				Jackpot []dedicationRow `json:"jackpot"`
+			} `json:"skills"`
+			Transfigured struct {
+				Safe    []dedicationRow `json:"safe"`
+				Premium []dedicationRow `json:"premium"`
+				Jackpot []dedicationRow `json:"jackpot"`
+			} `json:"transfigured"`
+			EntryFee float64 `json:"entryFee"`
+		}{
+			EntryFee: entryFee,
+		}
+
+		resp.Skills.Safe = nonNil(skillSafe)
+		resp.Skills.Premium = nonNil(skillPremium)
+		resp.Skills.Jackpot = nonNil(skillJackpot)
+		resp.Transfigured.Safe = nonNil(transSafe)
+		resp.Transfigured.Premium = nonNil(transPremium)
+		resp.Transfigured.Jackpot = nonNil(transJackpot)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "public, max-age=30")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			slog.Error("dedication analysis: encode response", "error", err)
+		}
+	}
+}
+
+// dedicationRow is the JSON response shape for a single Dedication result.
+type dedicationRow struct {
+	Time              string               `json:"time"`
+	Color             string               `json:"color"`
+	GemType           string               `json:"gemType"`
+	Pool              int                  `json:"pool"`
+	Winners           int                  `json:"winners"`
+	PWin              float64              `json:"pWin"`
+	AvgWinRaw         float64              `json:"avgWinRaw"`
+	EVRaw             float64              `json:"evRaw"`
+	InputCost         float64              `json:"inputCost"`
+	Profit            float64              `json:"profit"`
+	FontsToHit        float64              `json:"fontsToHit"`
+	JackpotGems       []lab.JackpotGemInfo `json:"jackpotGems,omitempty"`
+	ThinPoolGems      int                  `json:"thinPoolGems"`
+	LiquidityRisk     string               `json:"liquidityRisk"`
+	PoolBreakdown     []lab.TierPoolInfo   `json:"poolBreakdown,omitempty"`
+}
+
+func toDedicationRow(dr lab.DedicationResult) dedicationRow {
+	return dedicationRow{
+		Time:          dr.Time.UTC().Format(time.RFC3339),
+		Color:         dr.Color,
+		GemType:       dr.GemType,
+		Pool:          dr.Pool,
+		Winners:       dr.Winners,
+		PWin:          dr.PWin,
+		AvgWinRaw:     dr.AvgWinRaw,
+		EVRaw:         dr.EVRaw,
+		InputCost:     dr.InputCost,
+		Profit:        dr.Profit,
+		FontsToHit:    dr.FontsToHit,
+		JackpotGems:   dr.JackpotGems,
+		ThinPoolGems:  dr.ThinPoolGems,
+		LiquidityRisk: dr.LiquidityRisk,
+		PoolBreakdown: dr.PoolBreakdown,
+	}
+}
+
+func sortDedicationRows(rows []dedicationRow) {
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].Profit > rows[j].Profit
+	})
+}
+
+// nonNil ensures a nil slice is serialized as [] instead of null.
+func nonNil(rows []dedicationRow) []dedicationRow {
+	if rows == nil {
+		return []dedicationRow{}
+	}
+	return rows
+}

--- a/internal/server/handlers/dedication.go
+++ b/internal/server/handlers/dedication.go
@@ -134,40 +134,42 @@ func DedicationAnalysis(repo *lab.Repository, cache *lab.Cache) http.HandlerFunc
 
 // dedicationRow is the JSON response shape for a single Dedication result.
 type dedicationRow struct {
-	Time              string               `json:"time"`
-	Color             string               `json:"color"`
-	GemType           string               `json:"gemType"`
-	Pool              int                  `json:"pool"`
-	Winners           int                  `json:"winners"`
-	PWin              float64              `json:"pWin"`
-	AvgWinRaw         float64              `json:"avgWinRaw"`
-	EVRaw             float64              `json:"evRaw"`
-	InputCost         float64              `json:"inputCost"`
-	Profit            float64              `json:"profit"`
-	FontsToHit        float64              `json:"fontsToHit"`
-	JackpotGems       []lab.JackpotGemInfo `json:"jackpotGems,omitempty"`
-	ThinPoolGems      int                  `json:"thinPoolGems"`
-	LiquidityRisk     string               `json:"liquidityRisk"`
-	PoolBreakdown     []lab.TierPoolInfo   `json:"poolBreakdown,omitempty"`
+	Time              string                    `json:"time"`
+	Color             string                    `json:"color"`
+	GemType           string                    `json:"gemType"`
+	Pool              int                       `json:"pool"`
+	Winners           int                       `json:"winners"`
+	PWin              float64                   `json:"pWin"`
+	AvgWinRaw         float64                   `json:"avgWinRaw"`
+	EVRaw             float64                   `json:"evRaw"`
+	InputCost         float64                   `json:"inputCost"`
+	Profit            float64                   `json:"profit"`
+	FontsToHit        float64                   `json:"fontsToHit"`
+	JackpotGems       []lab.JackpotGemInfo      `json:"jackpotGems,omitempty"`
+	ThinPoolGems      int                       `json:"thinPoolGems"`
+	LiquidityRisk     string                    `json:"liquidityRisk"`
+	PoolBreakdown     []lab.TierPoolInfo        `json:"poolBreakdown,omitempty"`
+	LowConfidenceGems []lab.LowConfidenceGemInfo `json:"lowConfidenceGems,omitempty"`
 }
 
 func toDedicationRow(dr lab.DedicationResult) dedicationRow {
 	return dedicationRow{
-		Time:          dr.Time.UTC().Format(time.RFC3339),
-		Color:         dr.Color,
-		GemType:       dr.GemType,
-		Pool:          dr.Pool,
-		Winners:       dr.Winners,
-		PWin:          dr.PWin,
-		AvgWinRaw:     dr.AvgWinRaw,
-		EVRaw:         dr.EVRaw,
-		InputCost:     dr.InputCost,
-		Profit:        dr.Profit,
-		FontsToHit:    dr.FontsToHit,
-		JackpotGems:   dr.JackpotGems,
-		ThinPoolGems:  dr.ThinPoolGems,
-		LiquidityRisk: dr.LiquidityRisk,
-		PoolBreakdown: dr.PoolBreakdown,
+		Time:              dr.Time.UTC().Format(time.RFC3339),
+		Color:             dr.Color,
+		GemType:           dr.GemType,
+		Pool:              dr.Pool,
+		Winners:           dr.Winners,
+		PWin:              dr.PWin,
+		AvgWinRaw:         dr.AvgWinRaw,
+		EVRaw:             dr.EVRaw,
+		InputCost:         dr.InputCost,
+		Profit:            dr.Profit,
+		FontsToHit:        dr.FontsToHit,
+		JackpotGems:       dr.JackpotGems,
+		ThinPoolGems:      dr.ThinPoolGems,
+		LiquidityRisk:     dr.LiquidityRisk,
+		PoolBreakdown:     dr.PoolBreakdown,
+		LowConfidenceGems: dr.LowConfidenceGems,
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -97,6 +97,7 @@ func NewRouter(pinger handlers.Pinger, frontendFS fs.FS, cfg RouterConfig) http.
 	if cfg.LabRepo != nil {
 		r.Get("/api/analysis/transfigure", handlers.TransfigureAnalysis(cfg.LabRepo, cfg.LabCache))
 		r.Get("/api/analysis/font", handlers.FontAnalysis(cfg.LabRepo, cfg.LabCache))
+		r.Get("/api/analysis/dedication", handlers.DedicationAnalysis(cfg.LabRepo, cfg.LabCache))
 		r.Get("/api/analysis/quality", handlers.QualityAnalysis(cfg.LabRepo, cfg.LabCache))
 		r.Get("/api/analysis/trends", handlers.TrendAnalysis(cfg.LabRepo, cfg.LabCache))
 		r.Get("/api/analysis/collective", handlers.CollectiveAnalysis(cfg.LabRepo, cfg.LabCache))


### PR DESCRIPTION
## Summary
- New Dedication EV engine computing best-of-3 EV for corrupted 21/23 gem pools (both skill and transfigured)
- Migration for dedication_snapshots hypertable with compression and retention policies
- API endpoint /api/analysis/dedication with entry fee from offering timing cache
- FontEVCompare adapted for Dedication mode (2 rows: skills + transfigured, per-color input cost, tooltips)
- Lab selector renamed Merciless→Normal, added Dedication option, mode persisted to localStorage
- Comparator backend endpoint for corrupted pool with auto-detection (transfigured vs non-transfigured)
- Web + Desktop + Overlay comparator adapted for Dedication mode with variant locking
- OCR pipeline: corrupted gem vocabulary loading, font parser wiring for Dedication craft options
- Desktop lab mode persistence via Tauri settings with serde defaults
- Comprehensive test suite for Dedication engine and classification

## Tracker
https://softsolution.youtrack.cloud/issue/POE-65

## Test Plan
- [ ] All tests pass (make qa)
- [ ] Switch between Normal/Dedication in web dashboard
- [ ] Verify FontEVCompare shows both rows with correct EV/profit/pool data
- [ ] Verify trade links open correct filters for corrupted 21/23 gems
- [ ] Verify entry fee displays and tooltip explains it's excluded from EV
- [ ] Desktop: verify lab mode persists across restarts
- [ ] Desktop: verify OCR loads corrupted gem names in Dedication mode
- [ ] Trigger /api/admin/recalculate and verify Dedication results computed

Generated with [Claude Code](https://claude.com/claude-code)