### PR TITLE
POE-119: League SSOT foundation and schema isolation migration

### DIFF
--- a/cmd/migrate/migrate_integration_test.go
+++ b/cmd/migrate/migrate_integration_test.go
@@ -96,7 +96,7 @@ func TestRunForceValidation(t *testing.T) {
 	}
 }
 
-func TestRunUpDownVersion(t *testing.T) {
+func TestRunUpAndVersion(t *testing.T) {
 	dbURL := testDatabaseURL(t)
 
 	// Apply all migrations.
@@ -109,18 +109,4 @@ func TestRunUpDownVersion(t *testing.T) {
 		t.Fatalf("migrate version after up: %v", err)
 	}
 
-	// Roll back one migration.
-	if err := run([]string{"down", "1"}, dbURL); err != nil {
-		t.Fatalf("migrate down 1: %v", err)
-	}
-
-	// Version should still work (either reports a version or "no migrations applied").
-	if err := run([]string{"version"}, dbURL); err != nil {
-		t.Fatalf("migrate version after down: %v", err)
-	}
-
-	// Re-apply to leave DB in a clean state.
-	if err := run([]string{"up"}, dbURL); err != nil {
-		t.Fatalf("migrate up (cleanup): %v", err)
-	}
 }

--- a/db/seeds/002_gem_snapshots.sql
+++ b/db/seeds/002_gem_snapshots.sql
@@ -6,44 +6,44 @@
 -- Uses timestamps spread across 3 hours to test time_bucket aggregations.
 -- Gem names match real PoE items for domain realism.
 
-INSERT INTO gem_snapshots (time, name, variant, is_corrupted, chaos, listings, is_transfigured, gem_color) VALUES
+INSERT INTO gem_snapshots (league, time, name, variant, is_corrupted, chaos, listings, is_transfigured, gem_color) VALUES
 
 -- Kinetic Blast of Fragmentation (transfigured RED gem, three snapshots, uncorrupted)
-('2026-03-10 09:00:00+00', 'Kinetic Blast of Fragmentation', '1/20', false, 177.00, 65, true, 'RED'),
-('2026-03-10 10:00:00+00', 'Kinetic Blast of Fragmentation', '1/20', false, 182.50, 58, true, 'RED'),
-('2026-03-10 11:00:00+00', 'Kinetic Blast of Fragmentation', '1/20', false, 170.00, 72, true, 'RED'),
+('Mirage', '2026-03-10 09:00:00+00', 'Kinetic Blast of Fragmentation', '1/20', false, 177.00, 65, true, 'RED'),
+('Mirage', '2026-03-10 10:00:00+00', 'Kinetic Blast of Fragmentation', '1/20', false, 182.50, 58, true, 'RED'),
+('Mirage', '2026-03-10 11:00:00+00', 'Kinetic Blast of Fragmentation', '1/20', false, 170.00, 72, true, 'RED'),
 
 -- Kinetic Blast of Fragmentation (corrupted — same gem/variant, different is_corrupted PK)
-('2026-03-10 09:00:00+00', 'Kinetic Blast of Fragmentation', '1/20', true, 55.00, 18, true, 'RED'),
-('2026-03-10 10:00:00+00', 'Kinetic Blast of Fragmentation', '1/20', true, 52.00, 21, true, 'RED'),
+('Mirage', '2026-03-10 09:00:00+00', 'Kinetic Blast of Fragmentation', '1/20', true, 55.00, 18, true, 'RED'),
+('Mirage', '2026-03-10 10:00:00+00', 'Kinetic Blast of Fragmentation', '1/20', true, 52.00, 21, true, 'RED'),
 
 -- Kinetic Blast base gem (not transfigured, BLUE gem per gem_colors seed)
-('2026-03-10 09:00:00+00', 'Kinetic Blast', '1/20', false, 7.00, 95, false, 'BLUE'),
-('2026-03-10 10:00:00+00', 'Kinetic Blast', '1/20', false, 6.50, 102, false, 'BLUE'),
+('Mirage', '2026-03-10 09:00:00+00', 'Kinetic Blast', '1/20', false, 7.00, 95, false, 'BLUE'),
+('Mirage', '2026-03-10 10:00:00+00', 'Kinetic Blast', '1/20', false, 6.50, 102, false, 'BLUE'),
 
 -- Ball Lightning of Orbiting (transfigured BLUE gem, 20/20 variant)
-('2026-03-10 09:00:00+00', 'Ball Lightning of Orbiting', '20/20', false, 350.00, 12, true, 'BLUE'),
-('2026-03-10 10:00:00+00', 'Ball Lightning of Orbiting', '20/20', false, 345.00, 14, true, 'BLUE'),
+('Mirage', '2026-03-10 09:00:00+00', 'Ball Lightning of Orbiting', '20/20', false, 350.00, 12, true, 'BLUE'),
+('Mirage', '2026-03-10 10:00:00+00', 'Ball Lightning of Orbiting', '20/20', false, 345.00, 14, true, 'BLUE'),
 
 -- Empower Support (base, RED gem per gem_colors seed, multiple variants)
-('2026-03-10 09:00:00+00', 'Empower Support', '1/0', false, 1.00, 407, false, 'RED'),
-('2026-03-10 09:00:00+00', 'Empower Support', '3/0', false, 45.00, 120, false, 'RED'),
-('2026-03-10 10:00:00+00', 'Empower Support', '3/0', false, 47.00, 115, false, 'RED'),
+('Mirage', '2026-03-10 09:00:00+00', 'Empower Support', '1/0', false, 1.00, 407, false, 'RED'),
+('Mirage', '2026-03-10 09:00:00+00', 'Empower Support', '3/0', false, 45.00, 120, false, 'RED'),
+('Mirage', '2026-03-10 10:00:00+00', 'Empower Support', '3/0', false, 47.00, 115, false, 'RED'),
 
 -- Empower Support corrupted (corrupted gems often trade at different prices)
-('2026-03-10 09:00:00+00', 'Empower Support', '3/0', true, 38.00, 85, false, 'RED'),
+('Mirage', '2026-03-10 09:00:00+00', 'Empower Support', '3/0', true, 38.00, 85, false, 'RED'),
 
 -- Vaal Grace (Vaal prefix gem, GREEN — corrupted by nature since Vaal gems are always corrupted)
-('2026-03-10 09:00:00+00', 'Vaal Grace', '20/20', true, 25.00, 88, false, 'GREEN'),
+('Mirage', '2026-03-10 09:00:00+00', 'Vaal Grace', '20/20', true, 25.00, 88, false, 'GREEN'),
 
 -- Edge case: low listings (confidence = LOW at < 5), corrupted
-('2026-03-10 09:00:00+00', 'Arcanist Brand of Volatility', '20/20', true, 750.00, 2, true, 'BLUE'),
+('Mirage', '2026-03-10 09:00:00+00', 'Arcanist Brand of Volatility', '20/20', true, 750.00, 2, true, 'BLUE'),
 
 -- Edge case: low listings uncorrupted for comparison
-('2026-03-10 09:00:00+00', 'Arcanist Brand of Volatility', '20/20', false, 900.00, 3, true, 'BLUE'),
+('Mirage', '2026-03-10 09:00:00+00', 'Arcanist Brand of Volatility', '20/20', false, 900.00, 3, true, 'BLUE'),
 
 -- Edge case: NULL chaos (price unavailable)
-('2026-03-10 09:00:00+00', 'Herald of Ice of Freezing', '1/20', false, NULL, 0, true, 'GREEN'),
+('Mirage', '2026-03-10 09:00:00+00', 'Herald of Ice of Freezing', '1/20', false, NULL, 0, true, 'GREEN'),
 
 -- Edge case: zero-value gem
-('2026-03-10 09:00:00+00', 'Determination', '1/0', false, 0.00, 500, false, 'RED');
+('Mirage', '2026-03-10 09:00:00+00', 'Determination', '1/0', false, 0.00, 500, false, 'RED');

--- a/db/seeds/003_font_snapshots.sql
+++ b/db/seeds/003_font_snapshots.sql
@@ -1,27 +1,27 @@
 -- Seed data for font_snapshots hypertable
 -- Covers: all 3 primary colors (RED/GREEN/BLUE), multiple variants,
--- multiple time points for aggregation testing, edge case min=max
+-- multiple time points for aggregation testing.
 --
 -- Values modeled on real Font of Divine Skill analysis output.
 
-INSERT INTO font_snapshots (time, color, variant, pool, ev, min_val, max_val) VALUES
+INSERT INTO font_snapshots (league, time, color, variant, pool, ev) VALUES
 
 -- RED color, 1/20 variant (3 snapshots for time_bucket testing)
-('2026-03-10 09:00:00+00', 'RED', '1/20', 33, 26.00, 3.00, 120.00),
-('2026-03-10 10:00:00+00', 'RED', '1/20', 33, 28.50, 3.00, 135.00),
-('2026-03-10 11:00:00+00', 'RED', '1/20', 33, 24.00, 3.00, 110.00),
+('Mirage', '2026-03-10 09:00:00+00', 'RED', '1/20', 33, 26.00),
+('Mirage', '2026-03-10 10:00:00+00', 'RED', '1/20', 33, 28.50),
+('Mirage', '2026-03-10 11:00:00+00', 'RED', '1/20', 33, 24.00),
 
 -- GREEN color, 1/20 variant
-('2026-03-10 09:00:00+00', 'GREEN', '1/20', 28, 18.00, 1.00, 85.00),
-('2026-03-10 10:00:00+00', 'GREEN', '1/20', 28, 19.50, 1.00, 90.00),
+('Mirage', '2026-03-10 09:00:00+00', 'GREEN', '1/20', 28, 18.00),
+('Mirage', '2026-03-10 10:00:00+00', 'GREEN', '1/20', 28, 19.50),
 
 -- BLUE color, 1/20 variant
-('2026-03-10 09:00:00+00', 'BLUE', '1/20', 25, 22.00, 2.00, 95.00),
-('2026-03-10 10:00:00+00', 'BLUE', '1/20', 25, 21.00, 2.00, 92.00),
+('Mirage', '2026-03-10 09:00:00+00', 'BLUE', '1/20', 25, 22.00),
+('Mirage', '2026-03-10 10:00:00+00', 'BLUE', '1/20', 25, 21.00),
 
 -- RED color, 20/20 variant (higher quality = better EV)
-('2026-03-10 09:00:00+00', 'RED', '20/20', 33, 45.00, 5.00, 200.00),
-('2026-03-10 10:00:00+00', 'RED', '20/20', 33, 48.00, 5.00, 210.00),
+('Mirage', '2026-03-10 09:00:00+00', 'RED', '20/20', 33, 45.00),
+('Mirage', '2026-03-10 10:00:00+00', 'RED', '20/20', 33, 48.00),
 
--- Edge case: min equals max (single gem in pool worth something)
-('2026-03-10 09:00:00+00', 'BLUE', '20/0', 1, 15.00, 15.00, 15.00);
+-- Edge case: single-gem pool
+('Mirage', '2026-03-10 09:00:00+00', 'BLUE', '20/0', 1, 15.00);

--- a/db/seeds/004_currency_snapshots.sql
+++ b/db/seeds/004_currency_snapshots.sql
@@ -6,29 +6,29 @@
 -- currency_snapshots stores periodic price snapshots from poe.ninja
 -- currency overview (chaos equivalent, trade volume, sparkline delta).
 
-INSERT INTO currency_snapshots (time, currency_id, chaos, volume, sparkline_change) VALUES
+INSERT INTO currency_snapshots (league, time, currency_id, chaos, volume, sparkline_change) VALUES
 
 -- Divine Orb (high value, high volume, price rising)
-('2026-03-10 09:00:00+00', 'divine-orb',     168.00000000, 4523.0000,  2.35),
-('2026-03-10 10:00:00+00', 'divine-orb',     169.50000000, 4410.0000,  2.50),
-('2026-03-10 11:00:00+00', 'divine-orb',     170.00000000, 4385.0000,  2.80),
+('Mirage', '2026-03-10 09:00:00+00', 'divine-orb',     168.00000000, 4523.0000,  2.35),
+('Mirage', '2026-03-10 10:00:00+00', 'divine-orb',     169.50000000, 4410.0000,  2.50),
+('Mirage', '2026-03-10 11:00:00+00', 'divine-orb',     170.00000000, 4385.0000,  2.80),
 
 -- Exalted Orb (moderate value, moderate volume, price declining)
-('2026-03-10 09:00:00+00', 'exalted-orb',     12.00000000, 1820.0000, -1.10),
-('2026-03-10 10:00:00+00', 'exalted-orb',     11.80000000, 1795.0000, -1.45),
-('2026-03-10 11:00:00+00', 'exalted-orb',     11.50000000, 1810.0000, -1.80),
+('Mirage', '2026-03-10 09:00:00+00', 'exalted-orb',     12.00000000, 1820.0000, -1.10),
+('Mirage', '2026-03-10 10:00:00+00', 'exalted-orb',     11.80000000, 1795.0000, -1.45),
+('Mirage', '2026-03-10 11:00:00+00', 'exalted-orb',     11.50000000, 1810.0000, -1.80),
 
 -- Gemcutter's Prism (low value, carries over from old gcp_snapshots)
-('2026-03-10 09:00:00+00', 'gemcutters-prism', 4.00000000,  950.0000,  0.00),
-('2026-03-10 10:00:00+00', 'gemcutters-prism', 4.10000000,  940.0000,  0.25),
-('2026-03-10 11:00:00+00', 'gemcutters-prism', 3.90000000,  965.0000, -0.15),
+('Mirage', '2026-03-10 09:00:00+00', 'gemcutters-prism', 4.00000000,  950.0000,  0.00),
+('Mirage', '2026-03-10 10:00:00+00', 'gemcutters-prism', 4.10000000,  940.0000,  0.25),
+('Mirage', '2026-03-10 11:00:00+00', 'gemcutters-prism', 3.90000000,  965.0000, -0.15),
 
 -- Vaal Orb (stable price, zero sparkline)
-('2026-03-10 09:00:00+00', 'vaal-orb',         1.50000000,  620.0000,  0.00),
-('2026-03-10 10:00:00+00', 'vaal-orb',         1.50000000,  615.0000,  0.00),
+('Mirage', '2026-03-10 09:00:00+00', 'vaal-orb',         1.50000000,  620.0000,  0.00),
+('Mirage', '2026-03-10 10:00:00+00', 'vaal-orb',         1.50000000,  615.0000,  0.00),
 
 -- Edge case: NULL chaos (API returned no price)
-('2026-03-10 11:00:00+00', 'vaal-orb',         NULL,           0.0000,  NULL),
+('Mirage', '2026-03-10 11:00:00+00', 'vaal-orb',         NULL,           0.0000,  NULL),
 
 -- Edge case: zero volume (no trades observed)
-('2026-03-10 09:00:00+00', 'mirror-of-kalandra', 95000.00000000, 0.0000, 0.00);
+('Mirage', '2026-03-10 09:00:00+00', 'mirror-of-kalandra', 95000.00000000, 0.0000, 0.00);

--- a/docs/LEAGUE-SCHEMA-MIGRATION-RUNBOOK.md
+++ b/docs/LEAGUE-SCHEMA-MIGRATION-RUNBOOK.md
@@ -1,0 +1,129 @@
+# League Schema Migration Runbook
+
+**Status:** Current operational gate for POE-119; execute only with the
+matching POE-120/POE-121 application revision.
+
+**Last verified:** 2026-07-23 against the POE-119 migration set, embedded
+migration loader, and deployment workflow.
+
+**Canonical for:** rehearsal and production execution of the POE-119
+league-scoping schema migration. The tracker tasks remain canonical for the
+application implementation.
+
+## Gate
+
+POE-119 cannot deploy independently. Its migrations make `league` mandatory
+on twelve data tables, while the pre-POE-120/POE-121 writers do not supply it
+and server analysis is not yet scoped. Before starting, an operator must
+confirm all of the following in the change record:
+
+1. A pre-deploy backup exists and has a documented restore procedure.
+2. The server and collector are staged from the same immutable revision that
+   contains the POE-120/POE-121 compatible writers, readers, and analysis
+   paths.
+3. The server and collector are both stopped by an operator; record the
+   confirmation and time. Do not rely on a deploy trigger to stop either one.
+4. A successful isolated rehearsal completed using the same migration files
+   and intended service revision.
+
+Do not use generic down migrations against restored production data. Recovery
+is restore of the pre-deploy backup, then investigation and a new forward
+migration; it is not `migrate down`.
+
+## Rehearsal
+
+Use an isolated, disposable database restored from a production backup. Never
+run the rehearsal against the live database.
+
+1. Restore a complete database backup, or export and import every hypertable
+   with `COPY (SELECT * FROM <hypertable>)`. Do not use `pg_dump -t` for every
+   hypertable as the rehearsal source.
+2. Before migration, record the revision under test, PostgreSQL and TimescaleDB
+   versions, `schema_migrations` version/dirty state, compression and
+   continuous-aggregate policies, aggregate indexes, and the twelve-table
+   count manifest below.
+3. Compare the restored counts to the captured source manifest. Stop if any
+   count differs; the rehearsal is invalid until the restore is explained.
+4. Start only the staged server revision. Its startup migration must complete
+   before the server binds; the collector must remain stopped.
+5. Record the post-migration migration state and repeat the count manifest.
+   Each table must retain its count, and every table must have zero null
+   `league` values.
+6. Refresh a controlled, completed source window in dependency order: hourly
+   aggregate first, then daily. Do not refresh daily before hourly.
+
+   ```sql
+   CALL refresh_continuous_aggregate(
+       'gem_snapshots_hourly',
+       TIMESTAMPTZ '<completed-window-start>',
+       TIMESTAMPTZ '<completed-window-end>'
+   );
+   CALL refresh_continuous_aggregate(
+       'gem_snapshots_daily',
+       TIMESTAMPTZ '<completed-window-start>',
+       TIMESTAMPTZ '<completed-window-end>'
+   );
+   ```
+
+7. With a controlled fixture in the disposable restore, prove aggregate
+   isolation: two valid league values with otherwise matching source dimensions
+   produce separate hourly and daily aggregate rows. Discard the fixture with
+   the restored database.
+8. Record migration duration. Start the staged collector only after the server
+   migration and health checks pass. Confirm server and collector startup
+   health, then dispose of the rehearsal database.
+
+## Twelve-table count manifest
+
+Capture a `COUNT(*)` for each relation before and after the migration. The
+manifest is complete only with all twelve rows:
+
+| Relation | Pre-migration count | Post-migration count | Null `league` count |
+| --- | ---: | ---: | ---: |
+| `gem_snapshots` |  |  |  |
+| `currency_snapshots` |  |  |  |
+| `fragment_snapshots` |  |  |  |
+| `font_snapshots` |  |  |  |
+| `transfigure_results` |  |  |  |
+| `quality_results` |  |  |  |
+| `trend_results` |  |  |  |
+| `gem_features` |  |  |  |
+| `gem_signals` |  |  |  |
+| `dedication_snapshots` |  |  |  |
+| `trade_lookups` |  |  |  |
+| `market_context` |  |  |  |
+
+## Production execution
+
+1. Reconfirm the gate, backup, server/collector revision, operator-confirmed
+   stops, and successful rehearsal. Record the intended start time.
+2. Keep the collector stopped. Start the staged server revision and wait for
+   migration completion, migration state, and server health. Record duration.
+3. Verify the twelve-table counts and zero-null-league result, the recreated
+   continuous aggregates and indexes, and retain the completed-window
+   league-isolation proof from rehearsal with the production change record.
+4. Start the collector from the same revision only after those checks pass.
+   Verify collector health and a scoped write/read path.
+5. If any gate or check fails, keep both services stopped and restore the
+   pre-deploy backup. Do not attempt a generic down migration on production
+   data.
+
+## Evidence to retain
+
+Retain the source and restored count manifests; version, migration-state,
+policy, and aggregate-index captures; operator stop/start confirmations;
+rehearsal and production durations; aggregate-isolation proof; and server and
+collector health results. Keep them with the deployment record, not this public
+repository.
+
+## Verified implementation references
+
+- `internal/db/migrate.go` embeds `internal/db/migrations/` and is used by
+  both the server and `cmd/migrate`.
+- `cmd/server/main.go` applies pending migrations before binding its HTTP
+  listener; `cmd/collector/main.go` deliberately does not migrate.
+- `internal/db/migrations/20260723160017_league_scope_gem_snapshots.up.sql`
+  recreates the hourly aggregate before the daily aggregate and their indexes
+  and policies.
+- `.github/workflows/deploy.yml` can deploy server and collector separately;
+  this runbook's same-revision gate prevents a mixed writer/schema deployment.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This is the documentation entry point. Documents are classified so historical pl
 - [Trade and Market Data Lifecycles](TRADE-LIFECYCLE.md) — current workflows plus clearly labeled reliability targets for collection, native trade, contributions, optional server trading, pairing, and Mercure.
 - [Overlay Guide](OVERLAY-GUIDE.md) — maintained Windows/Tauri overlay mechanics and regression guards.
 - [Collector Endpoint Guide](COLLECTOR-ENDPOINTS.md) — current cross-layer recipe for adding a market-data source.
+- [League Schema Migration Runbook](LEAGUE-SCHEMA-MIGRATION-RUNBOOK.md) — current production gate and rehearsal procedure for POE-119; requires the matching POE-120/POE-121 application revision.
 - [Architecture decisions](adr/) — accepted and superseded architecture decisions.
 
 ## Proposed specifications
@@ -32,6 +33,7 @@ The three are interdependent: league identity scopes events and data, Mercure de
 - [ADR-006: Database-backed gem colors](adr/006-gem-colors-db-backed-upsert-table.md)
 - [ADR-007: Unified analysis pipeline](adr/007-v3-hybrid-analysis-unified-pipeline.md)
 - [ADR-008: Current Go package architecture](adr/008-current-go-package-architecture.md)
+- [ADR-009: League-scoped repository convention](adr/009-league-scope-repository-convention.md)
 
 Superseded:
 

--- a/docs/adr/004-database-migration-strategy.md
+++ b/docs/adr/004-database-migration-strategy.md
@@ -22,7 +22,9 @@ Key considerations:
 
 ## Decision
 
-Use `golang-migrate/migrate/v4` with `file`-sourced SQL migrations in `db/migrations/`. Migrations run automatically on app start. A dedicated CLI binary provides manual control.
+Use `golang-migrate/migrate/v4` with SQL migrations embedded from
+`internal/db/migrations/`. Migrations run automatically on server start. A
+dedicated CLI binary provides manual control.
 
 ### Auto-migration on start
 
@@ -31,7 +33,13 @@ Use `golang-migrate/migrate/v4` with `file`-sourced SQL migrations in `db/migrat
 - `migrate.ErrNoChange` is not an error — log at Info and continue.
 - Any other error → `slog.Error("auto-migrate failed", "error", err)` + `os.Exit(1)`. The app does not start with a broken schema.
 
-This applies to both dev and production. The migration source path is `file://db/migrations`, resolved relative to the working directory (`/app` in the container).
+This applies to both development and production. `internal/db/migrate.go`
+embeds the migration directory in `db.MigrationsFS` and constructs an `iofs`
+source for both the server and the migration CLI. The migration source is
+therefore independent of the process working directory.
+
+The collector does not run migrations. It must start only after the server has
+applied the matching revision's migrations successfully.
 
 ### Dedicated migration binary
 
@@ -57,8 +65,8 @@ make migrate-force VERSION=<n>   # force <n>
 Timestamp-based: `YYYYMMDDHHmmSS_<description>.{up,down}.sql`. Example:
 
 ```
-db/migrations/20260312100000_create_strategies.up.sql
-db/migrations/20260312100000_create_strategies.down.sql
+internal/db/migrations/20260312100000_create_strategies.up.sql
+internal/db/migrations/20260312100000_create_strategies.down.sql
 ```
 
 Timestamps avoid merge conflicts when two branches add migrations simultaneously (unlike sequential integers).
@@ -75,7 +83,8 @@ Timestamps avoid merge conflicts when two branches add migrations simultaneously
 ### Negative
 
 - Auto-migration on start means a bad migration will take down the app on every restart until fixed or rolled back. Operators need awareness of this behaviour.
-- The `file://` source path couples the binary to its working directory (`/app`). Running outside Docker requires setting the CWD or adjusting the path.
+- The migration set is compiled into each server and migration CLI binary.
+  Operators must use a binary built from the intended revision.
 - No migration locking across multiple replicas in v1 — golang-migrate uses an advisory lock, so concurrent starts are safe, but this is worth revisiting if horizontal scaling is introduced.
 
 ## Alternatives Considered
@@ -92,11 +101,15 @@ Alternative migration library with sequential or timestamp naming, Go-based migr
 
 **Rejected because**: golang-migrate was already cited in ADR-003 as the chosen tool. goose offers similar functionality but switching would diverge from the established decision without clear gain. golang-migrate's separate `up`/`down` SQL files are a better fit for this project's SQL-first approach.
 
-### Embed migrations in binary
+### External filesystem migration source
 
-Use Go `embed` to bundle migration files into the server binary, eliminating the `file://` path dependency.
+Read migrations from a `file://` source relative to the process working
+directory.
 
-**Rejected because**: Adds build-time complexity (embed directive, iofs source) for v1 when the container's working directory is deterministic. Can be revisited if the binary ever needs to run outside its expected container context.
+**Rejected because**: The current implementation embeds
+`internal/db/migrations/` and uses the same source in the server and
+`cmd/migrate`. An external source would reintroduce working-directory coupling
+and could let the running binary and applied migrations diverge.
 
 ### Manual-only migrations (no auto-migrate)
 
@@ -107,4 +120,7 @@ Require explicit `make migrate` before every deploy.
 ## References
 
 - [ADR-003](003-no-orm-direct-pgx-queries.md) — established golang-migrate as the migration tool; this ADR defines the operational model
+- `internal/db/migrate.go` — embedded migration source and `MigrateUp`
+- `cmd/server/main.go` — auto-migration before the HTTP server binds
+- `cmd/migrate/main.go` — manual migration commands
 - POE-15 — database layer + migration tooling task that prompted these decisions

--- a/docs/adr/009-league-scope-repository-convention.md
+++ b/docs/adr/009-league-scope-repository-convention.md
@@ -1,0 +1,51 @@
+# ADR-009: League-Scoped Repository Convention
+
+## Status
+
+Accepted
+
+## Context
+
+POE-119 adds a league column to the twelve historical data tables and introduces
+`runtime_config` as the database-backed selection of the active league. A
+repository query without a league predicate can mix observations and analysis
+from distinct leagues. A string parameter at individual call sites does not
+make the selection's configuration revision visible or establish one convention
+for historical access.
+
+`internal/league.Scope` identifies the selected league and carries the runtime
+configuration revision returned by `league.Resolve`. `league.Historical`
+explicitly creates a revision-neutral scope for historical research.
+
+## Decision
+
+Repositories that read or write league-scoped data must accept
+`league.Scope`. They use `scope.ID()` in all predicates and inserted rows; they
+do not resolve the active league internally and do not accept a bare league ID
+for normal scoped operations.
+
+The caller resolves the scope once at the lifecycle boundary, then passes the
+same value through every repository and analysis operation in that workflow.
+`Scope.Revision()` is carried with the selection so callers can detect a
+runtime-configuration change before committing work that depends on it.
+
+Historical reads must be explicit through `league.Historical`; they do not
+silently substitute the active league.
+
+## Consequences
+
+- Repository signatures reveal the required data-isolation boundary.
+- A workflow can retain one league identity and configuration revision across
+  multiple repository calls.
+- POE-120 and POE-121 must apply this convention to existing writers, readers,
+  and analysis paths before the POE-119 schema migration is deployed.
+- Unscoped lookup/control repositories remain unscoped only when they cannot
+  access league-scoped data.
+
+## Evidence
+
+- `internal/league/league.go` — `Scope`, runtime resolution, and historical
+  selection.
+- `internal/db/migrations/20260723160016_create_league_control_tables.up.sql`
+  — `leagues` and `runtime_config`.
+- POE-119 — schema foundation that establishes the storage boundary.

--- a/internal/db/migrations/20260723160016_create_league_control_tables.down.sql
+++ b/internal/db/migrations/20260723160016_create_league_control_tables.down.sql
@@ -1,0 +1,5 @@
+DO $$
+BEGIN
+    RAISE EXCEPTION '20260723160016_create_league_control_tables is forward-only; restore from a pre-migration backup';
+END
+$$;

--- a/internal/db/migrations/20260723160016_create_league_control_tables.up.sql
+++ b/internal/db/migrations/20260723160016_create_league_control_tables.up.sql
@@ -1,0 +1,29 @@
+BEGIN;
+
+CREATE TABLE leagues (
+    id               TEXT PRIMARY KEY,
+    display_name     TEXT NOT NULL UNIQUE,
+    starts_at        TIMESTAMPTZ,
+    ends_at          TIMESTAMPTZ,
+    collection_state TEXT NOT NULL CHECK (collection_state IN ('prepared', 'collecting', 'archived')),
+    prepared_at      TIMESTAMPTZ,
+    activated_at     TIMESTAMPTZ,
+    archived_at      TIMESTAMPTZ,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE runtime_config (
+    singleton     BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+    active_league TEXT NOT NULL REFERENCES leagues(id),
+    revision      BIGINT NOT NULL DEFAULT 1,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+INSERT INTO leagues (id, display_name, collection_state, prepared_at, activated_at)
+VALUES ('Mirage', 'Mirage', 'collecting', NOW(), NOW());
+
+INSERT INTO runtime_config (active_league, revision)
+VALUES ('Mirage', 1);
+
+COMMIT;

--- a/internal/db/migrations/20260723160017_league_scope_gem_snapshots.down.sql
+++ b/internal/db/migrations/20260723160017_league_scope_gem_snapshots.down.sql
@@ -1,0 +1,5 @@
+DO $$
+BEGIN
+    RAISE EXCEPTION '20260723160017_league_scope_gem_snapshots is forward-only; restore from a pre-migration backup';
+END
+$$;

--- a/internal/db/migrations/20260723160017_league_scope_gem_snapshots.up.sql
+++ b/internal/db/migrations/20260723160017_league_scope_gem_snapshots.up.sql
@@ -1,0 +1,101 @@
+SELECT remove_continuous_aggregate_policy('gem_snapshots_daily', if_exists => TRUE);
+SELECT remove_continuous_aggregate_policy('gem_snapshots_hourly', if_exists => TRUE);
+DROP MATERIALIZED VIEW IF EXISTS gem_snapshots_daily;
+DROP MATERIALIZED VIEW IF EXISTS gem_snapshots_hourly;
+
+SELECT remove_compression_policy('gem_snapshots', if_exists => TRUE);
+
+DO $$
+DECLARE
+    chunk REGCLASS;
+BEGIN
+    FOR chunk IN
+        SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS
+        FROM timescaledb_information.chunks
+        WHERE hypertable_name = 'gem_snapshots' AND is_compressed
+    LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+
+ALTER TABLE gem_snapshots ADD COLUMN league TEXT;
+UPDATE gem_snapshots SET league = 'Mirage' WHERE league IS NULL;
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1
+        FROM gem_snapshots snapshots
+        LEFT JOIN leagues ON leagues.id = snapshots.league
+        WHERE snapshots.league IS NULL OR leagues.id IS NULL
+    ) THEN
+        RAISE EXCEPTION 'gem_snapshots contains a null or unknown league after backfill';
+    END IF;
+END
+$$;
+
+ALTER TABLE gem_snapshots DROP CONSTRAINT gem_snapshots_pkey;
+ALTER TABLE gem_snapshots ADD PRIMARY KEY (league, time, name, variant, is_corrupted);
+
+DROP INDEX IF EXISTS idx_gem_snapshots_name_variant;
+CREATE INDEX idx_gem_snapshots_league_name_variant ON gem_snapshots (league, name, variant, time DESC);
+
+ALTER TABLE gem_snapshots SET (
+    timescaledb.compress,
+    timescaledb.compress_segmentby = 'league, name, variant',
+    timescaledb.compress_orderby = 'time DESC'
+);
+SELECT add_compression_policy('gem_snapshots', INTERVAL '7 days');
+
+ALTER TABLE gem_snapshots ALTER COLUMN league SET NOT NULL;
+
+CREATE MATERIALIZED VIEW gem_snapshots_hourly
+WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
+SELECT
+    time_bucket('1 hour', time) AS bucket,
+    league,
+    name,
+    variant,
+    is_corrupted,
+    avg(chaos) AS avg_chaos,
+    avg(listings::numeric) AS avg_listings,
+    last(gem_color, time) AS gem_color,
+    last(is_transfigured, time) AS is_transfigured
+FROM gem_snapshots
+GROUP BY bucket, league, name, variant, is_corrupted
+WITH NO DATA;
+
+CREATE INDEX idx_gem_snapshots_hourly_league_name_variant
+    ON gem_snapshots_hourly (league, name, variant, is_corrupted, bucket DESC);
+
+SELECT add_continuous_aggregate_policy('gem_snapshots_hourly',
+    start_offset => INTERVAL '3 hours',
+    end_offset => INTERVAL '1 hour',
+    schedule_interval => INTERVAL '1 hour'
+);
+
+CREATE MATERIALIZED VIEW gem_snapshots_daily
+WITH (timescaledb.continuous, timescaledb.materialized_only = false) AS
+SELECT
+    time_bucket('1 day', bucket) AS bucket,
+    league,
+    name,
+    variant,
+    is_corrupted,
+    avg(avg_chaos) AS avg_chaos,
+    avg(avg_listings) AS avg_listings,
+    last(gem_color, bucket) AS gem_color,
+    last(is_transfigured, bucket) AS is_transfigured
+FROM gem_snapshots_hourly
+GROUP BY time_bucket('1 day', bucket), league, name, variant, is_corrupted
+WITH NO DATA;
+
+CREATE INDEX idx_gem_snapshots_daily_league_name_variant
+    ON gem_snapshots_daily (league, name, variant, is_corrupted, bucket DESC);
+
+SELECT add_continuous_aggregate_policy('gem_snapshots_daily',
+    start_offset => INTERVAL '3 days',
+    end_offset => INTERVAL '1 day',
+    schedule_interval => INTERVAL '1 day'
+);

--- a/internal/db/migrations/20260723160018_league_scope_currency_snapshots.down.sql
+++ b/internal/db/migrations/20260723160018_league_scope_currency_snapshots.down.sql
@@ -1,0 +1,1 @@
+DO $$ BEGIN RAISE EXCEPTION '20260723160018_league_scope_currency_snapshots is forward-only; restore from a pre-migration backup'; END $$;

--- a/internal/db/migrations/20260723160018_league_scope_currency_snapshots.up.sql
+++ b/internal/db/migrations/20260723160018_league_scope_currency_snapshots.up.sql
@@ -1,0 +1,23 @@
+SELECT remove_compression_policy('currency_snapshots', if_exists => TRUE);
+DO $$
+DECLARE chunk REGCLASS;
+BEGIN
+    FOR chunk IN SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS FROM timescaledb_information.chunks WHERE hypertable_name = 'currency_snapshots' AND is_compressed LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+ALTER TABLE currency_snapshots ADD COLUMN league TEXT;
+UPDATE currency_snapshots SET league = 'Mirage' WHERE league IS NULL;
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM currency_snapshots snapshots LEFT JOIN leagues ON leagues.id = snapshots.league WHERE snapshots.league IS NULL OR leagues.id IS NULL) THEN
+        RAISE EXCEPTION 'currency_snapshots contains a null or unknown league after backfill';
+    END IF;
+END $$;
+ALTER TABLE currency_snapshots DROP CONSTRAINT currency_snapshots_pkey;
+ALTER TABLE currency_snapshots ADD PRIMARY KEY (league, time, currency_id);
+DROP INDEX IF EXISTS idx_currency_snapshots_id_time;
+CREATE INDEX idx_currency_snapshots_league_id_time ON currency_snapshots (league, currency_id, time DESC);
+ALTER TABLE currency_snapshots SET (timescaledb.compress, timescaledb.compress_segmentby = 'league, currency_id', timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('currency_snapshots', INTERVAL '7 days');
+ALTER TABLE currency_snapshots ALTER COLUMN league SET NOT NULL;

--- a/internal/db/migrations/20260723160019_league_scope_fragment_snapshots.down.sql
+++ b/internal/db/migrations/20260723160019_league_scope_fragment_snapshots.down.sql
@@ -1,0 +1,1 @@
+DO $$ BEGIN RAISE EXCEPTION '20260723160019_league_scope_fragment_snapshots is forward-only; restore from a pre-migration backup'; END $$;

--- a/internal/db/migrations/20260723160019_league_scope_fragment_snapshots.up.sql
+++ b/internal/db/migrations/20260723160019_league_scope_fragment_snapshots.up.sql
@@ -1,0 +1,23 @@
+SELECT remove_compression_policy('fragment_snapshots', if_exists => TRUE);
+DO $$
+DECLARE chunk REGCLASS;
+BEGIN
+    FOR chunk IN SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS FROM timescaledb_information.chunks WHERE hypertable_name = 'fragment_snapshots' AND is_compressed LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+ALTER TABLE fragment_snapshots ADD COLUMN league TEXT;
+UPDATE fragment_snapshots SET league = 'Mirage' WHERE league IS NULL;
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM fragment_snapshots snapshots LEFT JOIN leagues ON leagues.id = snapshots.league WHERE snapshots.league IS NULL OR leagues.id IS NULL) THEN
+        RAISE EXCEPTION 'fragment_snapshots contains a null or unknown league after backfill';
+    END IF;
+END $$;
+ALTER TABLE fragment_snapshots DROP CONSTRAINT fragment_snapshots_pkey;
+ALTER TABLE fragment_snapshots ADD PRIMARY KEY (league, time, fragment_id);
+DROP INDEX IF EXISTS idx_fragment_snapshots_id_time;
+CREATE INDEX idx_fragment_snapshots_league_id_time ON fragment_snapshots (league, fragment_id, time DESC);
+ALTER TABLE fragment_snapshots SET (timescaledb.compress, timescaledb.compress_segmentby = 'league, fragment_id', timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('fragment_snapshots', INTERVAL '7 days');
+ALTER TABLE fragment_snapshots ALTER COLUMN league SET NOT NULL;

--- a/internal/db/migrations/20260723160020_league_scope_font_snapshots.down.sql
+++ b/internal/db/migrations/20260723160020_league_scope_font_snapshots.down.sql
@@ -1,0 +1,1 @@
+DO $$ BEGIN RAISE EXCEPTION '20260723160020_league_scope_font_snapshots is forward-only; restore from a pre-migration backup'; END $$;

--- a/internal/db/migrations/20260723160020_league_scope_font_snapshots.up.sql
+++ b/internal/db/migrations/20260723160020_league_scope_font_snapshots.up.sql
@@ -1,0 +1,23 @@
+SELECT remove_compression_policy('font_snapshots', if_exists => TRUE);
+DO $$
+DECLARE chunk REGCLASS;
+BEGIN
+    FOR chunk IN SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS FROM timescaledb_information.chunks WHERE hypertable_name = 'font_snapshots' AND is_compressed LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+ALTER TABLE font_snapshots ADD COLUMN league TEXT;
+UPDATE font_snapshots SET league = 'Mirage' WHERE league IS NULL;
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM font_snapshots snapshots LEFT JOIN leagues ON leagues.id = snapshots.league WHERE snapshots.league IS NULL OR leagues.id IS NULL) THEN
+        RAISE EXCEPTION 'font_snapshots contains a null or unknown league after backfill';
+    END IF;
+END $$;
+ALTER TABLE font_snapshots DROP CONSTRAINT font_snapshots_pkey;
+ALTER TABLE font_snapshots ADD PRIMARY KEY (league, time, color, variant, mode);
+DROP INDEX IF EXISTS idx_font_snapshots_color_variant;
+CREATE INDEX idx_font_snapshots_league_color_variant ON font_snapshots (league, color, variant, time DESC);
+ALTER TABLE font_snapshots SET (timescaledb.compress, timescaledb.compress_segmentby = 'league, color, variant', timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('font_snapshots', INTERVAL '7 days');
+ALTER TABLE font_snapshots ALTER COLUMN league SET NOT NULL;

--- a/internal/db/migrations/20260723160021_league_scope_transfigure_results.down.sql
+++ b/internal/db/migrations/20260723160021_league_scope_transfigure_results.down.sql
@@ -1,0 +1,1 @@
+DO $$ BEGIN RAISE EXCEPTION '20260723160021_league_scope_transfigure_results is forward-only; restore from a pre-migration backup'; END $$;

--- a/internal/db/migrations/20260723160021_league_scope_transfigure_results.up.sql
+++ b/internal/db/migrations/20260723160021_league_scope_transfigure_results.up.sql
@@ -1,0 +1,25 @@
+SELECT remove_compression_policy('transfigure_results', if_exists => TRUE);
+DO $$
+DECLARE chunk REGCLASS;
+BEGIN
+    FOR chunk IN SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS FROM timescaledb_information.chunks WHERE hypertable_name = 'transfigure_results' AND is_compressed LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+ALTER TABLE transfigure_results ADD COLUMN league TEXT;
+UPDATE transfigure_results SET league = 'Mirage' WHERE league IS NULL;
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM transfigure_results results LEFT JOIN leagues ON leagues.id = results.league WHERE results.league IS NULL OR leagues.id IS NULL) THEN
+        RAISE EXCEPTION 'transfigure_results contains a null or unknown league after backfill';
+    END IF;
+END $$;
+ALTER TABLE transfigure_results DROP CONSTRAINT transfigure_results_pkey;
+ALTER TABLE transfigure_results ADD PRIMARY KEY (league, time, transfigured_name, variant);
+DROP INDEX IF EXISTS idx_transfigure_results_roi;
+DROP INDEX IF EXISTS idx_transfigure_results_variant;
+CREATE INDEX idx_transfigure_results_league_roi ON transfigure_results (league, time DESC, roi DESC);
+CREATE INDEX idx_transfigure_results_league_variant ON transfigure_results (league, variant, time DESC);
+ALTER TABLE transfigure_results SET (timescaledb.compress, timescaledb.compress_segmentby = 'league, variant', timescaledb.compress_orderby = 'time DESC, roi DESC');
+SELECT add_compression_policy('transfigure_results', INTERVAL '7 days');
+ALTER TABLE transfigure_results ALTER COLUMN league SET NOT NULL;

--- a/internal/db/migrations/20260723160022_league_scope_quality_results.down.sql
+++ b/internal/db/migrations/20260723160022_league_scope_quality_results.down.sql
@@ -1,0 +1,1 @@
+DO $$ BEGIN RAISE EXCEPTION '20260723160022_league_scope_quality_results is forward-only; restore from a pre-migration backup'; END $$;

--- a/internal/db/migrations/20260723160022_league_scope_quality_results.up.sql
+++ b/internal/db/migrations/20260723160022_league_scope_quality_results.up.sql
@@ -1,0 +1,25 @@
+SELECT remove_compression_policy('quality_results', if_exists => TRUE);
+DO $$
+DECLARE chunk REGCLASS;
+BEGIN
+    FOR chunk IN SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS FROM timescaledb_information.chunks WHERE hypertable_name = 'quality_results' AND is_compressed LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+ALTER TABLE quality_results ADD COLUMN league TEXT;
+UPDATE quality_results SET league = 'Mirage' WHERE league IS NULL;
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM quality_results results LEFT JOIN leagues ON leagues.id = results.league WHERE results.league IS NULL OR leagues.id IS NULL) THEN
+        RAISE EXCEPTION 'quality_results contains a null or unknown league after backfill';
+    END IF;
+END $$;
+ALTER TABLE quality_results DROP CONSTRAINT quality_results_pkey;
+ALTER TABLE quality_results ADD PRIMARY KEY (league, time, name, level);
+DROP INDEX IF EXISTS idx_quality_results_roi;
+DROP INDEX IF EXISTS idx_quality_results_level;
+CREATE INDEX idx_quality_results_league_roi ON quality_results (league, time DESC, avg_roi DESC);
+CREATE INDEX idx_quality_results_league_level ON quality_results (league, level, time DESC);
+ALTER TABLE quality_results SET (timescaledb.compress, timescaledb.compress_segmentby = 'league, level', timescaledb.compress_orderby = 'time DESC, avg_roi DESC');
+SELECT add_compression_policy('quality_results', INTERVAL '7 days');
+ALTER TABLE quality_results ALTER COLUMN league SET NOT NULL;

