### PR TITLE
POE-111: hotfix Mercure subscriber topic dispatch (fixes trade-tick regression)

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -306,7 +306,7 @@ func runLayoutResetTicker(ctx context.Context, mercureURL, mercureSecret string)
 		case <-time.After(sleepDur):
 		}
 
-		payload := `{"action":"reset","source":"collector"}`
+		payload := `{"topic":"poe/lab/layout","action":"reset","source":"collector"}`
 		if err := collector.PublishMercureEvent(ctx, mercureURL, mercureSecret, "poe/lab/layout", payload); err != nil {
 			slog.Error("layout reset: mercure publish failed", "error", err)
 		} else {
@@ -344,9 +344,9 @@ func runTradeRefresher(ctx context.Context, mercureURL, mercureSecret string, in
 		case <-ticker.C:
 			var payload string
 			if tierTick {
-				payload = `{"variant":"20/20","minTier":"MID","minAge":"5m"}`
+				payload = `{"topic":"poe/collector/trade-tick","variant":"20/20","minTier":"MID","minAge":"5m"}`
 			} else {
-				payload = `{"variant":"20/20","minAge":"5m"}`
+				payload = `{"topic":"poe/collector/trade-tick","variant":"20/20","minAge":"5m"}`
 			}
 			tierTick = !tierTick
 

--- a/cmd/recalculate/main.go
+++ b/cmd/recalculate/main.go
@@ -36,7 +36,7 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	if err := pub.Publish(ctx, "poe/admin/recompute", "{}"); err != nil {
+	if err := pub.Publish(ctx, "poe/admin/recompute", `{"topic":"poe/admin/recompute"}`); err != nil {
 		fmt.Fprintf(os.Stderr, "recalculate: publish failed: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/collector/scheduler.go
+++ b/internal/collector/scheduler.go
@@ -387,6 +387,7 @@ func (s *Scheduler) postCollect(ctx context.Context, endpointName string, snapTi
 	// Mercure publish (non-fatal on failure).
 	nextFetch := time.Now().Add(nextSleep).UTC()
 	payload, err := json.Marshal(map[string]any{
+		"topic":     topic,
 		"league":    s.league,
 		"endpoint":  endpointName,
 		"timestamp": snapTime.Format(time.RFC3339),

--- a/internal/server/mercure.go
+++ b/internal/server/mercure.go
@@ -146,6 +146,19 @@ func (s *MercureSubscriber) connect(ctx context.Context) (connected bool, err er
 
 		if line == "" {
 			if event.Data != "" {
+				// dunglas/mercure SSE feeds carry only `id:` + `data:` — no
+				// `event:` line. Fall back to a `topic` field embedded in the
+				// JSON payload so dispatch can branch on event type. Unmarshal
+				// failure is non-fatal: the handler will fail to parse on its
+				// own and log accordingly.
+				if event.Topic == "" {
+					var meta struct {
+						Topic string `json:"topic"`
+					}
+					if json.Unmarshal([]byte(event.Data), &meta) == nil && meta.Topic != "" {
+						event.Topic = meta.Topic
+					}
+				}
 				s.handler(event)
 			}
 			event = MercureEvent{}

--- a/internal/server/mercure_test.go
+++ b/internal/server/mercure_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestMercureSubscriber_TopicFallbackToPayload locks in the POE-111 hotfix:
+// dunglas/mercure SSE feeds carry only `id:` + `data:` lines (no `event:`),
+// so dispatch logic that branches on `ev.Topic` would otherwise silently drop
+// every event. The subscriber must fall back to a `topic` field embedded in
+// the JSON payload when the SSE event field is absent.
+func TestMercureSubscriber_TopicFallbackToPayload(t *testing.T) {
+	tests := []struct {
+		name      string
+		ssePayload string
+		wantTopic string
+		wantData  string
+	}{
+		{
+			name:       "topic field in payload populates Topic",
+			ssePayload: `id: urn:uuid:111` + "\n" + `data: {"topic":"poe/collector/trade-tick","minAge":"5m"}` + "\n\n",
+			wantTopic:  "poe/collector/trade-tick",
+			wantData:   `{"topic":"poe/collector/trade-tick","minAge":"5m"}`,
+		},
+		{
+			name:       "no topic field leaves Topic empty",
+			ssePayload: `id: urn:uuid:222` + "\n" + `data: {"endpoint":"ninja-gems"}` + "\n\n",
+			wantTopic:  "",
+			wantData:   `{"endpoint":"ninja-gems"}`,
+		},
+		{
+			name:       "non-JSON data leaves Topic empty without panic",
+			ssePayload: `id: urn:uuid:333` + "\n" + `data: not-json` + "\n\n",
+			wantTopic:  "",
+			wantData:   "not-json",
+		},
+		{
+			name:       "explicit event line wins over payload topic",
+			ssePayload: `id: urn:uuid:444` + "\n" + `event: poe/explicit` + "\n" + `data: {"topic":"poe/payload"}` + "\n\n",
+			wantTopic:  "poe/explicit",
+			wantData:   `{"topic":"poe/payload"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				mu       sync.Mutex
+				received []MercureEvent
+			)
+			done := make(chan struct{})
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					t.Errorf("response writer does not support flushing")
+					return
+				}
+				fmt.Fprint(w, tc.ssePayload)
+				flusher.Flush()
+				<-r.Context().Done()
+			}))
+			defer srv.Close()
+
+			sub := NewMercureSubscriber(srv.URL, []string{"poe/collector/trade-tick"}, "", func(ev MercureEvent) {
+				mu.Lock()
+				received = append(received, ev)
+				mu.Unlock()
+				close(done)
+			})
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			runDone := make(chan struct{})
+			go func() {
+				sub.Run(ctx)
+				close(runDone)
+			}()
+
+			select {
+			case <-done:
+			case <-ctx.Done():
+				t.Fatalf("handler not invoked within 2s; SSE parse may be broken")
+			}
+
+			cancel()
+			<-runDone
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(received) != 1 {
+				t.Fatalf("expected exactly 1 event, got %d", len(received))
+			}
+			if received[0].Topic != tc.wantTopic {
+				t.Errorf("Topic: got %q, want %q", received[0].Topic, tc.wantTopic)
+			}
+			if received[0].Data != tc.wantData {
+				t.Errorf("Data: got %q, want %q", received[0].Data, tc.wantData)
+			}
+		})
+	}
+}

--- a/internal/server/mercure_test.go
+++ b/internal/server/mercure_test.go
@@ -52,6 +52,7 @@ func TestMercureSubscriber_TopicFallbackToPayload(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
 				mu       sync.Mutex
+				once     sync.Once
 				received []MercureEvent
 			)
 			done := make(chan struct{})
@@ -74,7 +75,7 @@ func TestMercureSubscriber_TopicFallbackToPayload(t *testing.T) {
 				mu.Lock()
 				received = append(received, ev)
 				mu.Unlock()
-				close(done)
+				once.Do(func() { close(done) })
 			})
 
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)


### PR DESCRIPTION
## Summary

Hotfix for **POE-111** — production trade refresh broken since POE-109 deployed.

`dunglas/mercure` SSE feeds carry only `id:` + `data:` lines (no `event:`), so the subscriber's `ev.Topic` is always empty. Pre-POE-109 this was harmless (dispatch keyed off `payload["endpoint"]` which all data events carry). POE-107's new dispatch in `cmd/server/main.go:386,395` introduced **topic-keyed branches** for `poe/admin/recompute` and `poe/collector/trade-tick` — those silently dropped every event in prod since the redeploy at 22:17 UTC.

Symptom in prod logs (40/30min):
```
WARN mercure: missing or non-string 'endpoint' in payload payload="map[minAge:5m minTier:MID variant:20/20]"
```

## Fix

- **Subscriber** (`internal/server/mercure.go`): when SSE `Topic` is empty after parsing, read `topic` from the JSON payload.
- **Publishers** include `"topic"` in payload:
  - `cmd/collector/main.go` `runTradeRefresher` and `runLayoutResetTicker`
  - `cmd/recalculate/main.go`
  - `internal/collector/scheduler.go` `postCollect` (for consistency, even though `endpoint` already routes correctly)
- **Test** (`internal/server/mercure_test.go`, new): 4 subtests locking the contract — topic from payload, no topic stays empty, non-JSON tolerated, explicit SSE `event:` line wins over payload.

## Tracker

POE-111: https://softsolution.youtrack.cloud/issue/POE-111
Related: POE-109 (the deploy that surfaced this latent bug).

## Test plan

- [x] `go test ./internal/server/... -run TestMercureSubscriber_TopicFallbackToPayload` — 4/4 PASS
- [x] `go test ./...` — all packages green
- [ ] **Post-deploy verification:**
  - `ssh profitofexile.top 'docker logs --since 5m $(docker ps -q -f name=vo7t5tzxr9sl3s1025f32wgy)' | grep -c "missing or non-string 'endpoint'"` → expect 0 (was ~40/30min)
  - Same log: visible `HandleTradeTick` / trade refresh outcomes every ~45s
  - `mercure subscriber connected` log line continues to show all 5 topics

## Notes

- Separate ticket POE-112 tracks the unrelated DB connection-slot exhaustion at deploy time (already self-recovered).
- After this merges, the auto-deploy will fire and the WARN flood should stop within a minute of the new server boot.

Generated with [Claude Code](https://claude.com/claude-code)