### PR TITLE
fix(lab): surface gems the market hasn't priced yet — rankings, OCR and pool counts at league start

### DIFF
--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1806,8 +1806,10 @@ fn send_font_session_data(app: &AppHandle) {
 async fn fetch_gem_names(app: &AppHandle, server_url: &str, client: &reqwest::Client, lab_mode: &str) -> Vec<String> {
     if lab_mode == "Dedication" {
         // Fetch both pools in parallel and merge.
-        let url_skills = format!("{}/api/analysis/gems/names?q=+&limit=500&corrupted=true&transfigured=false", server_url);
-        let url_transfig = format!("{}/api/analysis/gems/names?q=+&limit=500&corrupted=true&transfigured=true", server_url);
+        // Static game-data dictionary — OCR must recognise a gem whether or not the
+        // market prices it (a fresh league prices almost nothing for the first hours).
+        let url_skills = format!("{}/api/analysis/gems/dictionary?transfigured=false", server_url);
+        let url_transfig = format!("{}/api/analysis/gems/dictionary?transfigured=true", server_url);
 
         let (skills_res, transfig_res) = tokio::join!(
             client.get(&url_skills).send(),
@@ -1852,7 +1854,7 @@ async fn fetch_gem_names(app: &AppHandle, server_url: &str, client: &reqwest::Cl
         all_names
     } else {
         // Normal mode: transfigured gem names only.
-        let url = format!("{}/api/analysis/gems/names?q=of+&limit=500", server_url);
+        let url = format!("{}/api/analysis/gems/dictionary?transfigured=true", server_url);
         match client.get(&url).send().await {
             Ok(res) if res.status().is_success() => {
                 match res.json::<serde_json::Value>().await {

--- a/desktop/src/lib/api.test.ts
+++ b/desktop/src/lib/api.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// api.ts pulls in Tauri + the status store at module load; neither is needed for
+// the pure variant mapping under test.
+vi.mock('@tauri-apps/api/app', () => ({ getVersion: async () => '0.0.0-test' }));
+vi.mock('$lib/stores/status.svelte', () => ({ store: { status: { server_url: '' } } }));
+
+const { displayVariant } = await import('./api');
+
+/**
+ * The variant strings the UI filters on (ByVariant.svelte, FontEVCompare.svelte).
+ * Kept literal here on purpose: if the backend format and this list drift apart
+ * again, the "1/0" and "20/0" tabs silently render "No data for this variant".
+ */
+const UI_VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
+
+describe('displayVariant', () => {
+	it('restores the /0 suffix on a level-1 zero-quality variant so the 1/0 tab matches', () => {
+		// Backend stores/serves this as "1" (internal/lab/transfigure.go).
+		expect(displayVariant('1')).toBe('1/0');
+		expect(UI_VARIANTS).toContain(displayVariant('1'));
+	});
+
+	it('restores the /0 suffix on a level-20 zero-quality variant so the 20/0 tab matches', () => {
+		expect(displayVariant('20')).toBe('20/0');
+		expect(UI_VARIANTS).toContain(displayVariant('20'));
+	});
+
+	it('leaves variants that already carry a quality untouched', () => {
+		expect(displayVariant('1/20')).toBe('1/20');
+		expect(displayVariant('20/20')).toBe('20/20');
+	});
+
+	it('leaves the corrupted Dedication variant untouched', () => {
+		// "21/23" must not become "21/23/0" — Dedication rows are filtered by pool,
+		// but the variant is still displayed verbatim.
+		expect(displayVariant('21/23')).toBe('21/23');
+	});
+
+	it('leaves a missing variant empty rather than inventing "/0"', () => {
+		expect(displayVariant('')).toBe('');
+	});
+});

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -26,6 +26,8 @@ export interface GemPlay {
 	baseName: string;
 	variant: string;
 	color: 'RED' | 'GREEN' | 'BLUE';
+	/** 'OK' | 'LOW' | 'NO_BASE'. NO_BASE means the base gem is unpriced, so roi/basePrice are unknown — not zero. */
+	confidence: string;
 	roi: number;
 	roiPercent: number;
 	weightedRoi: number;
@@ -246,13 +248,25 @@ async function get<T>(path: string, params?: Record<string, string>): Promise<T>
 
 // --- Mapping helpers ---
 
+/**
+ * Convert a backend variant ("1", "20") to the UI's display format ("1/0", "20/0").
+ * The backend stores zero-quality variants without the quality suffix and normalizes
+ * "/0" away on inbound query params, but never restores it on responses — so UI code
+ * comparing against "1/0"/"20/0" would never match. Variants that already carry a
+ * quality ("1/20", "21/23") pass through unchanged.
+ */
+export function displayVariant(v: string): string {
+	return /^\d+$/.test(v) ? `${v}/0` : v;
+}
+
 /** Map a backend collective/trends row to frontend GemPlay. */
 function mapCollectiveRow(r: any): GemPlay {
 	return {
 		name: r.transfiguredName || r.name || '',
 		baseName: r.baseName || '',
-		variant: r.variant || '',
+		variant: displayVariant(r.variant || ''),
 		color: r.gemColor || '',
+		confidence: r.confidence || '',
 		roi: Math.round(r.roi || 0),
 		roiPercent: Math.round(r.roiPct || 0),
 		weightedRoi: Math.round(r.weightedRoi || 0),
@@ -295,7 +309,7 @@ function mapCompareRow(r: any): CompareGem {
 		: [];
 	return {
 		name: r.transfiguredName || '',
-		variant: r.variant || '',
+		variant: displayVariant(r.variant || ''),
 		color: r.gemColor || '',
 		roi: Math.round(r.roi || 0),
 		roiPercent: Math.round(r.roiPct || 0),

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -74,6 +74,8 @@ export interface FontColor {
 	color: 'RED' | 'GREEN' | 'BLUE';
 	ev: number;
 	pool: number;
+	/** How many of `pool` carry a price at this variant. Below `pool` means missing prices, not a smaller pool. */
+	pricedGems: number;
 	winners: number;
 	pWin: number;
 	profit: number;
@@ -399,6 +401,7 @@ function mapFontRows(rows: any[]): FontColor[] {
 		color: r.color || '',
 		ev: Math.round(r.ev || 0),
 		pool: r.pool || 0,
+		pricedGems: r.pricedGems ?? (r.pool || 0),
 		winners: r.winners || 0,
 		pWin: Math.round((r.pWin || 0) * 10000) / 100,
 		profit: Math.round(r.profit || 0),

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -172,6 +172,8 @@ export interface CompareGem {
 	name: string;
 	variant: string;
 	color: 'RED' | 'GREEN' | 'BLUE';
+	/** 'OK' | 'LOW' | 'NO_BASE' | 'NO_DATA'. NO_DATA means the gem is unpriced — its zeros are unknown, not 0c. */
+	confidence: string;
 	roi: number;
 	roiPercent: number;
 	weightedRoi: number;
@@ -313,6 +315,7 @@ function mapCompareRow(r: any): CompareGem {
 		name: r.transfiguredName || '',
 		variant: displayVariant(r.variant || ''),
 		color: r.gemColor || '',
+		confidence: r.confidence || '',
 		roi: Math.round(r.roi || 0),
 		roiPercent: Math.round(r.roiPct || 0),
 		weightedRoi: Math.round(r.weightedRoi || 0),

--- a/desktop/src/routes/(app)/components/BestPlays.svelte
+++ b/desktop/src/routes/(app)/components/BestPlays.svelte
@@ -107,7 +107,9 @@
 		}
 		const b = parseInt(budget);
 		if (b > 0) {
-			filtered = filtered.filter((p) => p.basePrice <= b);
+			// NO_BASE gems have no known cost basis (basePrice 0 means unknown, not
+			// free), so they can't be shown to fit a budget — same rule as the server.
+			filtered = filtered.filter((p) => p.confidence !== 'NO_BASE' && p.basePrice <= b);
 			if (b <= 50) sortBy = 'roiPercent';
 		}
 		if (sortBy === 'price') {
@@ -229,7 +231,13 @@
 					<span class="tier-badge tier-{gem.priceTier.toLowerCase()}" class:low-conf={gem.lowConfidence}>{gem.priceTier}</span>
 				</td>
 				<td class="col-num price-val">{gem.transPrice}c</td>
-				<td class="col-num roi-val">{sortBy === 'riskAdjusted' ? gem.weightedRoi : gem.roi}c</td>
+				<td class="col-num roi-val">
+					{#if gem.confidence === 'NO_BASE'}
+						<Tooltip text="Base gem is not listed on poe.ninja yet, so ROI can't be computed. The gem's own price is real — common right after a league start."><span class="roi-unknown">—</span></Tooltip>
+					{:else}
+						{sortBy === 'riskAdjusted' ? gem.weightedRoi : gem.roi}c
+					{/if}
+				</td>
 				<td class="col-signal">
 					<SignalBadge signal={gem.signal} />
 					{#if gem.sellConfidence}
@@ -260,7 +268,7 @@
 					<td colspan={showVariantColumn ? 10 : 9} class="expanded-cell">
 						<div class="expanded-content">
 							<span class="expanded-meta">
-								Base: {gem.basePrice}c | Trans: {gem.transPrice}c |
+								Base: {gem.confidence === 'NO_BASE' ? 'not listed' : `${gem.basePrice}c`} | Trans: {gem.transPrice}c |
 								Liq: {gem.liquidityTier} |
 								Color: <span class="color-{gem.color.toLowerCase()}">{gem.color}</span> |
 								Sellability: {gem.sellabilityLabel} ({gem.sellability})
@@ -509,6 +517,10 @@
 	.roi-val {
 		color: var(--color-lab-green);
 		font-weight: 700;
+	}
+	.roi-unknown {
+		color: var(--color-lab-text-secondary);
+		font-weight: 400;
 	}
 	.cv-val {
 		color: var(--color-lab-text-secondary);

--- a/desktop/src/routes/(app)/components/Comparator.svelte
+++ b/desktop/src/routes/(app)/components/Comparator.svelte
@@ -602,6 +602,7 @@
 	{#if results.length > 0}
 		<div class="cards-row">
 			{#each results as gem}
+				{@const noData = gem.confidence === 'NO_DATA' || (gem.transPrice === 0 && gem.low7d === 0 && gem.high7d === 0)}
 				<!-- svelte-ignore a11y_click_events_have_key_events -->
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<div class="compare-card" class:queue-selected={selectedForQueue === gem.name} onclick={() => { selectedForQueue = gem.name; }}>
@@ -612,7 +613,8 @@
 					</div>
 					<div class="card-row price-line">
 						<Tooltip text="Ninja price vs risk-adjusted (sell probability × stability)"><span class="price-display">
-							<span class="price-raw">{gem.transPrice}c{divSuffix(gem.transPrice)}</span>
+							<!-- An unpriced gem's 0 is unknown, not a 0c valuation. -->
+							<span class="price-raw">{noData ? '—' : `${gem.transPrice}c${divSuffix(gem.transPrice)}`}</span>
 							{#if gem.riskAdjustedPrice > 0}
 								<span class="price-risk-adj">(<span class="price-risk-label">Risk-adjusted:</span> {gem.riskAdjustedPrice}c{divSuffix(gem.riskAdjustedPrice)})</span>
 							{/if}
@@ -634,7 +636,7 @@
 					</div>
 					<div class="price-context">
 						<div class="price-row">
-							<span>Listed: {gem.transPrice}c{divSuffix(gem.transPrice)}</span>
+							<span>Listed: {noData ? '—' : `${gem.transPrice}c${divSuffix(gem.transPrice)}`}</span>
 							{#if gem.quickSellPrice > 0}
 								<span class="quick-sell">Quick-sell: ~{gem.quickSellPrice}c</span>
 							{/if}
@@ -645,7 +647,7 @@
 								<span class="range-sep">&middot;</span>
 								<span class="range-label">7 days highest: {gem.high7d}c</span>
 							</div>
-						{:else if gem.transPrice === 0}
+						{:else if noData}
 							<div class="anomaly-banner">No poe.ninja data — check trade listings</div>
 						{/if}
 					</div>

--- a/desktop/src/routes/(app)/components/FontEVCompare.svelte
+++ b/desktop/src/routes/(app)/components/FontEVCompare.svelte
@@ -504,8 +504,15 @@
 						{@const breakdown = getPoolBreakdown(poolVariant, color)}
 						{@const safe = getColorData(poolVariant, color, 'safe')}
 						{@const totalGems = safe?.pool || breakdown.reduce((s, t) => s + t.count, 0)}
+						{@const pricedGems = safe?.pricedGems ?? totalGems}
 						<div class="pool-color-card">
-							<div class="pool-color-header c-{color.toLowerCase()}">{color} <span class="pool-count">{totalGems} gems</span></div>
+							<div class="pool-color-header c-{color.toLowerCase()}">{color}
+								{#if pricedGems < totalGems}
+									<Tooltip text="Only {pricedGems} of the {totalGems} {color} gems this Font can roll are priced at {poolVariant}. The rest count as outcomes worth 0c, so the EV here is a floor — missing prices, not worthless gems."><span class="pool-count pool-count-partial">{pricedGems} / {totalGems} priced</span></Tooltip>
+								{:else}
+									<span class="pool-count">{totalGems} gems</span>
+								{/if}
+							</div>
 							{#each ALL_TIERS as tierName}
 								{@const tier = breakdown.find(t => t.tier === tierName)}
 								{@const tierPWin = tier ? Math.round(pWin3(tier.count, totalGems) * 100) : 0}
@@ -731,6 +738,10 @@
 		font-size: 0.8125rem;
 		color: var(--color-lab-text-secondary);
 		margin-left: 6px;
+	}
+	.pool-count-partial {
+		border-bottom: 1px dotted var(--color-lab-text-secondary);
+		cursor: help;
 	}
 	.pool-tier-row {
 		display: flex;

--- a/desktop/src/routes/overlay/comparator/+page.svelte
+++ b/desktop/src/routes/overlay/comparator/+page.svelte
@@ -273,12 +273,13 @@
 					{@const tierColor = TIER_COLORS[gem.priceTier] ?? '#94a3b8'}
 					{@const sigColor = SIGNAL_COLORS[gem.signal] ?? '#9ca3af'}
 					{@const trade = tradeData[gem.name]}
+					{@const noData = gem.confidence === 'NO_DATA' || (gem.transPrice === 0 && gem.low7d === 0 && gem.high7d === 0)}
 					<div class="gem-row" class:selected={selectedGem === gem.name}>
 						<div class="row-top">
 							<GemIcon name={gem.name} size={24} />
 							<span class="gem-name" style="color: {rec.color}">{gem.name}</span>
 							<span class="rec" style="color: {rec.color}; background: {rec.bg}">{gem.recommendation}</span>
-							{#if gem.transPrice === 0 && gem.low7d === 0 && gem.high7d === 0}
+							{#if noData}
 								<span class="anomaly">no ninja data</span>
 							{:else}
 								<span class="sell" style="color: {sigColor}">{gem.signal}</span>
@@ -290,7 +291,8 @@
 							<span class="variant-label">{gem.variant}</span>
 							<span class="price-col">
 								<span class="price-label">ninja</span>
-								<span class="price">{formatPrice(gem.transPrice)}{divSuffix(gem.transPrice)}</span>
+								<!-- A NO_DATA gem's 0 means unpriced, not worth 0c — never print it as a price. -->
+								<span class="price">{noData ? '—' : `${formatPrice(gem.transPrice)}${divSuffix(gem.transPrice)}`}</span>
 							</span>
 							{#if trade}
 								{#if trade.signals.sellerConcentration !== 'NORMAL'}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -72,6 +72,8 @@ export interface FontColor {
 	color: 'RED' | 'GREEN' | 'BLUE';
 	ev: number;
 	pool: number;
+	/** How many of `pool` carry a price at this variant. Below `pool` means missing prices, not a smaller pool. */
+	pricedGems: number;
 	winners: number;
 	pWin: number;
 	profit: number;
@@ -368,6 +370,7 @@ function mapFontRows(rows: any[]): FontColor[] {
 		color: r.color || '',
 		ev: Math.round(r.ev || 0),
 		pool: r.pool || 0,
+		pricedGems: r.pricedGems ?? (r.pool || 0),
 		winners: r.winners || 0,
 		pWin: Math.round((r.pWin || 0) * 10000) / 100,
 		profit: Math.round(r.profit || 0),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -170,6 +170,8 @@ export interface CompareGem {
 	name: string;
 	variant: string;
 	color: 'RED' | 'GREEN' | 'BLUE';
+	/** 'OK' | 'LOW' | 'NO_BASE' | 'NO_DATA'. NO_DATA means the gem is unpriced — its zeros are unknown, not 0c. */
+	confidence: string;
 	roi: number;
 	roiPercent: number;
 	weightedRoi: number;
@@ -283,6 +285,7 @@ function mapCompareRow(r: any): CompareGem {
 		name: r.transfiguredName || '',
 		variant: displayVariant(r.variant || ''),
 		color: r.gemColor || '',
+		confidence: r.confidence || '',
 		roi: Math.round(r.roi || 0),
 		roiPercent: Math.round(r.roiPct || 0),
 		weightedRoi: Math.round(r.weightedRoi || 0),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -24,6 +24,8 @@ export interface GemPlay {
 	name: string;
 	variant: string;
 	color: 'RED' | 'GREEN' | 'BLUE';
+	/** 'OK' | 'LOW' | 'NO_BASE'. NO_BASE means the base gem is unpriced, so roi/basePrice are unknown — not zero. */
+	confidence: string;
 	roi: number;
 	roiPercent: number;
 	weightedRoi: number;
@@ -217,12 +219,24 @@ async function get<T>(path: string, params?: Record<string, string>): Promise<T>
 
 // --- Mapping helpers ---
 
+/**
+ * Convert a backend variant ("1", "20") to the UI's display format ("1/0", "20/0").
+ * The backend stores zero-quality variants without the quality suffix and normalizes
+ * "/0" away on inbound query params, but never restores it on responses — so UI code
+ * comparing against "1/0"/"20/0" would never match. Variants that already carry a
+ * quality ("1/20", "21/23") pass through unchanged.
+ */
+export function displayVariant(v: string): string {
+	return /^\d+$/.test(v) ? `${v}/0` : v;
+}
+
 /** Map a backend collective/trends row to frontend GemPlay. */
 function mapCollectiveRow(r: any): GemPlay {
 	return {
 		name: r.transfiguredName || r.name || '',
-		variant: r.variant || '',
+		variant: displayVariant(r.variant || ''),
 		color: r.gemColor || '',
+		confidence: r.confidence || '',
 		roi: Math.round(r.roi || 0),
 		roiPercent: Math.round(r.roiPct || 0),
 		weightedRoi: Math.round(r.weightedRoi || 0),
@@ -265,7 +279,7 @@ function mapCompareRow(r: any): CompareGem {
 		: [];
 	return {
 		name: r.transfiguredName || '',
-		variant: r.variant || '',
+		variant: displayVariant(r.variant || ''),
 		color: r.gemColor || '',
 		roi: Math.round(r.roi || 0),
 		roiPercent: Math.round(r.roiPct || 0),

--- a/frontend/src/routes/lab/components/BestPlays.svelte
+++ b/frontend/src/routes/lab/components/BestPlays.svelte
@@ -107,7 +107,9 @@
 		}
 		const b = parseInt(budget);
 		if (b > 0) {
-			filtered = filtered.filter((p) => p.basePrice <= b);
+			// NO_BASE gems have no known cost basis (basePrice 0 means unknown, not
+			// free), so they can't be shown to fit a budget — same rule as the server.
+			filtered = filtered.filter((p) => p.confidence !== 'NO_BASE' && p.basePrice <= b);
 			if (b <= 50) sortBy = 'roiPercent';
 		}
 		if (sortBy === 'price') {
@@ -229,7 +231,13 @@
 					<span class="tier-badge tier-{gem.priceTier.toLowerCase()}" class:low-conf={gem.lowConfidence}>{gem.priceTier}</span>
 				</td>
 				<td class="col-num price-val">{gem.transPrice}c</td>
-				<td class="col-num roi-val">{sortBy === 'riskAdjusted' ? gem.weightedRoi : gem.roi}c</td>
+				<td class="col-num roi-val">
+					{#if gem.confidence === 'NO_BASE'}
+						<span class="roi-unknown" title="Base gem is not listed on poe.ninja yet, so ROI can't be computed. The gem's own price is real — common right after a league start.">—</span>
+					{:else}
+						{sortBy === 'riskAdjusted' ? gem.weightedRoi : gem.roi}c
+					{/if}
+				</td>
 				<td class="col-signal">
 					<SignalBadge signal={gem.signal} />
 					{#if gem.sellConfidence}
@@ -260,7 +268,7 @@
 					<td colspan={showVariantColumn ? 10 : 9} class="expanded-cell">
 						<div class="expanded-content">
 							<span class="expanded-meta">
-								Base: {gem.basePrice}c | Trans: {gem.transPrice}c |
+								Base: {gem.confidence === 'NO_BASE' ? 'not listed' : `${gem.basePrice}c`} | Trans: {gem.transPrice}c |
 								Liq: {gem.liquidityTier} |
 								Color: <span class="color-{gem.color.toLowerCase()}">{gem.color}</span> |
 								Sellability: {gem.sellabilityLabel} ({gem.sellability})
@@ -501,6 +509,10 @@
 	.roi-val {
 		color: var(--color-lab-green);
 		font-weight: 700;
+	}
+	.roi-unknown {
+		color: var(--color-lab-text-secondary);
+		font-weight: 400;
 	}
 	.cv-val {
 		color: var(--color-lab-text-secondary);

--- a/frontend/src/routes/lab/components/Comparator.svelte
+++ b/frontend/src/routes/lab/components/Comparator.svelte
@@ -522,6 +522,8 @@
 									<div class="range-fill" style="width: {Math.min(100, Math.max(0, gem.histPosition))}%"></div>
 								</div>
 							</div>
+						{:else if noData}
+							<div class="anomaly-banner">No poe.ninja data — check trade listings</div>
 						{/if}
 					</div>
 					{#if gem.signal === 'DUMPING'}
@@ -1405,6 +1407,12 @@
 	.range-sep {
 		margin: 0 4px;
 		opacity: 0.5;
+	}
+	.anomaly-banner {
+		color: var(--color-lab-yellow, #eab308);
+		font-size: 0.75rem;
+		font-style: italic;
+		margin-top: 4px;
 	}
 	.range-bar {
 		width: 100%;

--- a/frontend/src/routes/lab/components/Comparator.svelte
+++ b/frontend/src/routes/lab/components/Comparator.svelte
@@ -474,6 +474,7 @@
 	{#if results.length > 0}
 		<div class="cards-row">
 			{#each results as gem}
+				{@const noData = gem.confidence === 'NO_DATA' || (gem.transPrice === 0 && gem.low7d === 0 && gem.high7d === 0)}
 				<!-- svelte-ignore a11y_click_events_have_key_events -->
 				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<div class="compare-card" class:queue-selected={selectedForQueue === gem.name} onclick={() => { selectedForQueue = gem.name; }}>
@@ -484,7 +485,8 @@
 					</div>
 					<div class="card-row price-line">
 						<span class="price-display" title="Ninja price vs risk-adjusted (sell probability × stability)">
-							<span class="price-raw">{gem.transPrice}c</span>
+							<!-- An unpriced gem's 0 is unknown, not a 0c valuation. -->
+							<span class="price-raw">{noData ? '—' : `${gem.transPrice}c`}</span>
 							{#if gem.riskAdjustedPrice > 0}
 								<span class="price-risk-adj">(<span class="price-risk-label">Risk-adjusted:</span> {gem.riskAdjustedPrice}c)</span>
 							{/if}
@@ -506,7 +508,7 @@
 					</div>
 					<div class="price-context">
 						<div class="price-row">
-							<span>Listed: {gem.transPrice}c</span>
+							<span>Listed: {noData ? '—' : `${gem.transPrice}c`}</span>
 							{#if gem.quickSellPrice > 0}
 								<span class="quick-sell">Quick-sell: ~{gem.quickSellPrice}c</span>
 							{/if}

--- a/frontend/src/routes/lab/components/FontEVCompare.svelte
+++ b/frontend/src/routes/lab/components/FontEVCompare.svelte
@@ -478,8 +478,15 @@
 						{@const breakdown = getPoolBreakdown(poolVariant, color)}
 						{@const safe = getColorData(poolVariant, color, 'safe')}
 						{@const totalGems = safe?.pool || breakdown.reduce((s, t) => s + t.count, 0)}
+						{@const pricedGems = safe?.pricedGems ?? totalGems}
 						<div class="pool-color-card">
-							<div class="pool-color-header c-{color.toLowerCase()}">{color} <span class="pool-count">{totalGems} gems</span></div>
+							<div class="pool-color-header c-{color.toLowerCase()}">{color}
+								{#if pricedGems < totalGems}
+									<span class="pool-count pool-count-partial" title="Only {pricedGems} of the {totalGems} {color} gems this Font can roll are priced at {poolVariant}. The rest count as outcomes worth 0c, so the EV here is a floor — missing prices, not worthless gems.">{pricedGems} / {totalGems} priced</span>
+								{:else}
+									<span class="pool-count">{totalGems} gems</span>
+								{/if}
+							</div>
 							{#each ALL_TIERS as tierName}
 								{@const tier = breakdown.find(t => t.tier === tierName)}
 								{@const tierPWin = tier ? Math.round(pWin3(tier.count, totalGems) * 100) : 0}
@@ -735,6 +742,10 @@
 		margin-bottom: 4px;
 		padding-bottom: 4px;
 		border-bottom: 1px solid var(--color-lab-border);
+	}
+	.pool-count-partial {
+		border-bottom: 1px dotted var(--color-lab-text-secondary);
+		cursor: help;
 	}
 	.pool-count {
 		font-weight: 400;

--- a/internal/db/migrations/20260725000000_transfigure_confidence_no_base.down.sql
+++ b/internal/db/migrations/20260725000000_transfigure_confidence_no_base.down.sql
@@ -1,0 +1,6 @@
+-- Drop the rows the widened constraint allowed before restoring it. transfigure_results
+-- is derived analysis output — the next collection cycle recomputes it.
+DELETE FROM transfigure_results WHERE confidence = 'NO_BASE';
+ALTER TABLE transfigure_results DROP CONSTRAINT IF EXISTS transfigure_results_confidence_check;
+ALTER TABLE transfigure_results ADD CONSTRAINT transfigure_results_confidence_check
+    CHECK (confidence IN ('OK', 'LOW'));

--- a/internal/db/migrations/20260725000000_transfigure_confidence_no_base.down.sql
+++ b/internal/db/migrations/20260725000000_transfigure_confidence_no_base.down.sql
@@ -1,6 +1,11 @@
--- Drop the rows the widened constraint allowed before restoring it. transfigure_results
--- is derived analysis output — the next collection cycle recomputes it.
-DELETE FROM transfigure_results WHERE confidence = 'NO_BASE';
+-- Restore the narrower constraint. NOT VALID again, and deliberately without a
+-- DELETE of the NO_BASE rows: transfigure_results is derived output that the next
+-- collection cycle recomputes, and a DELETE keyed on a non-segmentby column would
+-- decompress every chunk to evaluate it.
+--
+-- Note this is not a strict inverse everywhere: production carries no confidence
+-- CHECK at all (its table predates the one in the create migration), so rolling
+-- back there adds a constraint rather than restoring one.
 ALTER TABLE transfigure_results DROP CONSTRAINT IF EXISTS transfigure_results_confidence_check;
 ALTER TABLE transfigure_results ADD CONSTRAINT transfigure_results_confidence_check
-    CHECK (confidence IN ('OK', 'LOW'));
+    CHECK (confidence IN ('OK', 'LOW')) NOT VALID;

--- a/internal/db/migrations/20260725000000_transfigure_confidence_no_base.up.sql
+++ b/internal/db/migrations/20260725000000_transfigure_confidence_no_base.up.sql
@@ -1,0 +1,5 @@
+-- Allow the NO_BASE confidence written by AnalyzeTransfigure for transfigured
+-- gems whose base gem is absent from the snapshot (ROI unknown, not zero).
+ALTER TABLE transfigure_results DROP CONSTRAINT IF EXISTS transfigure_results_confidence_check;
+ALTER TABLE transfigure_results ADD CONSTRAINT transfigure_results_confidence_check
+    CHECK (confidence IN ('OK', 'LOW', 'NO_BASE'));

--- a/internal/db/migrations/20260725000000_transfigure_confidence_no_base.up.sql
+++ b/internal/db/migrations/20260725000000_transfigure_confidence_no_base.up.sql
@@ -1,5 +1,10 @@
 -- Allow the NO_BASE confidence written by AnalyzeTransfigure for transfigured
 -- gems whose base gem is absent from the snapshot (ROI unknown, not zero).
+--
+-- NOT VALID: every existing row was written as 'OK' or 'LOW' by an older binary,
+-- so there is nothing to validate. Skipping the scan keeps this off the
+-- ACCESS EXCLUSIVE path over a hypertable that retains full league history and
+-- compresses chunks after 7 days. New writes are still checked.
 ALTER TABLE transfigure_results DROP CONSTRAINT IF EXISTS transfigure_results_confidence_check;
 ALTER TABLE transfigure_results ADD CONSTRAINT transfigure_results_confidence_check
-    CHECK (confidence IN ('OK', 'LOW', 'NO_BASE'));
+    CHECK (confidence IN ('OK', 'LOW', 'NO_BASE')) NOT VALID;

--- a/internal/db/migrations/20260725001000_font_snapshots_priced_gems.down.sql
+++ b/internal/db/migrations/20260725001000_font_snapshots_priced_gems.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE font_snapshots DROP COLUMN IF EXISTS priced_gems;

--- a/internal/db/migrations/20260725001000_font_snapshots_priced_gems.up.sql
+++ b/internal/db/migrations/20260725001000_font_snapshots_priced_gems.up.sql
@@ -1,0 +1,6 @@
+-- PricedGems: how many of a colour pool carry a usable price at that variant.
+-- Persisted so the DB-read path reports the same number the analyzer computed —
+-- without it, any response served before the first font run after a restart
+-- reports 0 priced for a fully priced pool.
+-- NULL means "written before this column existed"; readers coalesce to pool.
+ALTER TABLE font_snapshots ADD COLUMN IF NOT EXISTS priced_gems INTEGER;

--- a/internal/lab/collective.go
+++ b/internal/lab/collective.go
@@ -332,10 +332,26 @@ func BuildCompareResults(
 		found := false
 		var bestTr *TransfigureResult
 		for k, tr := range trIndex {
-			if k.name == name {
-				if bestTr == nil || tr.ROI > bestTr.ROI {
+			if k.name != name {
+				continue
+			}
+			// A NO_BASE row's ROI is 0 meaning "unknown", so it must never win this
+			// comparison against a row with a real (possibly negative) ROI — that
+			// would pick the variant with no data over the one that has it.
+			if bestTr == nil {
+				bestTr = tr
+				continue
+			}
+			bestIsNoBase := bestTr.Confidence == ConfidenceNoBase
+			trIsNoBase := tr.Confidence == ConfidenceNoBase
+			if bestIsNoBase != trIsNoBase {
+				if bestIsNoBase {
 					bestTr = tr
 				}
+				continue
+			}
+			if tr.ROI > bestTr.ROI {
+				bestTr = tr
 			}
 		}
 		if bestTr != nil {
@@ -352,6 +368,12 @@ func BuildCompareResults(
 				cr.ROI = bestTr.TransfiguredPrice - colorBase
 				if colorBase > 0 {
 					cr.ROIPct = (cr.ROI / colorBase) * 100
+				}
+				// The lab cost basis is any base gem of this colour, not this gem's own
+				// base — so a NO_BASE row that gets one is no longer missing its cost
+				// basis. Keeping the label here would tell the UI to hide real numbers.
+				if cr.Confidence == ConfidenceNoBase {
+					cr.Confidence = "LOW"
 				}
 			} else {
 				cr.BasePrice = bestTr.BasePrice

--- a/internal/lab/collective.go
+++ b/internal/lab/collective.go
@@ -151,13 +151,23 @@ func RankCollective(transfigure []TransfigureResult, signals []GemSignal, featur
 	var results []CollectiveResult
 
 	for _, tr := range transfigure {
-		// Only include profitable, confident results.
-		if tr.ROI <= 0 || tr.Confidence != "OK" {
+		noBase := tr.Confidence == ConfidenceNoBase
+
+		// Only include profitable, confident results — except NO_BASE gems, whose
+		// ROI is unknown rather than zero. Those are kept on their own price alone
+		// so a gem the market prices stays visible (the Font EV analyzer already
+		// shows it), with the missing base surfaced via Confidence.
+		if noBase {
+			if tr.TransfiguredPrice <= 0 {
+				continue
+			}
+		} else if tr.ROI <= 0 || tr.Confidence != "OK" {
 			continue
 		}
 
-		// Budget filter on base price.
-		if budget > 0 && tr.BasePrice > budget {
+		// Budget filter on base price. A NO_BASE gem has no known cost basis, so it
+		// cannot be shown to fit a budget — drop it whenever a budget is in play.
+		if budget > 0 && (noBase || tr.BasePrice > budget) {
 			continue
 		}
 
@@ -229,14 +239,22 @@ func RankCollective(transfigure []TransfigureResult, signals []GemSignal, featur
 		results = append(results, cr)
 	}
 
-	// Sort by chosen metric descending.
+	// Sort by chosen metric descending. Ties break on transfigured price so that
+	// NO_BASE gems — all of which score 0 on any ROI metric — still rank by value
+	// among themselves instead of in map order.
 	if sortBy == SortPct {
 		sort.Slice(results, func(i, j int) bool {
-			return results[i].WeightedROIPct > results[j].WeightedROIPct
+			if results[i].WeightedROIPct != results[j].WeightedROIPct {
+				return results[i].WeightedROIPct > results[j].WeightedROIPct
+			}
+			return results[i].TransfiguredPrice > results[j].TransfiguredPrice
 		})
 	} else {
 		sort.Slice(results, func(i, j int) bool {
-			return results[i].WeightedROI > results[j].WeightedROI
+			if results[i].WeightedROI != results[j].WeightedROI {
+				return results[i].WeightedROI > results[j].WeightedROI
+			}
+			return results[i].TransfiguredPrice > results[j].TransfiguredPrice
 		})
 	}
 
@@ -277,8 +295,13 @@ func BuildCompareResults(
 	type colorVariantKey struct{ color, variant string }
 	cheapestBase := make(map[colorVariantKey]float64)
 	for _, t := range transfigure {
+		// NO_BASE rows carry BasePrice 0 (unknown, not free) — letting one seed the
+		// map would make every gem of that color/variant look like a free base.
+		if t.BasePrice <= 0 {
+			continue
+		}
 		key := colorVariantKey{t.GemColor, t.Variant}
-		if existing, ok := cheapestBase[key]; !ok || (t.BasePrice > 0 && t.BasePrice < existing) {
+		if existing, ok := cheapestBase[key]; !ok || t.BasePrice < existing {
 			cheapestBase[key] = t.BasePrice
 		}
 	}

--- a/internal/lab/collective.go
+++ b/internal/lab/collective.go
@@ -364,8 +364,10 @@ func BuildCompareResults(
 		if !found {
 			// Gem not found in transfigure results — include with zero values
 			// but preserve the requested variant so the frontend doesn't fall
-			// back to a different one.
-			cr.Confidence = "LOW"
+			// back to a different one. NO_DATA (not LOW) so the UI can render
+			// those zeros as "unknown" rather than as a 0c price; OCR can now
+			// recognise gems the market has not priced at all.
+			cr.Confidence = ConfidenceNoData
 			if requestedVariant != "" {
 				cr.Variant = requestedVariant
 			}

--- a/internal/lab/collective_test.go
+++ b/internal/lab/collective_test.go
@@ -664,3 +664,50 @@ func TestBuildCompareResults_NoBaseRowDoesNotBecomeTheCheapestBase(t *testing.T)
 			results[0].ROI)
 	}
 }
+
+func TestBuildCompareResults_PrefersAVariantWithRealDataOverNoBase(t *testing.T) {
+	// The 20/20 row is genuinely priced but currently sells below its base — a real
+	// league-start shape. Its negative ROI must still beat the NO_BASE row's 0,
+	// which means "unknown", or the comparison shows the variant we know nothing about.
+	transfigure := []TransfigureResult{
+		{TransfiguredName: "Spark of Nova", BaseName: "Spark", Variant: "20/20", GemColor: "BLUE",
+			BasePrice: 300, TransfiguredPrice: 100, ROI: -200, ROIPct: -66, Confidence: "OK"},
+		{TransfiguredName: "Spark of Nova", BaseName: "Spark", Variant: "1", GemColor: "BLUE",
+			TransfiguredPrice: 12, Confidence: ConfidenceNoBase},
+	}
+
+	results := BuildCompareResults([]string{"Spark of Nova"}, transfigure, nil, nil, nil, "")
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Variant != "20/20" {
+		t.Errorf("variant = %q, want 20/20 — the only variant with a known cost basis", results[0].Variant)
+	}
+}
+
+func TestBuildCompareResults_NoBaseGemWithAColorBaseIsNoLongerLabelledNoBase(t *testing.T) {
+	// The lab cost basis is the cheapest base of that colour/variant, not this
+	// gem's own base — so once one is found the ROI is real and the row must stop
+	// claiming its cost basis is unknown, or the UI hides valid numbers.
+	transfigure := []TransfigureResult{
+		{TransfiguredName: "Spark of Nova", BaseName: "Spark", Variant: "20/20", GemColor: "BLUE",
+			TransfiguredPrice: 200, Confidence: ConfidenceNoBase},
+		{TransfiguredName: "Arc of Surging", BaseName: "Arc", Variant: "20/20", GemColor: "BLUE",
+			BasePrice: 20, TransfiguredPrice: 90, ROI: 70, ROIPct: 350, Confidence: "OK"},
+	}
+
+	results := BuildCompareResults([]string{"Spark of Nova"}, transfigure, nil, nil, nil, "20/20")
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Confidence == ConfidenceNoBase {
+		t.Errorf("confidence = %s with BasePrice %.0f and ROI %.0f — a substituted colour base is a known cost basis",
+			results[0].Confidence, results[0].BasePrice, results[0].ROI)
+	}
+	if results[0].BasePrice != 20 || results[0].ROI != 180 {
+		t.Errorf("BasePrice/ROI = %.0f/%.0f, want 20/180 (cheapest BLUE 20/20 base)",
+			results[0].BasePrice, results[0].ROI)
+	}
+}

--- a/internal/lab/collective_test.go
+++ b/internal/lab/collective_test.go
@@ -579,3 +579,86 @@ func TestSignalWeight(t *testing.T) {
 		}
 	}
 }
+
+func TestRankCollective_KeepsNoBaseGemWithUnknownROI(t *testing.T) {
+	now := time.Now()
+	// The gem the Font EV analyzer can already price: transfigured price known,
+	// base unpriced. It must not be dropped by the profitability gate.
+	transfigure := []TransfigureResult{
+		{Time: now, TransfiguredName: "Tornado of Elemental Turbulence", Variant: "1",
+			TransfiguredPrice: 20, Confidence: ConfidenceNoBase},
+	}
+
+	results := RankCollective(transfigure, nil, nil, 0, 50, "")
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1 (NO_BASE gem must stay in the rankings)", len(results))
+	}
+	if results[0].Confidence != ConfidenceNoBase {
+		t.Errorf("Confidence = %q, want %q so the UI can mark ROI unknown",
+			results[0].Confidence, ConfidenceNoBase)
+	}
+	if results[0].TransfiguredPrice != 20 {
+		t.Errorf("TransfiguredPrice = %f, want 20", results[0].TransfiguredPrice)
+	}
+}
+
+func TestRankCollective_DropsNoBaseGemWithoutAPrice(t *testing.T) {
+	now := time.Now()
+	transfigure := []TransfigureResult{
+		{Time: now, TransfiguredName: "Unpriced Both Ways", Variant: "1", Confidence: ConfidenceNoBase},
+	}
+
+	results := RankCollective(transfigure, nil, nil, 0, 50, "")
+
+	if len(results) != 0 {
+		t.Fatalf("got %d results, want 0 — a gem with neither price is not actionable", len(results))
+	}
+}
+
+func TestRankCollective_BudgetFilterDropsNoBaseGem(t *testing.T) {
+	now := time.Now()
+	transfigure := []TransfigureResult{
+		{Time: now, TransfiguredName: "Known Cost", Variant: "20/20", ROI: 20, BasePrice: 10, Confidence: "OK"},
+		{Time: now, TransfiguredName: "Unknown Cost", Variant: "20/20", TransfiguredPrice: 500, Confidence: ConfidenceNoBase},
+	}
+
+	results := RankCollective(transfigure, nil, nil, 50, 50, "")
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1 — an unknown cost basis cannot be shown to fit a budget", len(results))
+	}
+	if results[0].TransfiguredName != "Known Cost" {
+		t.Errorf("got %s, want Known Cost", results[0].TransfiguredName)
+	}
+}
+
+func TestBuildCompareResults_NoBaseRowDoesNotBecomeTheCheapestBase(t *testing.T) {
+	// A NO_BASE row carries BasePrice 0 (unknown). Seeding the per-color cheapest-base
+	// map with it pins that color/variant at 0 forever — no later real price is
+	// "cheaper" — which silently drops the whole cheapest-color-base rule and prices
+	// every gem off its own base instead.
+	transfigure := []TransfigureResult{
+		{TransfiguredName: "Unpriced Base Trans", BaseName: "Unpriced Base", Variant: "20/20",
+			GemColor: "RED", TransfiguredPrice: 300, Confidence: ConfidenceNoBase},
+		{TransfiguredName: "Expensive Trans", BaseName: "Expensive Base", Variant: "20/20",
+			GemColor: "RED", BasePrice: 100, TransfiguredPrice: 500, ROI: 400, ROIPct: 400, Confidence: "OK"},
+		{TransfiguredName: "Cheap Trans", BaseName: "Cheap Base", Variant: "20/20",
+			GemColor: "RED", BasePrice: 5, TransfiguredPrice: 200, ROI: 195, ROIPct: 3900, Confidence: "OK"},
+	}
+
+	results := BuildCompareResults([]string{"Expensive Trans"}, transfigure, nil, nil, nil, "20/20")
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	// Lab cost basis is the cheapest RED 20/20 base (5c), not this gem's own base (100c).
+	if results[0].BasePrice != 5 {
+		t.Errorf("BasePrice = %f, want 5 (cheapest real color base, unaffected by the NO_BASE row)",
+			results[0].BasePrice)
+	}
+	if results[0].ROI != 495 {
+		t.Errorf("ROI = %f, want 495 — a poisoned 0 base falls back to the 100c own-base ROI of 400",
+			results[0].ROI)
+	}
+}

--- a/internal/lab/collective_test.go
+++ b/internal/lab/collective_test.go
@@ -245,8 +245,10 @@ func TestBuildCompareResults_GemNotFoundInTransfigure(t *testing.T) {
 	if len(results) != 1 {
 		t.Fatalf("got %d results, want 1", len(results))
 	}
-	if results[0].Confidence != "LOW" {
-		t.Errorf("confidence = %s, want LOW", results[0].Confidence)
+	// NO_DATA, not LOW: LOW means "priced, but thin market". This gem has no price
+	// at all, and the UI must render its zeros as unknown rather than as 0c.
+	if results[0].Confidence != ConfidenceNoData {
+		t.Errorf("confidence = %s, want %s", results[0].Confidence, ConfidenceNoData)
 	}
 	if results[0].ROI != 0 {
 		t.Errorf("ROI = %f, want 0", results[0].ROI)

--- a/internal/lab/font.go
+++ b/internal/lab/font.go
@@ -242,17 +242,6 @@ func AnalyzeFont(snapTime time.Time, features []GemFeature) FontAnalysis {
 			inputCost := InputCostForVariant(variant)
 			entries := byColor[color][variant]
 
-			// How much of the pool the market actually prices at this variant. Pool
-			// stays variant-independent — every transfigured gem of the colour is a
-			// possible font outcome whether or not poe.ninja lists it at this
-			// level/quality — so a low priced count means "we can't value most
-			// outcomes here", not "the pool is small". The UI shows the two together
-			// so an EV of 0 is readable as missing prices rather than worthless gems.
-			pricedGems := len(entries)
-			if pricedGems > pool {
-				pricedGems = pool
-			}
-
 			// Count winners and thin-market gems for each mode.
 			var safeWinnerCount, premiumWinnerCount, jackpotWinnerCount int
 			var safeThinCount, premiumThinCount, jackpotThinCount int
@@ -328,6 +317,19 @@ func AnalyzeFont(snapTime time.Time, features []GemFeature) FontAnalysis {
 						jackpotThinCount++
 					}
 				}
+			}
+
+			// How much of the pool carries a usable price at this variant. Pool stays
+			// variant-independent — every transfigured gem of the colour is a possible
+			// font outcome whether or not poe.ninja lists it at this level/quality — so
+			// a low count means "we can't value most outcomes here", not "the pool is
+			// small". Counted off gemAdjustedPrice, the same map that feeds poolValues,
+			// so it names exactly the gems contributing value: a low-confidence gem is
+			// listed but enters the EV as 0, and counting it as priced would understate
+			// the zero-valued set the UI is explaining.
+			pricedGems := len(gemAdjustedPrice)
+			if pricedGems > pool {
+				pricedGems = pool
 			}
 
 			// Build the full pool value array — one value per pool gem name.

--- a/internal/lab/font.go
+++ b/internal/lab/font.go
@@ -12,6 +12,7 @@ type FontResult struct {
 	Color             string  // RED, GREEN, BLUE
 	Variant           string  // "1", "1/20", "20", "20/20"
 	Pool              int     // total unique transfigured gem names of that color
+	PricedGems        int     // how many of Pool carry a price at THIS variant (Pool counts every possible outcome, priced or not)
 	Winners           int     // count of tier-qualifying gems (LOW+ for safe, MID-HIGH+ for premium, TOP for jackpot)
 	PWin              float64 // probability of seeing at least 1 winner in 3 picks
 	AvgWin            float64 // average risk-adjusted value when you hit (secondary info)
@@ -19,12 +20,12 @@ type FontResult struct {
 	EV                float64 // expected income per font (risk-adjusted, internal use)
 	EVRaw             float64 // expected income per font using raw listed prices (primary display)
 	InputCost         float64
-	Profit            float64 // EVRaw - InputCost
-	FontsToHit        float64          // expected fonts until hitting a winner (1/pWin), 0 if pWin=0
-	JackpotGems       []JackpotGemInfo // TOP gem names+prices (only for jackpot mode, 1-3 gems)
-	Mode              string  // "safe", "premium", or "jackpot"
-	ThinPoolGems      int     // count of winners with < 5 listings
-	LiquidityRisk     string  // "LOW", "MEDIUM", "HIGH"
+	Profit            float64                // EVRaw - InputCost
+	FontsToHit        float64                // expected fonts until hitting a winner (1/pWin), 0 if pWin=0
+	JackpotGems       []JackpotGemInfo       // TOP gem names+prices (only for jackpot mode, 1-3 gems)
+	Mode              string                 // "safe", "premium", or "jackpot"
+	ThinPoolGems      int                    // count of winners with < 5 listings
+	LiquidityRisk     string                 // "LOW", "MEDIUM", "HIGH"
 	PoolBreakdown     []TierPoolInfo         `json:"poolBreakdown,omitempty"`     // per-tier gem counts and price ranges
 	LowConfidenceGems []LowConfidenceGemInfo `json:"lowConfidenceGems,omitempty"` // gems excluded from EV due to thin market
 }
@@ -241,6 +242,17 @@ func AnalyzeFont(snapTime time.Time, features []GemFeature) FontAnalysis {
 			inputCost := InputCostForVariant(variant)
 			entries := byColor[color][variant]
 
+			// How much of the pool the market actually prices at this variant. Pool
+			// stays variant-independent — every transfigured gem of the colour is a
+			// possible font outcome whether or not poe.ninja lists it at this
+			// level/quality — so a low priced count means "we can't value most
+			// outcomes here", not "the pool is small". The UI shows the two together
+			// so an EV of 0 is readable as missing prices rather than worthless gems.
+			pricedGems := len(entries)
+			if pricedGems > pool {
+				pricedGems = pool
+			}
+
 			// Count winners and thin-market gems for each mode.
 			var safeWinnerCount, premiumWinnerCount, jackpotWinnerCount int
 			var safeThinCount, premiumThinCount, jackpotThinCount int
@@ -400,6 +412,7 @@ func AnalyzeFont(snapTime time.Time, features []GemFeature) FontAnalysis {
 				Color:             color,
 				Variant:           variant,
 				Pool:              pool,
+				PricedGems:        pricedGems,
 				Winners:           safeWinnerCount,
 				PWin:              safePWin,
 				AvgWin:            safeAvgWin,
@@ -432,6 +445,7 @@ func AnalyzeFont(snapTime time.Time, features []GemFeature) FontAnalysis {
 				Color:         color,
 				Variant:       variant,
 				Pool:          pool,
+				PricedGems:    pricedGems,
 				Winners:       premiumWinnerCount,
 				PWin:          premiumPWin,
 				AvgWin:        premiumAvgWin,
@@ -462,6 +476,7 @@ func AnalyzeFont(snapTime time.Time, features []GemFeature) FontAnalysis {
 				Color:         color,
 				Variant:       variant,
 				Pool:          pool,
+				PricedGems:    pricedGems,
 				Winners:       jackpotWinnerCount,
 				PWin:          jackpotPWin,
 				AvgWin:        jackpotAvgWin,

--- a/internal/lab/font_test.go
+++ b/internal/lab/font_test.go
@@ -573,3 +573,43 @@ func TestAnalyzeFont_LowConfidenceExcludedFromEV(t *testing.T) {
 		t.Errorf("LowConfidenceGems = %d, want 1", len(found.LowConfidenceGems))
 	}
 }
+
+func TestAnalyzeFont_PricedGemsCountsOnlyThisVariantWhilePoolStaysWhole(t *testing.T) {
+	now := time.Now()
+	// League-start shape: both RED gems trade at 1/0, only one of them at 20/20.
+	// The Font can still roll either gem at 20/20 — that outcome just has no price.
+	features := []GemFeature{
+		makeFeature("Cleave of Rage", "1", 30, 12, "TOP", 0.9, 0.95),
+		makeFeature("Slam of Force", "1", 8, 9, "LOW", 0.8, 0.9),
+		makeFeature("Cleave of Rage", "20/20", 250, 15, "TOP", 0.9, 0.95),
+	}
+
+	analysis := AnalyzeFont(now, features)
+
+	byVariant := make(map[string]FontResult, len(analysis.Safe))
+	for _, r := range analysis.Safe {
+		if r.Color == "RED" {
+			byVariant[r.Variant] = r
+		}
+	}
+
+	sparse, ok := byVariant["20/20"]
+	if !ok {
+		t.Fatalf("no RED 20/20 result; got variants %v", byVariant)
+	}
+	if sparse.Pool != 2 {
+		t.Errorf("20/20 Pool = %d, want 2 — both gems remain possible outcomes", sparse.Pool)
+	}
+	if sparse.PricedGems != 1 {
+		t.Errorf("20/20 PricedGems = %d, want 1 — only one gem is listed at this variant", sparse.PricedGems)
+	}
+
+	full, ok := byVariant["1"]
+	if !ok {
+		t.Fatalf("no RED 1 result; got variants %v", byVariant)
+	}
+	if full.PricedGems != full.Pool {
+		t.Errorf("1: PricedGems = %d, Pool = %d — want equal so the UI keeps the plain count",
+			full.PricedGems, full.Pool)
+	}
+}

--- a/internal/lab/font_test.go
+++ b/internal/lab/font_test.go
@@ -613,3 +613,35 @@ func TestAnalyzeFont_PricedGemsCountsOnlyThisVariantWhilePoolStaysWhole(t *testi
 			full.PricedGems, full.Pool)
 	}
 }
+
+func TestAnalyzeFont_PricedGemsExcludesLowConfidenceGems(t *testing.T) {
+	now := time.Now()
+	// Both gems are listed at 20/20, but the thin-market one is excluded from the
+	// EV and contributes 0. Counting it as "priced" would tell the UI the pool is
+	// fully valued while the EV is quietly depressed by a zero-valued outcome.
+	lowConf := makeFeature("Slam of Force", "20/20", 120, 1, "HIGH", 0.8, 0.9)
+	lowConf.LowConfidence = true
+	features := []GemFeature{
+		makeFeature("Cleave of Rage", "20/20", 250, 15, "TOP", 0.9, 0.95),
+		lowConf,
+	}
+
+	analysis := AnalyzeFont(now, features)
+
+	var got *FontResult
+	for i := range analysis.Safe {
+		if analysis.Safe[i].Color == "RED" && analysis.Safe[i].Variant == "20/20" {
+			got = &analysis.Safe[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("no RED 20/20 safe result")
+	}
+	if got.Pool != 2 {
+		t.Fatalf("Pool = %d, want 2 (both gems are possible outcomes)", got.Pool)
+	}
+	if got.PricedGems != 1 {
+		t.Errorf("PricedGems = %d, want 1 — the low-confidence gem enters the EV as 0, so it is not a valued outcome",
+			got.PricedGems)
+	}
+}

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
@@ -155,11 +156,11 @@ func (r *Repository) SaveFontResults(ctx context.Context, scope league.Scope, re
 	for _, r := range results {
 		batch.Queue(
 			`INSERT INTO font_snapshots
-			 (league, time, color, variant, pool, winners, p_win, avg_win, ev, input_cost, profit,
+			 (league, time, color, variant, pool, priced_gems, winners, p_win, avg_win, ev, input_cost, profit,
 			  mode, thin_pool_gems, liquidity_risk)
-			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 			 ON CONFLICT DO NOTHING`,
-			scope.ID(), r.Time, r.Color, r.Variant, r.Pool, r.Winners,
+			scope.ID(), r.Time, r.Color, r.Variant, r.Pool, r.PricedGems, r.Winners,
 			r.PWin, r.AvgWin, r.EV, r.InputCost, r.Profit,
 			r.Mode, r.ThinPoolGems, r.LiquidityRisk,
 		)
@@ -242,7 +243,7 @@ func (r *Repository) LatestFontResults(ctx context.Context, scope league.Scope, 
 		return nil, fmt.Errorf("lab repo: latest font results: %w", err)
 	}
 	query := `
-		SELECT time, color, variant, pool, winners, p_win, avg_win, ev, input_cost, profit,
+		SELECT time, color, variant, pool, COALESCE(priced_gems, pool), winners, p_win, avg_win, ev, input_cost, profit,
 		       COALESCE(mode, 'safe'), COALESCE(thin_pool_gems, 0), COALESCE(liquidity_risk, 'LOW')
 		FROM font_snapshots
 		WHERE league = $1 AND time = (SELECT MAX(time) FROM font_snapshots WHERE league = $1)`
@@ -272,7 +273,7 @@ func (r *Repository) LatestFontResults(ctx context.Context, scope league.Scope, 
 	var results []FontResult
 	for rows.Next() {
 		var fr FontResult
-		if err := rows.Scan(&fr.Time, &fr.Color, &fr.Variant, &fr.Pool, &fr.Winners,
+		if err := rows.Scan(&fr.Time, &fr.Color, &fr.Variant, &fr.Pool, &fr.PricedGems, &fr.Winners,
 			&fr.PWin, &fr.AvgWin, &fr.EV, &fr.InputCost, &fr.Profit,
 			&fr.Mode, &fr.ThinPoolGems, &fr.LiquidityRisk); err != nil {
 			return nil, fmt.Errorf("lab repo: scan font result: %w", err)
@@ -1467,23 +1468,36 @@ func (r *Repository) SparklineDataCorrupted(ctx context.Context, scope league.Sc
 	return result, nil
 }
 
-// GemNameDictionary returns known gem names from gem_colors, the static game-data
-// table — no league, no prices, no market activity required.
+// GemNameDictionary returns known gem names for OCR matching: every name in
+// gem_colors, plus every transfigured name the scoped league has ever had a
+// snapshot for.
 //
-// It exists for OCR: recognising the gem under the cursor must not depend on
-// whether poe.ninja happens to price it. The market-derived sources (transfigure
-// results, gem_snapshots) collapse to a handful of names at league start, which
-// silently blinds the desktop matcher exactly when players are running the most
-// labs.
+// It exists because recognising the gem under the cursor must not depend on
+// whether the market prices it. The previous source (transfigure results) needed
+// BOTH the gem and its base priced, collapsing to a handful of names at league
+// start — silently blinding the desktop matcher exactly when players run the
+// most labs.
 //
-// transfigured selects between the two halves of the table:
+// gem_colors carries no league and no prices, but it is not pure game data: the
+// collector's gemcolor.Resolver upserts names into it as it sees them (ADR-006),
+// so a brand-new transfigured gem lands there only once it has been priced at
+// least once. Unioning the league's snapshot names keeps this a strict superset
+// of the market-scoped endpoint it replaced, so the swap can never lose a name
+// the old path would have returned.
+//
+// transfigured selects between the two halves:
 //   - true  — names whose base gem is itself a known gem ("Rain of Arrows of
 //     Saturation" has base "Rain of Arrows"). This is what distinguishes a
 //     transfigured gem from a base gem that merely contains " of "
-//     ("Herald of Ash" has no base gem "Herald").
+//     ("Herald of Ash" has no base gem "Herald"). Names flagged transfigured in
+//     the league's snapshots are trusted directly — the market already told us.
 //   - false — everything else, minus support gems, which never appear in the
 //     Font or Dedication pools.
-func (r *Repository) GemNameDictionary(ctx context.Context, transfigured bool) ([]string, error) {
+func (r *Repository) GemNameDictionary(ctx context.Context, scope league.Scope, transfigured bool) ([]string, error) {
+	if err := scope.Validate(); err != nil {
+		return nil, fmt.Errorf("lab repo: gem name dictionary: %w", err)
+	}
+
 	rows, err := r.pool.Query(ctx, "SELECT name FROM gem_colors ORDER BY name")
 	if err != nil {
 		return nil, fmt.Errorf("lab repo: query gem name dictionary: %w", err)
@@ -1501,8 +1515,48 @@ func (r *Repository) GemNameDictionary(ctx context.Context, transfigured bool) (
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("lab repo: gem dictionary rows iteration: %w", err)
 	}
+	rows.Close()
 
-	return FilterGemDictionary(all, transfigured), nil
+	// Names the market has shown this league, with is_transfigured straight from
+	// the source rather than inferred from the base-name rule.
+	seen, err := r.pool.Query(ctx,
+		`SELECT DISTINCT name FROM gem_snapshots WHERE league = $1 AND is_transfigured = $2`,
+		scope.ID(), transfigured)
+	if err != nil {
+		return nil, fmt.Errorf("lab repo: query gem dictionary snapshots: %w", err)
+	}
+	defer seen.Close()
+
+	var fromSnapshots []string
+	for seen.Next() {
+		var name string
+		if err := seen.Scan(&name); err != nil {
+			return nil, fmt.Errorf("lab repo: scan gem dictionary snapshot name: %w", err)
+		}
+		fromSnapshots = append(fromSnapshots, name)
+	}
+	if err := seen.Err(); err != nil {
+		return nil, fmt.Errorf("lab repo: gem dictionary snapshot rows iteration: %w", err)
+	}
+
+	return MergeGemDictionary(FilterGemDictionary(all, transfigured), fromSnapshots), nil
+}
+
+// MergeGemDictionary unions two name lists into one sorted, de-duplicated list.
+func MergeGemDictionary(a, b []string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	merged := make([]string, 0, len(a)+len(b))
+	for _, list := range [][]string{a, b} {
+		for _, n := range list {
+			if _, dup := seen[n]; dup {
+				continue
+			}
+			seen[n] = struct{}{}
+			merged = append(merged, n)
+		}
+	}
+	sort.Strings(merged)
+	return merged
 }
 
 // FilterGemDictionary splits a full gem-name list into transfigured and

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -607,11 +607,19 @@ func (r *Repository) GemNamesAutocomplete(ctx context.Context, scope league.Scop
 	}
 	args = append(args, limit)
 
+	// A whitespace-only query has no words — callers use it to mean "every name"
+	// (the cache path treats it that way). Emitting an empty condition list here
+	// would produce "AND ORDER BY", a syntax error that 500s the endpoint.
+	filter := "TRUE"
+	if len(conditions) > 0 {
+		filter = strings.Join(conditions, " AND ")
+	}
+
 	sql := fmt.Sprintf(`
 		SELECT DISTINCT name FROM gem_snapshots
 		WHERE league = $1 AND is_transfigured = true AND %s
 		ORDER BY name LIMIT $%d`,
-		strings.Join(conditions, " AND "), len(args))
+		filter, len(args))
 
 	rows, err := r.pool.Query(ctx, sql, args...)
 	if err != nil {
@@ -1457,4 +1465,67 @@ func (r *Repository) SparklineDataCorrupted(ctx context.Context, scope league.Sc
 	}
 
 	return result, nil
+}
+
+// GemNameDictionary returns known gem names from gem_colors, the static game-data
+// table — no league, no prices, no market activity required.
+//
+// It exists for OCR: recognising the gem under the cursor must not depend on
+// whether poe.ninja happens to price it. The market-derived sources (transfigure
+// results, gem_snapshots) collapse to a handful of names at league start, which
+// silently blinds the desktop matcher exactly when players are running the most
+// labs.
+//
+// transfigured selects between the two halves of the table:
+//   - true  — names whose base gem is itself a known gem ("Rain of Arrows of
+//     Saturation" has base "Rain of Arrows"). This is what distinguishes a
+//     transfigured gem from a base gem that merely contains " of "
+//     ("Herald of Ash" has no base gem "Herald").
+//   - false — everything else, minus support gems, which never appear in the
+//     Font or Dedication pools.
+func (r *Repository) GemNameDictionary(ctx context.Context, transfigured bool) ([]string, error) {
+	rows, err := r.pool.Query(ctx, "SELECT name FROM gem_colors ORDER BY name")
+	if err != nil {
+		return nil, fmt.Errorf("lab repo: query gem name dictionary: %w", err)
+	}
+	defer rows.Close()
+
+	var all []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("lab repo: scan gem dictionary name: %w", err)
+		}
+		all = append(all, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("lab repo: gem dictionary rows iteration: %w", err)
+	}
+
+	return FilterGemDictionary(all, transfigured), nil
+}
+
+// FilterGemDictionary splits a full gem-name list into transfigured and
+// non-transfigured halves. Separated from the query so the rule is testable
+// without a database.
+func FilterGemDictionary(all []string, transfigured bool) []string {
+	known := make(map[string]struct{}, len(all))
+	for _, n := range all {
+		known[n] = struct{}{}
+	}
+
+	names := make([]string, 0, len(all))
+	for _, n := range all {
+		base := extractBaseName(n)
+		_, isTransfigured := known[base]
+		isTransfigured = isTransfigured && base != n
+		if isTransfigured != transfigured {
+			continue
+		}
+		if !transfigured && strings.HasSuffix(n, " Support") {
+			continue
+		}
+		names = append(names, n)
+	}
+	return names
 }

--- a/internal/lab/repository_integration_test.go
+++ b/internal/lab/repository_integration_test.go
@@ -290,6 +290,9 @@ func TestGemNameDictionary_ignoresLeagueAndMarketData(t *testing.T) {
 	ctx := context.Background()
 	repo := NewRepository(pool)
 
+	leagueID := "POE-128-dictionary"
+	registerLeague(t, pool, leagueID)
+
 	// gem_colors is static game data: no league column, no prices. Seed a
 	// transfigured/base pair that appears in NO snapshot, so a dictionary built
 	// from market tables could not return it.
@@ -307,7 +310,7 @@ func TestGemNameDictionary_ignoresLeagueAndMarketData(t *testing.T) {
 		t.Fatalf("seed gem_colors: %v", err)
 	}
 
-	names, err := repo.GemNameDictionary(ctx, true)
+	names, err := repo.GemNameDictionary(ctx, league.Historical(leagueID), true)
 	if err != nil {
 		t.Fatalf("GemNameDictionary: %v", err)
 	}
@@ -327,6 +330,46 @@ func TestGemNameDictionary_ignoresLeagueAndMarketData(t *testing.T) {
 	if sawBase {
 		t.Errorf("%q returned as transfigured — it is the base gem", base)
 	}
+}
+
+func TestGemNameDictionary_includesLeagueNamesMissingFromGemColors(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueID := "POE-128-dict-superset"
+	registerLeague(t, pool, leagueID)
+
+	tm := futureTime(7)
+	cleanupAtTime(t, pool, tm, "gem_snapshots")
+
+	// gem_colors is collector-fed (gemcolor.Resolver upserts what it prices), so a
+	// gem can be listed on the market before it lands there. The dictionary must
+	// stay a superset of the market-scoped endpoint it replaced, or swapping the
+	// desktop over to it loses names OCR could previously match.
+	const onlyInSnapshots = "POE128 Snapshot Only of Testing"
+	seedGemSnapshot(t, pool, leagueID, tm, onlyInSnapshots, "20/20", true, false, 100, 5, "BLUE")
+
+	var inColors bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM gem_colors WHERE name = $1)`, onlyInSnapshots).Scan(&inColors); err != nil {
+		t.Fatalf("check gem_colors: %v", err)
+	}
+	if inColors {
+		t.Fatalf("%q unexpectedly present in gem_colors — the test cannot prove the union", onlyInSnapshots)
+	}
+
+	names, err := repo.GemNameDictionary(ctx, league.Historical(leagueID), true)
+	if err != nil {
+		t.Fatalf("GemNameDictionary: %v", err)
+	}
+
+	for _, n := range names {
+		if n == onlyInSnapshots {
+			return
+		}
+	}
+	t.Errorf("%q missing — a gem the market lists but gem_colors has not recorded is unmatchable by OCR", onlyInSnapshots)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/lab/repository_integration_test.go
+++ b/internal/lab/repository_integration_test.go
@@ -259,6 +259,76 @@ func TestGemNamesAutocomplete_returnsOnlyScopedLeague(t *testing.T) {
 	}
 }
 
+func TestGemNamesAutocomplete_whitespaceQueryReturnsEveryName(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueID := "POE-128-blank-query"
+	registerLeague(t, pool, leagueID)
+
+	tm := futureTime(6)
+	cleanupAtTime(t, pool, tm, "gem_snapshots")
+
+	// The desktop OCR path sends q=" " to mean "give me the whole dictionary".
+	// Building the SQL with zero ILIKE conditions emits "AND ORDER BY" — a syntax
+	// error that surfaces as a 500 whenever the in-memory cache is cold.
+	seedGemSnapshot(t, pool, leagueID, tm, "POE128 Blank Alpha", "20/20", true, false, 111, 10, "BLUE")
+	seedGemSnapshot(t, pool, leagueID, tm, "POE128 Blank Beta", "20/20", true, false, 222, 20, "BLUE")
+
+	names, err := repo.GemNamesAutocomplete(ctx, league.Historical(leagueID), " ", 100)
+	if err != nil {
+		t.Fatalf("GemNamesAutocomplete with a whitespace query: %v", err)
+	}
+	if len(names) != 2 {
+		t.Fatalf("name count = %d, want 2 (both seeded names); %v", len(names), names)
+	}
+}
+
+func TestGemNameDictionary_ignoresLeagueAndMarketData(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	// gem_colors is static game data: no league column, no prices. Seed a
+	// transfigured/base pair that appears in NO snapshot, so a dictionary built
+	// from market tables could not return it.
+	const base = "POE128 Dictionary Base"
+	const transfigured = "POE128 Dictionary Base of Testing"
+	t.Cleanup(func() {
+		if _, err := pool.Exec(context.Background(),
+			`DELETE FROM gem_colors WHERE name = ANY($1)`, []string{base, transfigured}); err != nil {
+			t.Logf("cleanup gem_colors: %v", err)
+		}
+	})
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO gem_colors (name, color) VALUES ($1, 'BLUE'), ($2, 'BLUE')
+		 ON CONFLICT (name) DO NOTHING`, base, transfigured); err != nil {
+		t.Fatalf("seed gem_colors: %v", err)
+	}
+
+	names, err := repo.GemNameDictionary(ctx, true)
+	if err != nil {
+		t.Fatalf("GemNameDictionary: %v", err)
+	}
+
+	var sawTransfigured, sawBase bool
+	for _, n := range names {
+		switch n {
+		case transfigured:
+			sawTransfigured = true
+		case base:
+			sawBase = true
+		}
+	}
+	if !sawTransfigured {
+		t.Errorf("%q missing — an unpriced gem must still be recognisable by OCR", transfigured)
+	}
+	if sawBase {
+		t.Errorf("%q returned as transfigured — it is the base gem", base)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Read isolation — result tables (seeded via the scoped Save* writers)
 // ---------------------------------------------------------------------------

--- a/internal/lab/transfigure.go
+++ b/internal/lab/transfigure.go
@@ -31,6 +31,10 @@ type TransfigureResult struct {
 // before their bases).
 const ConfidenceNoBase = "NO_BASE"
 
+// ConfidenceNoData marks a comparison entry for a gem with no transfigure data at
+// all — neither side of the pair is priced. Its zeros are "unknown", not "worthless".
+const ConfidenceNoData = "NO_DATA"
+
 // GemPrice is the minimal price data needed for analysis. Shared across analyzers.
 type GemPrice struct {
 	Name           string

--- a/internal/lab/transfigure.go
+++ b/internal/lab/transfigure.go
@@ -20,8 +20,16 @@ type TransfigureResult struct {
 	BaseListings         int
 	TransfiguredListings int
 	GemColor             string
-	Confidence           string // "OK" or "LOW"
+	Confidence           string // "OK", "LOW", or ConfidenceNoBase
 }
+
+// ConfidenceNoBase marks a transfigured gem the market prices but whose base gem
+// is absent from the snapshot, so ROI cannot be computed. Such rows carry
+// BasePrice/ROI/ROIPct of 0 — that is "unknown", not "breaks even". They exist so
+// a gem the Font EV analyzer can already price does not vanish from the rankings
+// (common right after a league start, when poe.ninja lists transfigured gems
+// before their bases).
+const ConfidenceNoBase = "NO_BASE"
 
 // GemPrice is the minimal price data needed for analysis. Shared across analyzers.
 type GemPrice struct {
@@ -82,15 +90,28 @@ func AnalyzeTransfigure(snapTime time.Time, gems []GemPrice) []TransfigureResult
 
 	for transName, transVariants := range transGems {
 		baseName := extractBaseName(transName)
-		baseVariants, ok := baseGems[baseName]
-		if !ok {
-			continue
-		}
+		baseVariants := baseGems[baseName] // nil when the base gem is unpriced
 
 		for _, variant := range variants {
 			trans, hasTransVar := transVariants[variant]
+			if !hasTransVar {
+				continue
+			}
+
 			base, hasBaseVar := baseVariants[variant]
-			if !hasTransVar || !hasBaseVar {
+			if !hasBaseVar {
+				// No base price: emit the gem with ROI unknown rather than
+				// dropping it. See ConfidenceNoBase.
+				results = append(results, TransfigureResult{
+					Time:                 snapTime,
+					BaseName:             baseName,
+					TransfiguredName:     transName,
+					Variant:              variant,
+					TransfiguredPrice:    trans.chaos,
+					TransfiguredListings: trans.listings,
+					GemColor:             trans.color,
+					Confidence:           ConfidenceNoBase,
+				})
 				continue
 			}
 

--- a/internal/lab/transfigure_test.go
+++ b/internal/lab/transfigure_test.go
@@ -315,3 +315,46 @@ func TestAnalyzeTransfigure_MissingBaseVariantMarkedNoBaseWhileOtherVariantCompu
 			got.Confidence, got.TransfiguredPrice, ConfidenceNoBase)
 	}
 }
+
+func TestFilterGemDictionary_TransfiguredRequiresAKnownBaseGem(t *testing.T) {
+	// "Herald of Ash" contains " of " but has no base gem "Herald" — it is a base
+	// gem itself. "Rain of Arrows of Saturation" has base "Rain of Arrows", which
+	// is in the list, so it is transfigured.
+	all := []string{
+		"Herald of Ash",
+		"Rain of Arrows",
+		"Rain of Arrows of Saturation",
+		"Spark",
+		"Spark of Nova",
+	}
+
+	got := FilterGemDictionary(all, true)
+
+	want := map[string]bool{"Rain of Arrows of Saturation": true, "Spark of Nova": true}
+	if len(got) != len(want) {
+		t.Fatalf("transfigured = %v, want exactly %v", got, want)
+	}
+	for _, n := range got {
+		if !want[n] {
+			t.Errorf("%q classified transfigured — it has no known base gem", n)
+		}
+	}
+}
+
+func TestFilterGemDictionary_SkillsExcludeSupportGems(t *testing.T) {
+	all := []string{"Bloodlust Support", "Herald of Ash", "Spark", "Spark of Nova"}
+
+	got := FilterGemDictionary(all, false)
+
+	for _, n := range got {
+		if n == "Bloodlust Support" {
+			t.Fatalf("support gem in the skill dictionary: %v — supports never drop from a Font", got)
+		}
+		if n == "Spark of Nova" {
+			t.Fatalf("transfigured gem in the skill dictionary: %v", got)
+		}
+	}
+	if len(got) != 2 {
+		t.Errorf("skills = %v, want Herald of Ash and Spark", got)
+	}
+}

--- a/internal/lab/transfigure_test.go
+++ b/internal/lab/transfigure_test.go
@@ -257,3 +257,61 @@ func TestAnalyzeTransfigure_MultipleTransfiguredPerBase(t *testing.T) {
 		t.Fatalf("got %d results, want 2 (two transfigured variants of one base)", len(results))
 	}
 }
+
+func TestAnalyzeTransfigure_UnpricedBaseKeepsGemWithUnknownROI(t *testing.T) {
+	now := time.Now()
+	// League-start shape: poe.ninja lists the transfigured gem before its base.
+	gems := []GemPrice{
+		{Name: "Tornado of Elemental Turbulence", Variant: "1", Chaos: 20, Listings: 1, IsTransfigured: true, GemColor: "GREEN"},
+	}
+
+	results := AnalyzeTransfigure(now, gems)
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1 (gem must survive a missing base)", len(results))
+	}
+	r := results[0]
+	if r.Confidence != ConfidenceNoBase {
+		t.Errorf("Confidence = %q, want %q", r.Confidence, ConfidenceNoBase)
+	}
+	if r.TransfiguredPrice != 20 {
+		t.Errorf("TransfiguredPrice = %f, want 20 (the known half of the pair)", r.TransfiguredPrice)
+	}
+	if r.BasePrice != 0 || r.ROI != 0 || r.ROIPct != 0 {
+		t.Errorf("BasePrice/ROI/ROIPct = %f/%f/%f, want 0/0/0 — unknown, not a computed profit",
+			r.BasePrice, r.ROI, r.ROIPct)
+	}
+	if r.BaseName != "Tornado" {
+		t.Errorf("BaseName = %q, want %q (still names the base we could not price)", r.BaseName, "Tornado")
+	}
+	if r.GemColor != "GREEN" {
+		t.Errorf("GemColor = %q, want GREEN", r.GemColor)
+	}
+}
+
+func TestAnalyzeTransfigure_MissingBaseVariantMarkedNoBaseWhileOtherVariantComputes(t *testing.T) {
+	now := time.Now()
+	// Base priced only at 20/20; the transfigured gem trades at both 20/20 and 1.
+	gems := []GemPrice{
+		{Name: "Spark", Variant: "20/20", Chaos: 50, Listings: 100, IsTransfigured: false},
+		{Name: "Spark of Nova", Variant: "20/20", Chaos: 200, Listings: 30, IsTransfigured: true},
+		{Name: "Spark of Nova", Variant: "1", Chaos: 12, Listings: 4, IsTransfigured: true},
+	}
+
+	results := AnalyzeTransfigure(now, gems)
+
+	byVariant := make(map[string]TransfigureResult, len(results))
+	for _, r := range results {
+		byVariant[r.Variant] = r
+	}
+	if len(byVariant) != 2 {
+		t.Fatalf("got variants %v, want both 1 and 20/20", byVariant)
+	}
+	if got := byVariant["20/20"]; got.ROI != 150 || got.Confidence == ConfidenceNoBase {
+		t.Errorf("20/20: ROI = %f, Confidence = %q — want ROI 150 with a real confidence", got.ROI, got.Confidence)
+	}
+	if got := byVariant["1"]; got.Confidence != ConfidenceNoBase || got.TransfiguredPrice != 12 {
+		t.Errorf("1: Confidence = %q, TransfiguredPrice = %f — want %q at 12c",
+			got.Confidence, got.TransfiguredPrice, ConfidenceNoBase)
+	}
+}

--- a/internal/server/handlers/analysis.go
+++ b/internal/server/handlers/analysis.go
@@ -217,23 +217,24 @@ func FontAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Scope) ht
 		}
 
 		type row struct {
-			Time          string  `json:"time"`
-			Color         string  `json:"color"`
-			Variant       string  `json:"variant"`
-			Pool          int     `json:"pool"`
-			Winners       int     `json:"winners"`
-			PWin          float64 `json:"pWin"`
-			AvgWin        float64 `json:"avgWin"`
-			AvgWinRaw     float64 `json:"avgWinRaw"`
-			EV            float64 `json:"ev"`
-			EVRaw         float64 `json:"evRaw"`
-			InputCost     float64 `json:"inputCost"`
-			Profit        float64 `json:"profit"`
+			Time          string               `json:"time"`
+			Color         string               `json:"color"`
+			Variant       string               `json:"variant"`
+			Pool          int                  `json:"pool"`
+			PricedGems    int                  `json:"pricedGems"`
+			Winners       int                  `json:"winners"`
+			PWin          float64              `json:"pWin"`
+			AvgWin        float64              `json:"avgWin"`
+			AvgWinRaw     float64              `json:"avgWinRaw"`
+			EV            float64              `json:"ev"`
+			EVRaw         float64              `json:"evRaw"`
+			InputCost     float64              `json:"inputCost"`
+			Profit        float64              `json:"profit"`
 			FontsToHit    float64              `json:"fontsToHit"`
 			JackpotGems   []lab.JackpotGemInfo `json:"jackpotGems,omitempty"`
-			ThinPoolGems  int                   `json:"thinPoolGems"`
-			LiquidityRisk string                `json:"liquidityRisk"`
-			PoolBreakdown []lab.TierPoolInfo    `json:"poolBreakdown,omitempty"`
+			ThinPoolGems  int                  `json:"thinPoolGems"`
+			LiquidityRisk string               `json:"liquidityRisk"`
+			PoolBreakdown []lab.TierPoolInfo   `json:"poolBreakdown,omitempty"`
 		}
 
 		toRows := func(results []lab.FontResult) []row {
@@ -244,6 +245,7 @@ func FontAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Scope) ht
 					Color:         r.Color,
 					Variant:       r.Variant,
 					Pool:          r.Pool,
+					PricedGems:    r.PricedGems,
 					Winners:       r.Winners,
 					PWin:          r.PWin,
 					AvgWin:        r.AvgWin,
@@ -305,12 +307,12 @@ func FontAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Scope) ht
 
 		w.Header().Set("Content-Type", "application/json")
 		if err := json.NewEncoder(w).Encode(map[string]any{
-			"safe":              safeRows,
-			"premium":           premiumRows,
-			"jackpot":           jackpotRows,
-			"bestColorSafe":     bestColor(safeResults),
-			"bestColorPremium":  bestColor(premiumResults),
-			"bestColorJackpot":  bestColor(jackpotResults),
+			"safe":             safeRows,
+			"premium":          premiumRows,
+			"jackpot":          jackpotRows,
+			"bestColorSafe":    bestColor(safeResults),
+			"bestColorPremium": bestColor(premiumResults),
+			"bestColorJackpot": bestColor(jackpotResults),
 		}); err != nil {
 			slog.Error("font analysis: encode response", "error", err)
 		}
@@ -1014,8 +1016,8 @@ func GemFeaturesAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Sc
 			VelLongListing        float64 `json:"velLongListing"`
 			CV                    float64 `json:"cv"`
 			HistPosition          float64 `json:"histPosition"`
-			High7Days                float64 `json:"high7d"`
-			Low7Days                 float64 `json:"low7d"`
+			High7Days             float64 `json:"high7d"`
+			Low7Days              float64 `json:"low7d"`
 			FloodCount            int     `json:"floodCount"`
 			CrashCount            int     `json:"crashCount"`
 			ListingElasticity     float64 `json:"listingElasticity"`
@@ -1042,8 +1044,8 @@ func GemFeaturesAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Sc
 				VelLongListing:        f.VelLongListing,
 				CV:                    f.CV,
 				HistPosition:          f.HistPosition,
-				High7Days:                f.High7Days,
-				Low7Days:                 f.Low7Days,
+				High7Days:             f.High7Days,
+				Low7Days:              f.Low7Days,
 				FloodCount:            f.FloodCount,
 				CrashCount:            f.CrashCount,
 				ListingElasticity:     f.ListingElasticity,
@@ -1223,19 +1225,19 @@ func MarketOverview(cache *lab.Cache, pool *pgxpool.Pool, scope league.Scope) ht
 		w.Header().Set("Content-Type", "application/json")
 
 		type overview struct {
-			AvgTransPrice        float64        `json:"avgTransPrice"`
-			AvgTransPriceDelta   float64        `json:"avgTransPriceDelta"`
-			AvgBaseListings      float64        `json:"avgBaseListings"`
-			AvgBaseListingsDelta float64        `json:"avgBaseListingsDelta"`
-			ActiveGems           int            `json:"activeGems"`
-			MostVolatileColor    string         `json:"mostVolatileColor"`
-			MostVolatileCV       float64        `json:"mostVolatileCV"`
-			MostStableColor      string         `json:"mostStableColor"`
-			MostStableCV         float64        `json:"mostStableCV"`
-			TemporalMode         string         `json:"temporalMode"`
-			DivineRate           float64        `json:"divineRate"`
-			SellConfidenceSpread map[string]int `json:"sellConfidenceSpread"`
-			SignalDistribution   map[string]int `json:"signalDistribution"`
+			AvgTransPrice        float64          `json:"avgTransPrice"`
+			AvgTransPriceDelta   float64          `json:"avgTransPriceDelta"`
+			AvgBaseListings      float64          `json:"avgBaseListings"`
+			AvgBaseListingsDelta float64          `json:"avgBaseListingsDelta"`
+			ActiveGems           int              `json:"activeGems"`
+			MostVolatileColor    string           `json:"mostVolatileColor"`
+			MostVolatileCV       float64          `json:"mostVolatileCV"`
+			MostStableColor      string           `json:"mostStableColor"`
+			MostStableCV         float64          `json:"mostStableCV"`
+			TemporalMode         string           `json:"temporalMode"`
+			DivineRate           float64          `json:"divineRate"`
+			SellConfidenceSpread map[string]int   `json:"sellConfidenceSpread"`
+			SignalDistribution   map[string]int   `json:"signalDistribution"`
 			Offerings            []offeringTiming `json:"offerings,omitempty"`
 		}
 
@@ -1338,16 +1340,16 @@ func MarketOverview(cache *lab.Cache, pool *pgxpool.Pool, scope league.Scope) ht
 
 // offeringTiming holds price timing analysis for a lab offering (Gift, Dedication, etc.).
 type offeringTiming struct {
-	Name           string            `json:"name"`
-	FragmentID     string            `json:"fragmentId"`
-	CurrentPrice   float64           `json:"currentPrice"`
-	CheapHours     []giftTimingEntry `json:"cheapHours,omitempty"`
-	ExpensiveHours []giftTimingEntry `json:"expensiveHours,omitempty"`
-	CheapDays      []giftDayEntry    `json:"cheapDays,omitempty"`
-	ExpensiveDays  []giftDayEntry    `json:"expensiveDays,omitempty"`
-	HourlyMedians     []giftTimingEntry `json:"hourlyMedians,omitempty"`
-	TodayHourMedians  []giftTimingEntry `json:"todayHourMedians,omitempty"`
-	Sparkline         []offeringSparkPt `json:"sparkline,omitempty"`
+	Name             string            `json:"name"`
+	FragmentID       string            `json:"fragmentId"`
+	CurrentPrice     float64           `json:"currentPrice"`
+	CheapHours       []giftTimingEntry `json:"cheapHours,omitempty"`
+	ExpensiveHours   []giftTimingEntry `json:"expensiveHours,omitempty"`
+	CheapDays        []giftDayEntry    `json:"cheapDays,omitempty"`
+	ExpensiveDays    []giftDayEntry    `json:"expensiveDays,omitempty"`
+	HourlyMedians    []giftTimingEntry `json:"hourlyMedians,omitempty"`
+	TodayHourMedians []giftTimingEntry `json:"todayHourMedians,omitempty"`
+	Sparkline        []offeringSparkPt `json:"sparkline,omitempty"`
 }
 
 // offeringSparkPt is a single sparkline data point for offering price history.
@@ -1514,7 +1516,7 @@ func computeOfferingTiming(ctx context.Context, pool *pgxpool.Pool, scope league
 		}
 		if len(days) >= 4 {
 			type dayWithIdx struct {
-				idx int
+				idx   int
 				entry giftDayEntry
 			}
 			var cheapD, expD []dayWithIdx
@@ -1527,8 +1529,12 @@ func computeOfferingTiming(ctx context.Context, pool *pgxpool.Pool, scope league
 			// Sort by weekday order (Sun=0 .. Sat=6).
 			sort.Slice(cheapD, func(i, j int) bool { return cheapD[i].idx < cheapD[j].idx })
 			sort.Slice(expD, func(i, j int) bool { return expD[i].idx < expD[j].idx })
-			for _, d := range cheapD { ot.CheapDays = append(ot.CheapDays, d.entry) }
-			for _, d := range expD { ot.ExpensiveDays = append(ot.ExpensiveDays, d.entry) }
+			for _, d := range cheapD {
+				ot.CheapDays = append(ot.CheapDays, d.entry)
+			}
+			for _, d := range expD {
+				ot.ExpensiveDays = append(ot.ExpensiveDays, d.entry)
+			}
 		}
 	}
 

--- a/internal/server/handlers/collective.go
+++ b/internal/server/handlers/collective.go
@@ -787,3 +787,34 @@ func GemNamesAutocomplete(repo *lab.Repository, cache *lab.Cache, scope league.S
 
 	}
 }
+
+// GemDictionary returns known gem names from static game data (gem_colors),
+// independent of league, prices and market activity.
+//
+// The desktop OCR matcher consumes this: recognising the gem under the cursor
+// must not depend on whether the market prices it. GemNamesAutocomplete stays
+// market-scoped — it drives search over gems that actually have analysis data.
+//
+// Query params: transfigured (default true; "false" returns skill gems).
+func GemDictionary(repo *lab.Repository) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		transfigured := r.URL.Query().Get("transfigured") != "false" // default true
+
+		names, err := repo.GemNameDictionary(r.Context(), transfigured)
+		if err != nil {
+			slog.Error("gem dictionary: query failed", "error", err, "transfigured", transfigured)
+			http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)
+			return
+		}
+		if names == nil {
+			names = []string{}
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		// Static game data — safe to cache far longer than the market endpoints.
+		w.Header().Set("Cache-Control", "public, max-age=3600")
+		if err := json.NewEncoder(w).Encode(map[string]any{"names": names}); err != nil {
+			slog.Error("gem dictionary: encode response", "error", err)
+		}
+	}
+}

--- a/internal/server/handlers/collective.go
+++ b/internal/server/handlers/collective.go
@@ -796,11 +796,11 @@ func GemNamesAutocomplete(repo *lab.Repository, cache *lab.Cache, scope league.S
 // market-scoped — it drives search over gems that actually have analysis data.
 //
 // Query params: transfigured (default true; "false" returns skill gems).
-func GemDictionary(repo *lab.Repository) http.HandlerFunc {
+func GemDictionary(repo *lab.Repository, scope league.Scope) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		transfigured := r.URL.Query().Get("transfigured") != "false" // default true
 
-		names, err := repo.GemNameDictionary(r.Context(), transfigured)
+		names, err := repo.GemNameDictionary(r.Context(), scope, transfigured)
 		if err != nil {
 			slog.Error("gem dictionary: query failed", "error", err, "transfigured", transfigured)
 			http.Error(w, `{"error":"query failed"}`, http.StatusInternalServerError)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -129,7 +129,7 @@ func NewRouter(pinger handlers.Pinger, frontendFS fs.FS, cfg RouterConfig) http.
 		r.Get("/api/analysis/collective", handlers.CollectiveAnalysis(cfg.LabRepo, cfg.LabCache, cfg.League))
 		r.Get("/api/analysis/compare", handlers.CompareAnalysis(cfg.LabRepo, cfg.LabCache, cfg.TradeCache, cfg.League))
 		r.Get("/api/analysis/gems/names", handlers.GemNamesAutocomplete(cfg.LabRepo, cfg.LabCache, cfg.League))
-		r.Get("/api/analysis/gems/dictionary", handlers.GemDictionary(cfg.LabRepo))
+		r.Get("/api/analysis/gems/dictionary", handlers.GemDictionary(cfg.LabRepo, cfg.League))
 		r.Get("/api/analysis/status", handlers.AnalysisStatus(cfg.LabCache, cfg.Pool, cfg.League))
 		r.Get("/api/analysis/history", handlers.SignalHistory(cfg.LabRepo, cfg.League))
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -129,6 +129,7 @@ func NewRouter(pinger handlers.Pinger, frontendFS fs.FS, cfg RouterConfig) http.
 		r.Get("/api/analysis/collective", handlers.CollectiveAnalysis(cfg.LabRepo, cfg.LabCache, cfg.League))
 		r.Get("/api/analysis/compare", handlers.CompareAnalysis(cfg.LabRepo, cfg.LabCache, cfg.TradeCache, cfg.League))
 		r.Get("/api/analysis/gems/names", handlers.GemNamesAutocomplete(cfg.LabRepo, cfg.LabCache, cfg.League))
+		r.Get("/api/analysis/gems/dictionary", handlers.GemDictionary(cfg.LabRepo))
 		r.Get("/api/analysis/status", handlers.AnalysisStatus(cfg.LabCache, cfg.Pool, cfg.League))
 		r.Get("/api/analysis/history", handlers.SignalHistory(cfg.LabRepo, cfg.League))
 


### PR DESCRIPTION
Six fixes for problems that all surfaced together at the Allflame league start, when the market has almost no data yet. Each is independent; the common thread is code that reads "no data" as "zero".

## What was broken

**Rankings showed nothing while Font EV showed gems.** `AnalyzeTransfigure` dropped any transfigured gem whose *base* gem was unpriced, so a gem the Font EV analyzer prices and counts in its pool was absent from Rankings entirely. That is the normal shape hours into a league: poe.ninja lists transfigured gems before their bases.

**The `1/0` and `20/0` tabs were empty regardless.** The backend serves zero-quality variants as `"1"`/`"20"` and strips `/0` from inbound query params, but never restores it on responses. `ByVariant` filters the loaded rows client-side against `"1/0"`, so those tabs matched nothing — a regression since 3e2f28d, which replaced a per-variant fetch (server-normalized, so it worked) with a local equality filter.

**The comparator overlay never opened.** The desktop OCR dictionary came from `/api/analysis/gems/names`, whose cache is derived from transfigure results — so a gem only became matchable once *both* it and its base carried a price. On Allflame day 1 that was 17 names against ~213 real transfigured gems: OCR read the gem under the cursor correctly and the matcher had nothing to match it to. The Dedication path's `q=+` match-all sentinel also 500s on a cold cache, because `strings.Fields(" ")` is empty and the query became `WHERE ... AND ORDER BY`.

**Pool Overview read as a market verdict.** One count per colour (`47 gems`) sat next to a variant-specific EV, so a variant with no prices looked like "47 outcomes, none valuable" rather than "no prices here yet".

## Approach

Zero now means *unknown* and is labelled as such, rather than being dropped or printed as a price:

- `NO_BASE` — the gem is priced, its base is not. Kept in rankings on its own price; dropped under a budget filter, since an unknown cost basis cannot be shown to fit one. ROI renders `—`.
- `NO_DATA` — neither side is priced. Was `"LOW"`, which conflates "thin market" with "no market".
- `PricedGems` — how many pool members carry a usable price at the selected variant. The pool denominator stays variant-independent on purpose (the Font can roll any transfigured gem of that colour whether or not poe.ninja prices it, and unpriced outcomes count as 0 so `pWin` stays honest), so only the label changed. EV math is untouched.
- `/api/analysis/gems/dictionary` — OCR names from `gem_colors` unioned with the league's snapshot names. Recognition no longer depends on prices. A name is transfigured when its base is itself a known gem, which separates `Rain of Arrows of Saturation` from base gems that merely contain " of " like `Herald of Ash`.

## Verification

Full Go suite + integration tests, `cargo check`, desktop `svelte-check` (0 errors) and vitest (25). The web frontend sits at its pre-existing 46-error `svelte-check` baseline — unchanged, none added.

Every behavior change is mutation-checked: the production code was broken deliberately and the new test confirmed to fail. The SQL fix reproduces the exact production error (`syntax error at or near "ORDER"`) when reverted.

Reviewed by three independent agents. Their findings are fixed in c25661b and 2b4e7f3 — notably `PricedGems` was never persisted (any response served from the DB before the first font run after a restart would have reported `0 / N priced` for a fully priced pool), it counted low-confidence gems that enter the EV as 0, `BuildCompareResults` picked the display variant by max ROI where `NO_BASE`'s 0 outranked a real negative ROI, and the dictionary was not actually a superset of the endpoint it replaced (`gem_colors` is collector-fed per ADR-006, not static game data).

## Deploy notes

Two migrations. `20260725000000` widens the `confidence` CHECK using `NOT VALID` — every existing row predates `NO_BASE`, so there is nothing to validate, and this keeps it off the ACCESS EXCLUSIVE path over a compressed hypertable holding full league history. Production has no such constraint at all, so it is close to a no-op there. `20260725001000` adds a nullable `font_snapshots.priced_gems`; readers coalesce to `pool`.

The desktop needs a rebuild to pick up the new endpoint, and the server must be deployed first.

## Known, not addressed

- `RankCollective` prices against a gem's own base while `BuildCompareResults` uses the cheapest base of that colour — the comparator's model is the real lab scenario. Unifying them would give `NO_BASE` gems a real ROI and remove the special case.
- Pre-existing: server-side trade enrichment never matches for `20/0`/`1/0` because `handlers/trade.go` submits without `normalizeVariant`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