--- a/internal/db/migrations/20260723160023_league_scope_trend_results.down.sql
+++ b/internal/db/migrations/20260723160023_league_scope_trend_results.down.sql
@@ -1,0 +1,1 @@
+DO $$ BEGIN RAISE EXCEPTION '20260723160023_league_scope_trend_results is forward-only; restore from a pre-migration backup'; END $$;

--- a/internal/db/migrations/20260723160023_league_scope_trend_results.up.sql
+++ b/internal/db/migrations/20260723160023_league_scope_trend_results.up.sql
@@ -1,0 +1,25 @@
+SELECT remove_compression_policy('trend_results', if_exists => TRUE);
+DO $$
+DECLARE chunk REGCLASS;
+BEGIN
+    FOR chunk IN SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS FROM timescaledb_information.chunks WHERE hypertable_name = 'trend_results' AND is_compressed LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+ALTER TABLE trend_results ADD COLUMN league TEXT;
+UPDATE trend_results SET league = 'Mirage' WHERE league IS NULL;
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM trend_results results LEFT JOIN leagues ON leagues.id = results.league WHERE results.league IS NULL OR leagues.id IS NULL) THEN
+        RAISE EXCEPTION 'trend_results contains a null or unknown league after backfill';
+    END IF;
+END $$;
+ALTER TABLE trend_results DROP CONSTRAINT trend_results_pkey;
+ALTER TABLE trend_results ADD PRIMARY KEY (league, time, name, variant);
+DROP INDEX IF EXISTS idx_trend_results_signal;
+DROP INDEX IF EXISTS idx_trend_results_variant;
+CREATE INDEX idx_trend_results_league_signal ON trend_results (league, time DESC, signal);
+CREATE INDEX idx_trend_results_league_variant ON trend_results (league, variant, time DESC);
+ALTER TABLE trend_results SET (timescaledb.compress, timescaledb.compress_segmentby = 'league, variant', timescaledb.compress_orderby = 'time DESC, name');
+SELECT add_compression_policy('trend_results', INTERVAL '7 days');
+ALTER TABLE trend_results ALTER COLUMN league SET NOT NULL;

--- a/internal/db/migrations/20260723160024_league_scope_gem_features.down.sql
+++ b/internal/db/migrations/20260723160024_league_scope_gem_features.down.sql
@@ -1,0 +1,1 @@
+DO $$ BEGIN RAISE EXCEPTION '20260723160024_league_scope_gem_features is forward-only; restore from a pre-migration backup'; END $$;

--- a/internal/db/migrations/20260723160024_league_scope_gem_features.up.sql
+++ b/internal/db/migrations/20260723160024_league_scope_gem_features.up.sql
@@ -1,0 +1,25 @@
+SELECT remove_compression_policy('gem_features', if_exists => TRUE);
+DO $$
+DECLARE chunk REGCLASS;
+BEGIN
+    FOR chunk IN SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS FROM timescaledb_information.chunks WHERE hypertable_name = 'gem_features' AND is_compressed LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+ALTER TABLE gem_features ADD COLUMN league TEXT;
+UPDATE gem_features SET league = 'Mirage' WHERE league IS NULL;
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM gem_features features LEFT JOIN leagues ON leagues.id = features.league WHERE features.league IS NULL OR leagues.id IS NULL) THEN
+        RAISE EXCEPTION 'gem_features contains a null or unknown league after backfill';
+    END IF;
+END $$;
+ALTER TABLE gem_features DROP CONSTRAINT gem_features_pkey;
+ALTER TABLE gem_features ADD PRIMARY KEY (league, time, name, variant);
+DROP INDEX IF EXISTS idx_gem_features_tier;
+DROP INDEX IF EXISTS idx_gem_features_variant;
+CREATE INDEX idx_gem_features_league_tier ON gem_features (league, time DESC, tier);
+CREATE INDEX idx_gem_features_league_variant ON gem_features (league, variant, time DESC);
+ALTER TABLE gem_features SET (timescaledb.compress, timescaledb.compress_segmentby = 'league, variant', timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('gem_features', INTERVAL '7 days');
+ALTER TABLE gem_features ALTER COLUMN league SET NOT NULL;

--- a/internal/db/migrations/20260723160025_league_scope_gem_signals.down.sql
+++ b/internal/db/migrations/20260723160025_league_scope_gem_signals.down.sql
@@ -1,0 +1,1 @@
+DO $$ BEGIN RAISE EXCEPTION '20260723160025_league_scope_gem_signals is forward-only; restore from a pre-migration backup'; END $$;

--- a/internal/db/migrations/20260723160025_league_scope_gem_signals.up.sql
+++ b/internal/db/migrations/20260723160025_league_scope_gem_signals.up.sql
@@ -1,0 +1,27 @@
+SELECT remove_compression_policy('gem_signals', if_exists => TRUE);
+DO $$
+DECLARE chunk REGCLASS;
+BEGIN
+    FOR chunk IN SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS FROM timescaledb_information.chunks WHERE hypertable_name = 'gem_signals' AND is_compressed LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+ALTER TABLE gem_signals ADD COLUMN league TEXT;
+UPDATE gem_signals SET league = 'Mirage' WHERE league IS NULL;
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM gem_signals signals LEFT JOIN leagues ON leagues.id = signals.league WHERE signals.league IS NULL OR leagues.id IS NULL) THEN
+        RAISE EXCEPTION 'gem_signals contains a null or unknown league after backfill';
+    END IF;
+END $$;
+ALTER TABLE gem_signals DROP CONSTRAINT gem_signals_pkey;
+ALTER TABLE gem_signals ADD PRIMARY KEY (league, time, name, variant);
+DROP INDEX IF EXISTS idx_gem_signals_confidence;
+DROP INDEX IF EXISTS idx_gem_signals_variant;
+DROP INDEX IF EXISTS idx_gem_signals_tier;
+CREATE INDEX idx_gem_signals_league_confidence ON gem_signals (league, time DESC, confidence DESC);
+CREATE INDEX idx_gem_signals_league_variant ON gem_signals (league, variant, time DESC);
+CREATE INDEX idx_gem_signals_league_tier ON gem_signals (league, tier, time DESC);
+ALTER TABLE gem_signals SET (timescaledb.compress, timescaledb.compress_segmentby = 'league, variant', timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('gem_signals', INTERVAL '7 days');
+ALTER TABLE gem_signals ALTER COLUMN league SET NOT NULL;

--- a/internal/db/migrations/20260723160026_league_scope_dedication_snapshots.down.sql
+++ b/internal/db/migrations/20260723160026_league_scope_dedication_snapshots.down.sql
@@ -1,0 +1,1 @@
+DO $$ BEGIN RAISE EXCEPTION '20260723160026_league_scope_dedication_snapshots is forward-only; restore from a pre-migration backup'; END $$;

--- a/internal/db/migrations/20260723160026_league_scope_dedication_snapshots.up.sql
+++ b/internal/db/migrations/20260723160026_league_scope_dedication_snapshots.up.sql
@@ -1,0 +1,23 @@
+SELECT remove_compression_policy('dedication_snapshots', if_exists => TRUE);
+DO $$
+DECLARE chunk REGCLASS;
+BEGIN
+    FOR chunk IN SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS FROM timescaledb_information.chunks WHERE hypertable_name = 'dedication_snapshots' AND is_compressed LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+ALTER TABLE dedication_snapshots ADD COLUMN league TEXT;
+UPDATE dedication_snapshots SET league = 'Mirage' WHERE league IS NULL;
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM dedication_snapshots snapshots LEFT JOIN leagues ON leagues.id = snapshots.league WHERE snapshots.league IS NULL OR leagues.id IS NULL) THEN
+        RAISE EXCEPTION 'dedication_snapshots contains a null or unknown league after backfill';
+    END IF;
+END $$;
+ALTER TABLE dedication_snapshots DROP CONSTRAINT dedication_snapshots_pkey;
+ALTER TABLE dedication_snapshots ADD PRIMARY KEY (league, time, color, gem_type, mode);
+DROP INDEX IF EXISTS idx_dedication_snapshots_color_gemtype_mode;
+CREATE INDEX idx_dedication_snapshots_league_color_gemtype_mode ON dedication_snapshots (league, color, gem_type, mode, time DESC);
+ALTER TABLE dedication_snapshots SET (timescaledb.compress, timescaledb.compress_segmentby = 'league, color, gem_type, mode');
+SELECT add_compression_policy('dedication_snapshots', INTERVAL '7 days');
+ALTER TABLE dedication_snapshots ALTER COLUMN league SET NOT NULL;

--- a/internal/db/migrations/20260723160027_league_scope_trade_lookups.down.sql
+++ b/internal/db/migrations/20260723160027_league_scope_trade_lookups.down.sql
@@ -1,0 +1,1 @@
+DO $$ BEGIN RAISE EXCEPTION '20260723160027_league_scope_trade_lookups is forward-only; restore from a pre-migration backup'; END $$;

--- a/internal/db/migrations/20260723160027_league_scope_trade_lookups.up.sql
+++ b/internal/db/migrations/20260723160027_league_scope_trade_lookups.up.sql
@@ -1,0 +1,23 @@
+SELECT remove_compression_policy('trade_lookups', if_exists => TRUE);
+DO $$
+DECLARE chunk REGCLASS;
+BEGIN
+    FOR chunk IN SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS FROM timescaledb_information.chunks WHERE hypertable_name = 'trade_lookups' AND is_compressed LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+ALTER TABLE trade_lookups ADD COLUMN league TEXT;
+UPDATE trade_lookups SET league = 'Mirage' WHERE league IS NULL;
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM trade_lookups lookups LEFT JOIN leagues ON leagues.id = lookups.league WHERE lookups.league IS NULL OR leagues.id IS NULL) THEN
+        RAISE EXCEPTION 'trade_lookups contains a null or unknown league after backfill';
+    END IF;
+END $$;
+ALTER TABLE trade_lookups DROP CONSTRAINT trade_lookups_pkey;
+ALTER TABLE trade_lookups ADD PRIMARY KEY (league, time, gem, variant);
+DROP INDEX IF EXISTS idx_trade_lookups_gem_variant_time;
+CREATE INDEX idx_trade_lookups_league_gem_variant_time ON trade_lookups (league, gem, variant, time DESC);
+ALTER TABLE trade_lookups SET (timescaledb.compress, timescaledb.compress_segmentby = 'league, gem, variant', timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('trade_lookups', INTERVAL '7 days');
+ALTER TABLE trade_lookups ALTER COLUMN league SET NOT NULL;

--- a/internal/db/migrations/20260723160028_league_scope_market_context.down.sql
+++ b/internal/db/migrations/20260723160028_league_scope_market_context.down.sql
@@ -1,0 +1,1 @@
+DO $$ BEGIN RAISE EXCEPTION '20260723160028_league_scope_market_context is forward-only; restore from a pre-migration backup'; END $$;

--- a/internal/db/migrations/20260723160028_league_scope_market_context.up.sql
+++ b/internal/db/migrations/20260723160028_league_scope_market_context.up.sql
@@ -1,0 +1,23 @@
+SELECT remove_compression_policy('market_context', if_exists => TRUE);
+DO $$
+DECLARE chunk REGCLASS;
+BEGIN
+    FOR chunk IN SELECT format('%I.%I', chunk_schema, chunk_name)::REGCLASS FROM timescaledb_information.chunks WHERE hypertable_name = 'market_context' AND is_compressed LOOP
+        PERFORM decompress_chunk(chunk);
+    END LOOP;
+END
+$$;
+ALTER TABLE market_context ADD COLUMN league TEXT;
+UPDATE market_context SET league = 'Mirage' WHERE league IS NULL;
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM market_context context_rows LEFT JOIN leagues ON leagues.id = context_rows.league WHERE context_rows.league IS NULL OR leagues.id IS NULL) THEN
+        RAISE EXCEPTION 'market_context contains a null or unknown league after backfill';
+    END IF;
+END $$;
+ALTER TABLE market_context DROP CONSTRAINT market_context_pkey;
+ALTER TABLE market_context ADD PRIMARY KEY (league, time);
+DROP INDEX IF EXISTS idx_market_context_time;
+CREATE INDEX idx_market_context_league_time ON market_context (league, time DESC);
+ALTER TABLE market_context SET (timescaledb.compress, timescaledb.compress_segmentby = 'league', timescaledb.compress_orderby = 'time DESC');
+SELECT add_compression_policy('market_context', INTERVAL '7 days');
+ALTER TABLE market_context ALTER COLUMN league SET NOT NULL;

--- a/internal/db/migrations/migrations_integration_test.go
+++ b/internal/db/migrations/migrations_integration_test.go
@@ -4,11 +4,15 @@ package migrations_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/golang-migrate/migrate/v4"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"profitofexile/internal/db"
@@ -39,14 +43,20 @@ func testSetup(t *testing.T) (*pgxpool.Pool, *migrate.Migrate) {
 	return pool, m
 }
 
+func migrateUp(t *testing.T, m *migrate.Migrate) {
+	t.Helper()
+	if err := m.Up(); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		t.Fatalf("migrate up: %v", err)
+	}
+}
+
 // requireTimescaleDB checks that TimescaleDB extension is available and skips
 // the test if it is not installed on the database server.
 func requireTimescaleDB(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
 
-	ctx := context.Background()
 	var available bool
-	err := pool.QueryRow(ctx,
+	err := pool.QueryRow(context.Background(),
 		"SELECT EXISTS (SELECT 1 FROM pg_available_extensions WHERE name = 'timescaledb')").
 		Scan(&available)
 	if err != nil {
@@ -57,236 +67,426 @@ func requireTimescaleDB(t *testing.T, pool *pgxpool.Pool) {
 	}
 }
 
-func TestMigrationUpDownReversibility(t *testing.T) {
+func TestMigrationsApply(t *testing.T) {
 	pool, m := testSetup(t)
 	defer pool.Close()
 	defer m.Close()
-
-	// Migrations beyond 20260312100000 require TimescaleDB.
 	requireTimescaleDB(t, pool)
+	migrateUp(t, m)
 
-	ctx := context.Background()
-
-	// Apply all migrations.
-	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
-		t.Fatalf("migrate up: %v", err)
-	}
-
-	// Verify the strategies table exists.
-	var exists bool
-	err := pool.QueryRow(ctx,
-		"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'strategies')").
-		Scan(&exists)
-	if err != nil {
-		t.Fatalf("check table existence: %v", err)
-	}
-	if !exists {
-		t.Fatal("strategies table should exist after up migration")
-	}
-
-	// Verify the index exists.
-	err = pool.QueryRow(ctx,
-		"SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_strategies_league')").
-		Scan(&exists)
-	if err != nil {
-		t.Fatalf("check index existence: %v", err)
-	}
-	if !exists {
-		t.Fatal("idx_strategies_league index should exist after up migration")
-	}
-
-	// Verify the trigger exists.
-	err = pool.QueryRow(ctx,
-		"SELECT EXISTS (SELECT 1 FROM information_schema.triggers WHERE trigger_name = 'trg_strategies_updated_at')").
-		Scan(&exists)
-	if err != nil {
-		t.Fatalf("check trigger existence: %v", err)
-	}
-	if !exists {
-		t.Fatal("trg_strategies_updated_at trigger should exist after up migration")
-	}
-
-	// Roll back all migrations.
-	if err := m.Down(); err != nil && err != migrate.ErrNoChange {
-		t.Fatalf("migrate down: %v", err)
-	}
-
-	// Verify the strategies table no longer exists.
-	err = pool.QueryRow(ctx,
-		"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'strategies')").
-		Scan(&exists)
-	if err != nil {
-		t.Fatalf("check table after down: %v", err)
-	}
-	if exists {
-		t.Fatal("strategies table should not exist after down migration")
-	}
-
-	// Re-apply to leave DB in clean state for other tests.
-	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
-		t.Fatalf("migrate up (cleanup): %v", err)
+	var strategies, index, trigger bool
+	for name, dest := range map[string]*bool{
+		"strategies":                &strategies,
+		"idx_strategies_league":     &index,
+		"trg_strategies_updated_at": &trigger,
+	} {
+		var query string
+		switch name {
+		case "strategies":
+			query = "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = $1)"
+		case "idx_strategies_league":
+			query = "SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = $1)"
+		default:
+			query = "SELECT EXISTS (SELECT 1 FROM information_schema.triggers WHERE trigger_name = $1)"
+		}
+		if err := pool.QueryRow(context.Background(), query, name).Scan(dest); err != nil {
+			t.Fatalf("check %s: %v", name, err)
+		}
+		if !*dest {
+			t.Errorf("%s should exist after migrations", name)
+		}
 	}
 }
 
-func TestTimescaleDBMigrations(t *testing.T) {
+func TestLeagueControlBootstrapSelectsMirage(t *testing.T) {
 	pool, m := testSetup(t)
 	defer pool.Close()
 	defer m.Close()
-
 	requireTimescaleDB(t, pool)
+	migrateUp(t, m)
 
-	ctx := context.Background()
-
-	// Apply all migrations.
-	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
-		t.Fatalf("migrate up: %v", err)
+	var controlRows int
+	if err := pool.QueryRow(context.Background(), "SELECT count(*) FROM runtime_config").Scan(&controlRows); err != nil {
+		t.Fatalf("count runtime control rows: %v", err)
+	}
+	if controlRows != 1 {
+		t.Fatalf("runtime control rows = %d, want 1", controlRows)
 	}
 
-	t.Run("hypertables exist", func(t *testing.T) {
-		expectedHypertables := []string{
-			"gem_snapshots",
-			"font_snapshots",
-			"exchange_snapshots",
-			"gcp_snapshots",
-		}
+	var activeLeague, state string
+	var revision int64
+	err := pool.QueryRow(context.Background(), `
+		SELECT config.active_league, config.revision, leagues.collection_state
+		FROM runtime_config AS config
+		JOIN leagues ON leagues.id = config.active_league
+		WHERE config.singleton = TRUE`).Scan(&activeLeague, &revision, &state)
+	if err != nil {
+		t.Fatalf("query Mirage runtime control: %v", err)
+	}
+	if activeLeague != "Mirage" || revision != 1 || state != "collecting" {
+		t.Errorf("runtime control = (%q, %d, %q), want (Mirage, 1, collecting)", activeLeague, revision, state)
+	}
+}
 
-		for _, name := range expectedHypertables {
-			var exists bool
-			err := pool.QueryRow(ctx,
-				"SELECT EXISTS (SELECT 1 FROM timescaledb_information.hypertables WHERE hypertable_name = $1)",
-				name).Scan(&exists)
+func TestCollectedLeagueCanStoreSnapshotsWhileMirageIsActive(t *testing.T) {
+	pool, m := testSetup(t)
+	defer pool.Close()
+	defer m.Close()
+	requireTimescaleDB(t, pool)
+	migrateUp(t, m)
+
+	ctx := context.Background()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	const collectedLeague = "POE-119-Test-League"
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO leagues (id, display_name, collection_state, prepared_at, activated_at)
+		VALUES ($1, $1, 'collecting', NOW(), NOW())`, collectedLeague); err != nil {
+		t.Fatalf("register collected league: %v", err)
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO gem_snapshots (league, time, name, variant, is_corrupted, chaos, listings)
+		VALUES ($1, '2099-01-01 00:00:00+00', 'POE-119 Test Gem', '1/20', FALSE, 1, 1)`, collectedLeague); err != nil {
+		t.Fatalf("insert collected-league snapshot: %v", err)
+	}
+
+	var activeLeague, storedLeague string
+	if err := tx.QueryRow(ctx, "SELECT active_league FROM runtime_config WHERE singleton = TRUE").Scan(&activeLeague); err != nil {
+		t.Fatalf("read active league: %v", err)
+	}
+	if err := tx.QueryRow(ctx, `SELECT league FROM gem_snapshots WHERE name = 'POE-119 Test Gem'`).Scan(&storedLeague); err != nil {
+		t.Fatalf("read collected-league snapshot: %v", err)
+	}
+	if activeLeague != "Mirage" || storedLeague != collectedLeague {
+		t.Errorf("active/stored league = (%q, %q), want (Mirage, %q)", activeLeague, storedLeague, collectedLeague)
+	}
+}
+
+func TestScopedRelationsHaveLeagueIdentityAndPrimaryKeys(t *testing.T) {
+	pool, m := testSetup(t)
+	defer pool.Close()
+	defer m.Close()
+	requireTimescaleDB(t, pool)
+	migrateUp(t, m)
+
+	relations := map[string][]string{
+		"currency_snapshots":   {"league", "time", "currency_id"},
+		"dedication_snapshots": {"league", "time", "color", "gem_type", "mode"},
+		"font_snapshots":       {"league", "time", "color", "variant", "mode"},
+		"fragment_snapshots":   {"league", "time", "fragment_id"},
+		"gem_features":         {"league", "time", "name", "variant"},
+		"gem_signals":          {"league", "time", "name", "variant"},
+		"gem_snapshots":        {"league", "time", "name", "variant", "is_corrupted"},
+		"market_context":       {"league", "time"},
+		"quality_results":      {"league", "time", "name", "level"},
+		"trade_lookups":        {"league", "time", "gem", "variant"},
+		"transfigure_results":  {"league", "time", "transfigured_name", "variant"},
+		"trend_results":        {"league", "time", "name", "variant"},
+	}
+
+	for relation, wantPrimaryKey := range relations {
+		t.Run(relation, func(t *testing.T) {
+			var nullable string
+			err := pool.QueryRow(context.Background(), `
+				SELECT is_nullable
+				FROM information_schema.columns
+				WHERE table_schema = 'public' AND table_name = $1 AND column_name = 'league'`, relation).Scan(&nullable)
 			if err != nil {
-				t.Fatalf("check hypertable %q: %v", name, err)
+				t.Fatalf("find league column: %v", err)
 			}
-			if !exists {
-				t.Errorf("hypertable %q should exist after migration", name)
+			if nullable != "NO" {
+				t.Errorf("league column nullable = %q, want NO", nullable)
 			}
-		}
-	})
 
-	t.Run("gem_colors seeded", func(t *testing.T) {
-		var count int
-		err := pool.QueryRow(ctx, "SELECT count(*) FROM gem_colors").Scan(&count)
-		if err != nil {
-			t.Fatalf("count gem_colors: %v", err)
-		}
-		if count < 700 {
-			t.Errorf("gem_colors count = %d, want >= 700 (seed has 750 entries)", count)
-		}
-	})
-
-	t.Run("gem_colors known entries", func(t *testing.T) {
-		knownGems := map[string]string{
-			"Arc":            "BLUE",
-			"Cleave":         "RED",
-			"Rain of Arrows": "GREEN",
-		}
-
-		for gem, wantColor := range knownGems {
-			var color string
-			err := pool.QueryRow(ctx, "SELECT color FROM gem_colors WHERE name = $1", gem).Scan(&color)
+			rows, err := pool.Query(context.Background(), `
+				SELECT key_columns.column_name
+				FROM information_schema.table_constraints AS constraints
+				JOIN information_schema.key_column_usage AS key_columns
+					ON key_columns.constraint_name = constraints.constraint_name
+					AND key_columns.table_schema = constraints.table_schema
+				WHERE constraints.table_schema = 'public'
+					AND constraints.table_name = $1
+					AND constraints.constraint_type = 'PRIMARY KEY'
+				ORDER BY key_columns.ordinal_position`, relation)
 			if err != nil {
-				t.Errorf("query gem %q: %v", gem, err)
-				continue
+				t.Fatalf("query primary key: %v", err)
 			}
-			if color != wantColor {
-				t.Errorf("gem %q color = %q, want %q", gem, color, wantColor)
+			defer rows.Close()
+
+			var gotPrimaryKey []string
+			for rows.Next() {
+				var column string
+				if err := rows.Scan(&column); err != nil {
+					t.Fatalf("scan primary key column: %v", err)
+				}
+				gotPrimaryKey = append(gotPrimaryKey, column)
 			}
-		}
-	})
+			if err := rows.Err(); err != nil {
+				t.Fatalf("iterate primary key columns: %v", err)
+			}
+			if fmt.Sprint(gotPrimaryKey) != fmt.Sprint(wantPrimaryKey) {
+				t.Errorf("primary key = %v, want %v", gotPrimaryKey, wantPrimaryKey)
+			}
 
-	t.Run("continuous aggregates exist", func(t *testing.T) {
-		expectedAggregates := []string{
-			"gem_snapshots_hourly",
-			"gem_snapshots_daily",
-		}
+			var nullLeagues int
+			query := fmt.Sprintf("SELECT count(*) FROM %s WHERE league IS NULL", relation)
+			if err := pool.QueryRow(context.Background(), query).Scan(&nullLeagues); err != nil {
+				t.Fatalf("count rows without league: %v", err)
+			}
+			if nullLeagues != 0 {
+				t.Errorf("rows without league = %d, want 0", nullLeagues)
+			}
+		})
+	}
+}
 
-		for _, name := range expectedAggregates {
-			var exists bool
-			err := pool.QueryRow(ctx,
-				"SELECT EXISTS (SELECT 1 FROM timescaledb_information.continuous_aggregates WHERE view_name = $1)",
-				name).Scan(&exists)
+func TestGemSnapshotsAllowSameIdentityAcrossLeaguesAndRejectDuplicatesWithinOneLeague(t *testing.T) {
+	pool, m := testSetup(t)
+	defer pool.Close()
+	defer m.Close()
+	requireTimescaleDB(t, pool)
+	migrateUp(t, m)
+
+	ctx := context.Background()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	const secondLeague = "POE-119-Duplicate-Test"
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO leagues (id, display_name, collection_state)
+		VALUES ($1, $1, 'collecting')`, secondLeague); err != nil {
+		t.Fatalf("create second league: %v", err)
+	}
+
+	insert := `
+		INSERT INTO gem_snapshots (league, time, name, variant, is_corrupted, chaos, listings)
+		VALUES ($1, '2099-01-02 00:00:00+00', 'POE-119 Duplicate Gem', '1/20', FALSE, 1, 1)`
+	for _, leagueID := range []string{"Mirage", secondLeague} {
+		if _, err := tx.Exec(ctx, insert, leagueID); err != nil {
+			t.Fatalf("insert raw identity for %s: %v", leagueID, err)
+		}
+	}
+	_, err = tx.Exec(ctx, insert, secondLeague)
+	if err == nil {
+		t.Fatal("duplicate raw gem identity within one league was accepted")
+	}
+	var dbErr *pgconn.PgError
+	if !errors.As(err, &dbErr) || dbErr.Code != "23505" {
+		t.Errorf("duplicate insert error = %v, want PostgreSQL unique violation", err)
+	}
+}
+
+func TestGemContinuousAggregatesPreserveLeagueAndCorruption(t *testing.T) {
+	pool, m := testSetup(t)
+	defer pool.Close()
+	defer m.Close()
+	requireTimescaleDB(t, pool)
+	migrateUp(t, m)
+
+	ctx := context.Background()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	const secondLeague = "POE-119-Aggregate-Test"
+	if _, err := tx.Exec(ctx, `INSERT INTO leagues (id, display_name, collection_state) VALUES ($1, $1, 'collecting')`, secondLeague); err != nil {
+		t.Fatalf("create aggregate test league: %v", err)
+	}
+	const snapshotName = "POE-119 Aggregate Gem"
+	snapshotTime := time.Date(2099, 1, 3, 1, 15, 0, 0, time.UTC)
+	for _, row := range []struct {
+		league      string
+		isCorrupted bool
+		chaos       int
+	}{
+		{"Mirage", false, 10},
+		{"Mirage", true, 20},
+		{secondLeague, false, 30},
+	} {
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO gem_snapshots (league, time, name, variant, is_corrupted, chaos, listings)
+			VALUES ($1, $2, $3, '1/20', $4, $5, 1)`, row.league, snapshotTime, snapshotName, row.isCorrupted, row.chaos); err != nil {
+			t.Fatalf("insert aggregate input for %s corrupted=%t: %v", row.league, row.isCorrupted, err)
+		}
+	}
+
+	for _, aggregate := range []string{"gem_snapshots_hourly", "gem_snapshots_daily"} {
+		t.Run(aggregate, func(t *testing.T) {
+			rows, err := tx.Query(ctx, fmt.Sprintf(`
+				SELECT league, is_corrupted, avg_chaos::float8
+				FROM %s
+				WHERE name = $1 AND variant = '1/20'
+					AND bucket = time_bucket(CASE WHEN $2 = 'gem_snapshots_hourly' THEN '1 hour'::interval ELSE '1 day'::interval END, $3)
+				ORDER BY league, is_corrupted`, aggregate), snapshotName, aggregate, snapshotTime)
 			if err != nil {
-				t.Fatalf("check continuous aggregate %q: %v", name, err)
+				t.Fatalf("query %s: %v", aggregate, err)
 			}
-			if !exists {
-				t.Errorf("continuous aggregate %q should exist after migration", name)
+			defer rows.Close()
+
+			got := map[string]float64{}
+			for rows.Next() {
+				var league string
+				var corrupted bool
+				var chaos float64
+				if err := rows.Scan(&league, &corrupted, &chaos); err != nil {
+					t.Fatalf("scan aggregate row: %v", err)
+				}
+				got[fmt.Sprintf("%s/%t", league, corrupted)] = chaos
 			}
-		}
-	})
+			if err := rows.Err(); err != nil {
+				t.Fatalf("iterate aggregate rows: %v", err)
+			}
+			want := map[string]float64{
+				"Mirage/false":          10,
+				"Mirage/true":           20,
+				secondLeague + "/false": 30,
+			}
+			if fmt.Sprint(got) != fmt.Sprint(want) {
+				t.Errorf("aggregate rows = %v, want %v", got, want)
+			}
+		})
+	}
+}
 
-	t.Run("compression policies exist", func(t *testing.T) {
-		compressedTables := []string{
-			"gem_snapshots",
-			"font_snapshots",
-			"exchange_snapshots",
-			"gcp_snapshots",
-		}
+func TestLeagueMigrationsRestoreRequiredPoliciesAndRemoveLegacyRelations(t *testing.T) {
+	pool, m := testSetup(t)
+	defer pool.Close()
+	defer m.Close()
+	requireTimescaleDB(t, pool)
+	migrateUp(t, m)
 
-		for _, name := range compressedTables {
-			var exists bool
-			err := pool.QueryRow(ctx,
-				`SELECT EXISTS (
-					SELECT 1 FROM timescaledb_information.jobs
-					WHERE proc_name = 'policy_compression'
-					AND hypertable_name = $1
-				)`, name).Scan(&exists)
+	compressedRelations := []string{
+		"currency_snapshots", "dedication_snapshots", "font_snapshots", "fragment_snapshots",
+		"gem_features", "gem_signals", "gem_snapshots", "market_context", "quality_results",
+		"trade_lookups", "transfigure_results", "trend_results",
+	}
+	rows, err := pool.Query(context.Background(), `
+		SELECT hypertable_name
+		FROM timescaledb_information.jobs
+		WHERE proc_name = 'policy_compression'
+		ORDER BY hypertable_name`)
+	if err != nil {
+		t.Fatalf("query compression policies: %v", err)
+	}
+	defer rows.Close()
+	var gotCompressed []string
+	for rows.Next() {
+		var relation string
+		if err := rows.Scan(&relation); err != nil {
+			t.Fatalf("scan compression policy: %v", err)
+		}
+		gotCompressed = append(gotCompressed, relation)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate compression policies: %v", err)
+	}
+	for _, relation := range compressedRelations {
+		if !contains(gotCompressed, relation) {
+			t.Errorf("missing compression policy for %s; got %v", relation, gotCompressed)
+		}
+	}
+
+	rows, err = pool.Query(context.Background(), `
+		SELECT aggregates.view_name
+		FROM timescaledb_information.continuous_aggregates AS aggregates
+		JOIN timescaledb_information.jobs AS jobs
+			ON jobs.hypertable_schema = aggregates.materialization_hypertable_schema
+			AND jobs.hypertable_name = aggregates.materialization_hypertable_name
+		WHERE jobs.proc_name = 'policy_refresh_continuous_aggregate'
+			AND aggregates.view_name IN ('gem_snapshots_hourly', 'gem_snapshots_daily')`)
+	if err != nil {
+		t.Fatalf("query continuous aggregate refresh policies: %v", err)
+	}
+	defer rows.Close()
+	var gotRefreshPolicies []string
+	for rows.Next() {
+		var aggregate string
+		if err := rows.Scan(&aggregate); err != nil {
+			t.Fatalf("scan continuous aggregate refresh policy: %v", err)
+		}
+		gotRefreshPolicies = append(gotRefreshPolicies, aggregate)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate continuous aggregate refresh policies: %v", err)
+	}
+	for _, aggregate := range []string{"gem_snapshots_hourly", "gem_snapshots_daily"} {
+		if !contains(gotRefreshPolicies, aggregate) {
+			t.Errorf("missing refresh policy for %s; got %v", aggregate, gotRefreshPolicies)
+		}
+	}
+
+	for _, relation := range []string{"exchange_snapshots", "gcp_snapshots"} {
+		var exists bool
+		if err := pool.QueryRow(context.Background(), `
+			SELECT EXISTS (
+				SELECT 1 FROM information_schema.tables
+				WHERE table_schema = 'public' AND table_name = $1)`, relation).Scan(&exists); err != nil {
+			t.Fatalf("check removed relation %s: %v", relation, err)
+		}
+		if exists {
+			t.Errorf("removed relation %s still exists", relation)
+		}
+	}
+}
+
+func TestLeagueScopedSeedScriptsInsertMirageRows(t *testing.T) {
+	pool, m := testSetup(t)
+	defer pool.Close()
+	defer m.Close()
+	requireTimescaleDB(t, pool)
+	migrateUp(t, m)
+
+	ctx := context.Background()
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin transaction: %v", err)
+	}
+	defer tx.Rollback(ctx)
+
+	seeds := []struct {
+		file     string
+		relation string
+	}{
+		{"002_gem_snapshots.sql", "gem_snapshots"},
+		{"003_font_snapshots.sql", "font_snapshots"},
+		{"004_currency_snapshots.sql", "currency_snapshots"},
+	}
+	for _, seed := range seeds {
+		t.Run(seed.file, func(t *testing.T) {
+			content, err := os.ReadFile(filepath.Join("..", "..", "..", "db", "seeds", seed.file))
 			if err != nil {
-				t.Fatalf("check compression policy for %q: %v", name, err)
+				t.Fatalf("read seed script: %v", err)
 			}
-			if !exists {
-				t.Errorf("compression policy for %q should exist after migration", name)
+			if _, err := tx.Exec(ctx, string(content)); err != nil {
+				t.Fatalf("execute seed script: %v", err)
 			}
-		}
-	})
 
-	t.Run("retention policies exist", func(t *testing.T) {
-		retainedTables := []string{
-			"gem_snapshots",
-			"font_snapshots",
-			"exchange_snapshots",
-			"gcp_snapshots",
-		}
-
-		for _, name := range retainedTables {
-			var exists bool
-			err := pool.QueryRow(ctx,
-				`SELECT EXISTS (
-					SELECT 1 FROM timescaledb_information.jobs
-					WHERE proc_name = 'policy_retention'
-					AND hypertable_name = $1
-				)`, name).Scan(&exists)
-			if err != nil {
-				t.Fatalf("check retention policy for %q: %v", name, err)
+			var total, mirage int
+			query := fmt.Sprintf("SELECT count(*), count(*) FILTER (WHERE league = 'Mirage') FROM %s", seed.relation)
+			if err := tx.QueryRow(ctx, query).Scan(&total, &mirage); err != nil {
+				t.Fatalf("count seeded rows: %v", err)
 			}
-			if !exists {
-				t.Errorf("retention policy for %q should exist after migration", name)
+			if total == 0 || total != mirage {
+				t.Errorf("Mirage-scoped rows = %d of %d, want all seeded rows scoped to Mirage", mirage, total)
 			}
-		}
-	})
+		})
+	}
+}
 
-	t.Run("full down migration reversibility", func(t *testing.T) {
-		// Roll back ALL migrations — verifies correct ordering:
-		// continuous aggregates first, then policies, then hypertables, then extension.
-		if err := m.Down(); err != nil && err != migrate.ErrNoChange {
-			t.Fatalf("migrate down: %v", err)
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
 		}
-
-		// Verify hypertables are gone.
-		var count int
-		err := pool.QueryRow(ctx,
-			"SELECT count(*) FROM information_schema.tables WHERE table_name IN ('gem_snapshots', 'font_snapshots', 'exchange_snapshots', 'gcp_snapshots', 'gem_colors')").
-			Scan(&count)
-		if err != nil {
-			t.Fatalf("check tables after down: %v", err)
-		}
-		if count != 0 {
-			t.Errorf("expected 0 price tables after full down, got %d", count)
-		}
-
-		// Re-apply all migrations to leave DB in clean state.
-		if err := m.Up(); err != nil && err != migrate.ErrNoChange {
-			t.Fatalf("migrate up (restore): %v", err)
-		}
-	})
+	}
+	return false
 }

--- a/internal/db/migrations/migrations_integration_test.go
+++ b/internal/db/migrations/migrations_integration_test.go
@@ -620,12 +620,3 @@ func TestLeagueScopedSeedScriptsInsertMirageRows(t *testing.T) {
 		})
 	}
 }
-
-func contains(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/db/migrations/migrations_integration_test.go
+++ b/internal/db/migrations/migrations_integration_test.go
@@ -386,7 +386,7 @@ func TestGemContinuousAggregatesPreserveLeagueAndCorruption(t *testing.T) {
 				SELECT league, is_corrupted, avg_chaos::float8
 				FROM %s
 				WHERE name = $1 AND variant = '1/20'
-					AND bucket = time_bucket(CASE WHEN $2 = 'gem_snapshots_hourly' THEN '1 hour'::interval ELSE '1 day'::interval END, $3)
+					AND bucket = time_bucket(CASE WHEN $2 = 'gem_snapshots_hourly' THEN '1 hour'::interval ELSE '1 day'::interval END, $3::timestamptz)
 				ORDER BY league, is_corrupted`, aggregate), snapshotName, aggregate, snapshotTime)
 			if err != nil {
 				t.Fatalf("query %s: %v", aggregate, err)
@@ -539,9 +539,11 @@ func continuousAggregateRefreshConfigurations(t *testing.T, pool *pgxpool.Pool) 
 				'schedule_interval', jobs.schedule_interval
 			)::text
 		FROM timescaledb_information.continuous_aggregates AS aggregates
+		JOIN _timescaledb_catalog.continuous_agg AS continuous_aggregate_catalog
+			ON continuous_aggregate_catalog.user_view_schema = aggregates.view_schema
+			AND continuous_aggregate_catalog.user_view_name = aggregates.view_name
 		JOIN timescaledb_information.jobs AS jobs
-			ON jobs.hypertable_schema = aggregates.materialization_hypertable_schema
-			AND jobs.hypertable_name = aggregates.materialization_hypertable_name
+			ON (jobs.config->>'mat_hypertable_id')::integer = continuous_aggregate_catalog.mat_hypertable_id
 		WHERE jobs.proc_name = 'policy_refresh_continuous_aggregate'
 			AND aggregates.view_name = ANY($1)
 		ORDER BY aggregates.view_name`, continuousAggregates)

--- a/internal/db/migrations/migrations_integration_test.go
+++ b/internal/db/migrations/migrations_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -64,6 +65,53 @@ func requireTimescaleDB(t *testing.T, pool *pgxpool.Pool) {
 	}
 	if !available {
 		t.Skip("TimescaleDB not available, skipping test")
+	}
+}
+
+func TestLeagueMigrationsPreserveLegacySchemaContract(t *testing.T) {
+	pool, m := testSetup(t)
+	defer pool.Close()
+	defer m.Close()
+	requireTimescaleDB(t, pool)
+	migrateToPreLeagueSchema(t, m)
+
+	legacyTime := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+	insertLegacyScopedRows(t, pool, legacyTime)
+
+	compressionBefore := scopedPolicyConfigurations(t, pool, "policy_compression", scopedRelations)
+	retentionBefore := scopedPolicyConfigurations(t, pool, "policy_retention", retainedRelations)
+	refreshBefore := continuousAggregateRefreshConfigurations(t, pool)
+	assertPolicyCoverage(t, "compression", compressionBefore, scopedRelations)
+	assertPolicyCoverage(t, "retention", retentionBefore, retainedRelations)
+	assertPolicyCoverage(t, "continuous aggregate refresh", refreshBefore, continuousAggregates)
+	if _, ok := retentionBefore["trade_lookups"]; ok {
+		t.Fatal("trade_lookups unexpectedly had a retention policy before POE-119")
+	}
+
+	migrateUp(t, m)
+
+	assertLegacyRowsBackfilledToMirage(t, pool, legacyTime)
+	assertLegacyRelationsRemoved(t, pool)
+	compressionAfter := scopedPolicyConfigurations(t, pool, "policy_compression", scopedRelations)
+	retentionAfter := scopedPolicyConfigurations(t, pool, "policy_retention", retainedRelations)
+	refreshAfter := continuousAggregateRefreshConfigurations(t, pool)
+	assertPolicyCoverage(t, "compression", compressionAfter, scopedRelations)
+	assertPolicyCoverage(t, "retention", retentionAfter, retainedRelations)
+	assertPolicyCoverage(t, "continuous aggregate refresh", refreshAfter, continuousAggregates)
+	if !reflect.DeepEqual(compressionAfter, compressionBefore) {
+		t.Errorf("compression policies after migration = %v, want unchanged %v", compressionAfter, compressionBefore)
+	}
+	if !reflect.DeepEqual(retentionAfter, retentionBefore) {
+		t.Errorf("retention policies after migration = %v, want unchanged %v", retentionAfter, retentionBefore)
+	}
+	if !reflect.DeepEqual(refreshAfter, refreshBefore) {
+		t.Errorf("continuous aggregate refresh policies after migration = %v, want unchanged %v", refreshAfter, refreshBefore)
+	}
+	if _, ok := compressionAfter["trade_lookups"]; !ok {
+		t.Error("trade_lookups lost its compression policy")
+	}
+	if _, ok := retentionAfter["trade_lookups"]; ok {
+		t.Error("trade_lookups unexpectedly gained a retention policy")
 	}
 }
 
@@ -240,6 +288,19 @@ func TestScopedRelationsHaveLeagueIdentityAndPrimaryKeys(t *testing.T) {
 			if nullLeagues != 0 {
 				t.Errorf("rows without league = %d, want 0", nullLeagues)
 			}
+
+			var unknownLeagues int
+			query = fmt.Sprintf(`
+				SELECT count(*)
+				FROM %s AS scoped_rows
+				LEFT JOIN leagues ON leagues.id = scoped_rows.league
+				WHERE leagues.id IS NULL`, relation)
+			if err := pool.QueryRow(context.Background(), query).Scan(&unknownLeagues); err != nil {
+				t.Fatalf("count rows with unknown league: %v", err)
+			}
+			if unknownLeagues != 0 {
+				t.Errorf("rows with unknown league = %d, want 0", unknownLeagues)
+			}
 		})
 	}
 }
@@ -357,72 +418,71 @@ func TestGemContinuousAggregatesPreserveLeagueAndCorruption(t *testing.T) {
 	}
 }
 
-func TestLeagueMigrationsRestoreRequiredPoliciesAndRemoveLegacyRelations(t *testing.T) {
-	pool, m := testSetup(t)
-	defer pool.Close()
-	defer m.Close()
-	requireTimescaleDB(t, pool)
-	migrateUp(t, m)
+const preLeagueSchemaVersion uint = 20260412224254
 
-	compressedRelations := []string{
-		"currency_snapshots", "dedication_snapshots", "font_snapshots", "fragment_snapshots",
-		"gem_features", "gem_signals", "gem_snapshots", "market_context", "quality_results",
-		"trade_lookups", "transfigure_results", "trend_results",
-	}
-	rows, err := pool.Query(context.Background(), `
-		SELECT hypertable_name
-		FROM timescaledb_information.jobs
-		WHERE proc_name = 'policy_compression'
-		ORDER BY hypertable_name`)
-	if err != nil {
-		t.Fatalf("query compression policies: %v", err)
-	}
-	defer rows.Close()
-	var gotCompressed []string
-	for rows.Next() {
-		var relation string
-		if err := rows.Scan(&relation); err != nil {
-			t.Fatalf("scan compression policy: %v", err)
-		}
-		gotCompressed = append(gotCompressed, relation)
-	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("iterate compression policies: %v", err)
-	}
-	for _, relation := range compressedRelations {
-		if !contains(gotCompressed, relation) {
-			t.Errorf("missing compression policy for %s; got %v", relation, gotCompressed)
-		}
-	}
+var scopedRelations = []string{
+	"currency_snapshots", "dedication_snapshots", "font_snapshots", "fragment_snapshots",
+	"gem_features", "gem_signals", "gem_snapshots", "market_context", "quality_results",
+	"trade_lookups", "transfigure_results", "trend_results",
+}
 
-	rows, err = pool.Query(context.Background(), `
-		SELECT aggregates.view_name
-		FROM timescaledb_information.continuous_aggregates AS aggregates
-		JOIN timescaledb_information.jobs AS jobs
-			ON jobs.hypertable_schema = aggregates.materialization_hypertable_schema
-			AND jobs.hypertable_name = aggregates.materialization_hypertable_name
-		WHERE jobs.proc_name = 'policy_refresh_continuous_aggregate'
-			AND aggregates.view_name IN ('gem_snapshots_hourly', 'gem_snapshots_daily')`)
-	if err != nil {
-		t.Fatalf("query continuous aggregate refresh policies: %v", err)
+var retainedRelations = []string{
+	"currency_snapshots", "dedication_snapshots", "font_snapshots", "fragment_snapshots",
+	"gem_features", "gem_signals", "gem_snapshots", "market_context", "quality_results",
+	"transfigure_results", "trend_results",
+}
+
+var continuousAggregates = []string{"gem_snapshots_hourly", "gem_snapshots_daily"}
+
+func migrateToPreLeagueSchema(t *testing.T, m *migrate.Migrate) {
+	t.Helper()
+	if err := m.Migrate(preLeagueSchemaVersion); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		t.Fatalf("migrate to pre-POE-119 schema: %v", err)
 	}
-	defer rows.Close()
-	var gotRefreshPolicies []string
-	for rows.Next() {
-		var aggregate string
-		if err := rows.Scan(&aggregate); err != nil {
-			t.Fatalf("scan continuous aggregate refresh policy: %v", err)
+}
+
+func insertLegacyScopedRows(t *testing.T, pool *pgxpool.Pool, legacyTime time.Time) {
+	t.Helper()
+
+	for relation, statement := range map[string]string{
+		"currency_snapshots":   `INSERT INTO currency_snapshots (time, currency_id, chaos, volume, sparkline_change) VALUES ($1, 'POE-119 Legacy Currency', 1, 2, 3)`,
+		"dedication_snapshots": `INSERT INTO dedication_snapshots (time, color, gem_type, mode, pool, winners) VALUES ($1, 'POE-119 Legacy Dedication', 'skill', 'safe', 1, 1)`,
+		"font_snapshots":       `INSERT INTO font_snapshots (time, color, variant, mode, pool, winners) VALUES ($1, 'POE-119 Legacy Font', '1/20', 'safe', 1, 1)`,
+		"fragment_snapshots":   `INSERT INTO fragment_snapshots (time, fragment_id, chaos, sparkline_change) VALUES ($1, 'POE-119 Legacy Fragment', 1, 2)`,
+		"gem_features":         `INSERT INTO gem_features (time, name, variant, chaos, listings) VALUES ($1, 'POE-119 Legacy Feature', '1/20', 1, 1)`,
+		"gem_signals":          `INSERT INTO gem_signals (time, name, variant, signal, confidence) VALUES ($1, 'POE-119 Legacy Signal', '1/20', 'STABLE', 1)`,
+		"gem_snapshots":        `INSERT INTO gem_snapshots (time, name, variant, is_corrupted, chaos, listings) VALUES ($1, 'POE-119 Legacy Snapshot', '1/20', FALSE, 1, 1)`,
+		"market_context":       `INSERT INTO market_context (time, total_gems, total_listings) VALUES ($1, 1, 1)`,
+		"quality_results":      `INSERT INTO quality_results (time, name, level, buy_price, price_q20) VALUES ($1, 'POE-119 Legacy Quality', 20, 1, 2)`,
+		"trade_lookups":        `INSERT INTO trade_lookups (time, gem, variant, total_listings, price_floor) VALUES ($1, 'POE-119 Legacy Trade', '1/20', 1, 1)`,
+		"transfigure_results":  `INSERT INTO transfigure_results (time, base_name, transfigured_name, variant, base_price, transfigured_price) VALUES ($1, 'POE-119 Legacy Base', 'POE-119 Legacy Transfigure', '1/20', 1, 2)`,
+		"trend_results":        `INSERT INTO trend_results (time, name, variant, current_price, current_listings) VALUES ($1, 'POE-119 Legacy Trend', '1/20', 1, 1)`,
+	} {
+		if _, err := pool.Exec(context.Background(), statement, legacyTime); err != nil {
+			t.Fatalf("insert legacy %s row: %v", relation, err)
 		}
-		gotRefreshPolicies = append(gotRefreshPolicies, aggregate)
 	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("iterate continuous aggregate refresh policies: %v", err)
+}
+
+func assertLegacyRowsBackfilledToMirage(t *testing.T, pool *pgxpool.Pool, legacyTime time.Time) {
+	t.Helper()
+
+	for _, relation := range scopedRelations {
+		t.Run(relation, func(t *testing.T) {
+			var total, mirage int
+			query := fmt.Sprintf(`SELECT count(*), count(*) FILTER (WHERE league = 'Mirage') FROM %s WHERE time = $1`, relation)
+			if err := pool.QueryRow(context.Background(), query, legacyTime).Scan(&total, &mirage); err != nil {
+				t.Fatalf("count migrated legacy rows: %v", err)
+			}
+			if total != 1 || mirage != 1 {
+				t.Errorf("Mirage-backed legacy rows = %d of %d, want 1 of 1", mirage, total)
+			}
+		})
 	}
-	for _, aggregate := range []string{"gem_snapshots_hourly", "gem_snapshots_daily"} {
-		if !contains(gotRefreshPolicies, aggregate) {
-			t.Errorf("missing refresh policy for %s; got %v", aggregate, gotRefreshPolicies)
-		}
-	}
+}
+
+func assertLegacyRelationsRemoved(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
 
 	for _, relation := range []string{"exchange_snapshots", "gcp_snapshots"} {
 		var exists bool
@@ -434,6 +494,85 @@ func TestLeagueMigrationsRestoreRequiredPoliciesAndRemoveLegacyRelations(t *test
 		}
 		if exists {
 			t.Errorf("removed relation %s still exists", relation)
+		}
+	}
+}
+
+func scopedPolicyConfigurations(t *testing.T, pool *pgxpool.Pool, policy string, relations []string) map[string]string {
+	t.Helper()
+
+	rows, err := pool.Query(context.Background(), `
+		SELECT hypertable_name,
+			jsonb_build_object(
+				'config', config - 'hypertable_id',
+				'schedule_interval', schedule_interval
+			)::text
+		FROM timescaledb_information.jobs
+		WHERE proc_name = $1 AND hypertable_name = ANY($2)
+		ORDER BY hypertable_name`, policy, relations)
+	if err != nil {
+		t.Fatalf("query %s policies: %v", policy, err)
+	}
+	defer rows.Close()
+
+	policies := make(map[string]string)
+	for rows.Next() {
+		var relation, configuration string
+		if err := rows.Scan(&relation, &configuration); err != nil {
+			t.Fatalf("scan %s policy: %v", policy, err)
+		}
+		policies[relation] = configuration
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate %s policies: %v", policy, err)
+	}
+	return policies
+}
+
+func continuousAggregateRefreshConfigurations(t *testing.T, pool *pgxpool.Pool) map[string]string {
+	t.Helper()
+
+	rows, err := pool.Query(context.Background(), `
+		SELECT aggregates.view_name,
+			jsonb_build_object(
+				'config', jobs.config - 'mat_hypertable_id' - 'hypertable_id',
+				'schedule_interval', jobs.schedule_interval
+			)::text
+		FROM timescaledb_information.continuous_aggregates AS aggregates
+		JOIN timescaledb_information.jobs AS jobs
+			ON jobs.hypertable_schema = aggregates.materialization_hypertable_schema
+			AND jobs.hypertable_name = aggregates.materialization_hypertable_name
+		WHERE jobs.proc_name = 'policy_refresh_continuous_aggregate'
+			AND aggregates.view_name = ANY($1)
+		ORDER BY aggregates.view_name`, continuousAggregates)
+	if err != nil {
+		t.Fatalf("query continuous aggregate refresh policies: %v", err)
+	}
+	defer rows.Close()
+
+	policies := make(map[string]string)
+	for rows.Next() {
+		var aggregate, configuration string
+		if err := rows.Scan(&aggregate, &configuration); err != nil {
+			t.Fatalf("scan continuous aggregate refresh policy: %v", err)
+		}
+		policies[aggregate] = configuration
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate continuous aggregate refresh policies: %v", err)
+	}
+	return policies
+}
+
+func assertPolicyCoverage(t *testing.T, policy string, got map[string]string, want []string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Errorf("%s policy coverage = %v, want %v", policy, got, want)
+	}
+	for _, relation := range want {
+		if _, ok := got[relation]; !ok {
+			t.Errorf("missing %s policy for %s; got %v", policy, relation, got)
 		}
 	}
 }

--- a/internal/league/league.go
+++ b/internal/league/league.go
@@ -1,0 +1,67 @@
+// Package league owns the database-backed league scope used by scoped data.
+package league
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Scope identifies a league and the configuration revision that selected it.
+// Its fields are private so callers can obtain a scope only through Resolve or
+// Historical.
+type Scope struct {
+	id       string
+	revision int64
+}
+
+// ID returns the exact upstream league identifier.
+func (s Scope) ID() string { return s.id }
+
+// Revision returns the runtime configuration revision. Historical scopes are
+// revision-neutral and therefore return zero.
+func (s Scope) Revision() int64 { return s.revision }
+
+// Resolve reads the default league scope from the runtime SSOT.
+func Resolve(ctx context.Context, db interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}) (Scope, error) {
+	var scope Scope
+	err := db.QueryRow(ctx, `SELECT active_league, revision FROM runtime_config WHERE singleton = TRUE`).Scan(&scope.id, &scope.revision)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Scope{}, errors.New("league runtime configuration is not initialized")
+	}
+	if err != nil {
+		return Scope{}, fmt.Errorf("resolve league scope: %w", err)
+	}
+	return scope, nil
+}
+
+// Historical explicitly selects a non-runtime league for research. Its
+// revision is zero because no revision contract has been defined for archived
+// selections.
+func Historical(id string) Scope {
+	return Scope{id: id}
+}
+
+// RuntimeLockKey serializes process ownership of the runtime configuration.
+func RuntimeLockKey() int64 { return lockKey("runtime") }
+
+// DataLockKey serializes work against one scoped dataset.
+func DataLockKey(scope Scope) int64 { return lockKey("data", scope.id) }
+
+// AdministrationLockKey serializes league administration operations.
+func AdministrationLockKey() int64 { return lockKey("administration") }
+
+func lockKey(parts ...string) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte("profitofexile/league/"))
+	for _, part := range parts {
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(part))
+	}
+	return int64(h.Sum64() & (1<<63 - 1))
+}

--- a/internal/league/league_integration_test.go
+++ b/internal/league/league_integration_test.go
@@ -1,0 +1,40 @@
+//go:build integration
+
+package league
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"profitofexile/internal/db"
+)
+
+func TestResolveReadsMirageBootstrap(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set, skipping integration test")
+	}
+	if err := db.MigrateUp(db.MigrationsFS, databaseURL); err != nil {
+		t.Fatalf("apply migrations: %v", err)
+	}
+
+	pool, err := pgxpool.New(context.Background(), databaseURL)
+	if err != nil {
+		t.Fatalf("connect to database: %v", err)
+	}
+	defer pool.Close()
+
+	scope, err := Resolve(context.Background(), pool)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got, want := scope.ID(), "Mirage"; got != want {
+		t.Errorf("scope ID = %q, want %q", got, want)
+	}
+	if got, want := scope.Revision(), int64(1); got != want {
+		t.Errorf("scope revision = %d, want %d", got, want)
+	}
+}

--- a/internal/league/league_test.go
+++ b/internal/league/league_test.go
@@ -1,0 +1,110 @@
+package league
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+type scopeRow struct {
+	scan func(...any) error
+}
+
+func (r scopeRow) Scan(dest ...any) error {
+	return r.scan(dest...)
+}
+
+type scopeDB struct {
+	row pgx.Row
+}
+
+func (db scopeDB) QueryRow(context.Context, string, ...any) pgx.Row {
+	return db.row
+}
+
+func TestResolveReturnsRuntimeScope(t *testing.T) {
+	db := scopeDB{row: scopeRow{scan: func(dest ...any) error {
+		*dest[0].(*string) = "Mirage"
+		*dest[1].(*int64) = 7
+		return nil
+	}}}
+
+	scope, err := Resolve(context.Background(), db)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got, want := scope.ID(), "Mirage"; got != want {
+		t.Errorf("scope ID = %q, want %q", got, want)
+	}
+	if got, want := scope.Revision(), int64(7); got != want {
+		t.Errorf("scope revision = %d, want %d", got, want)
+	}
+}
+
+func TestResolveRejectsUninitializedRuntimeConfiguration(t *testing.T) {
+	db := scopeDB{row: scopeRow{scan: func(...any) error {
+		return pgx.ErrNoRows
+	}}}
+
+	_, err := Resolve(context.Background(), db)
+	if err == nil {
+		t.Fatal("Resolve returned nil error for missing runtime configuration")
+	}
+	if got, want := err.Error(), "league runtime configuration is not initialized"; got != want {
+		t.Errorf("Resolve error = %q, want %q", got, want)
+	}
+}
+
+func TestResolveWrapsDatabaseFailure(t *testing.T) {
+	db := scopeDB{row: scopeRow{scan: func(...any) error {
+		return errors.New("database unavailable")
+	}}}
+
+	_, err := Resolve(context.Background(), db)
+	if err == nil {
+		t.Fatal("Resolve returned nil error for database failure")
+	}
+	if got, want := err.Error(), "resolve league scope: database unavailable"; got != want {
+		t.Errorf("Resolve error = %q, want %q", got, want)
+	}
+}
+
+func TestHistoricalKeepsOnlyExplicitIdentity(t *testing.T) {
+	scope := Historical("Settlers")
+
+	if got, want := scope.ID(), "Settlers"; got != want {
+		t.Errorf("scope ID = %q, want %q", got, want)
+	}
+}
+
+func TestLockKeysAreStableAndPurposeSeparated(t *testing.T) {
+	scope := Historical("Mirage")
+
+	keys := map[string]int64{
+		"runtime":        RuntimeLockKey(),
+		"data":           DataLockKey(scope),
+		"administration": AdministrationLockKey(),
+	}
+	if got, want := RuntimeLockKey(), keys["runtime"]; got != want {
+		t.Errorf("runtime lock key changed between calls: got %d, want %d", got, want)
+	}
+	if got, want := DataLockKey(scope), keys["data"]; got != want {
+		t.Errorf("data lock key changed between calls: got %d, want %d", got, want)
+	}
+
+	for leftName, left := range keys {
+		for rightName, right := range keys {
+			if leftName < rightName && left == right {
+				t.Errorf("%s and %s use the same lock key %d", leftName, rightName, left)
+			}
+		}
+	}
+}
+
+func TestDataLockKeySeparatesLeagues(t *testing.T) {
+	if mirage, settlers := DataLockKey(Historical("Mirage")), DataLockKey(Historical("Settlers")); mirage == settlers {
+		t.Errorf("data lock keys collide for distinct leagues: %d", mirage)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds 12 forward-only league-scoping migrations and Mirage backfill.
- Establishes the league scope foundation, migration runbook, and ADRs.

## Verification

- Passed clean-local-DB focused migration integration: `go test -tags=integration ./internal/db/migrations` (2.159s).

## Not performed

- Restored-production rehearsal.
- Production stop/deploy/restart.
- Broader CI.