### PR TITLE
POE-133: cache sparkline data server-side instead of querying gem_snapshots per request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ specialized agent profiles.
   data-flow behavior, explicitly labelled.
 - [Overlay guide](docs/OVERLAY-GUIDE.md) — specialized Tauri/Windows knowledge;
   observe its status caveat.
+- [Analysis cache guide](docs/ANALYSIS-CACHE.md) — how `lab.Cache` is populated
+  and served, and the concurrency rules any new cache field must follow.
 
 Current code, migrations, tests, and deployment configuration are authoritative
 for implemented behavior. Document status matters: do not treat product vision,

--- a/docs/ANALYSIS-CACHE.md
+++ b/docs/ANALYSIS-CACHE.md
@@ -158,9 +158,13 @@ are never merged into one series.
   appearing in snapshots would otherwise decay to an empty sparkline inside the
   window; the tail leaves its last known shape visible.
 - `sparklineMaxLookbackHours = 168` — how far back the tail may reach. Past that
-  age, showing nothing beats showing a flat line from last week. This is also
-  the span `SparklineWindow` queries, so the 168-hour trend consumer is served
-  from the same cache and each consumer trims at request time.
+  age, showing nothing beats showing a flat line from last week. The 168-hour
+  trend consumer is served from the same cache, and each consumer trims at
+  request time.
+
+These three travel together as `SparklineBounds`, built by `sparklineCacheBounds()`
+and passed to the read. Binding them into one struct is what keeps the rows
+fetched matched to the rows retained — see the cold read below.
 
 ### Population and the high-water mark
 
@@ -168,11 +172,19 @@ are never merged into one series.
 guarded by `a.cache != nil`. A failure is **logged, not fatal**: handlers fall
 back to `gem_snapshots`, and the analysis output is already persisted.
 
-The read is incremental. `SparklineWindow(ctx, scope, since, hours)` fetches only
-rows newer than the cached high-water mark, except on a cold cache (both maps
-empty), where `since` is zero and the full window loads. Series that received no
-incoming points are still re-merged, so points aging out of the rolling window
-are trimmed.
+The read is incremental. `SparklineWindow(ctx, scope, since, bounds)` fetches only
+rows newer than the cached high-water mark. Series that received no incoming
+points are still re-merged, so points aging out of the rolling window are
+trimmed.
+
+A cold cache (both maps empty) passes a zero `since`. That path does **not** read
+the full 168-hour lookback — doing so would materialise roughly fourteen times
+the rows the merge retains, at process start, exactly when `RunV2` is already
+holding its own history load. Instead it runs a bounded union: the full
+12-hour window, plus a `DISTINCT ON (name, variant)` tail query taking the last
+`SparklineTailPoints` rows per series within the lookback. Both halves share one
+row predicate, so the variant allowlist and the corruption split cannot drift
+apart between them.
 
 The mark advances **only to the newest timestamp actually observed among incoming
 points**, never to `now`. An empty read leaves it where it was.

--- a/docs/ANALYSIS-CACHE.md
+++ b/docs/ANALYSIS-CACHE.md
@@ -1,0 +1,240 @@
+# The In-Memory Analysis Cache
+
+**Status:** Current  
+**Last verified:** 2026-07-26  
+**Canonical for:** How `lab.Cache` is populated, served, and safely written, including the sparkline series cache.
+
+`internal/lab.Cache` holds pre-computed analysis results in memory so the HTTP
+handlers can serve without querying Postgres on the request path. This document
+records the process topology, the tick chain that fills the cache, the
+concurrency contract every field must honour, and the specifics of the sparkline
+series cache.
+
+## Process topology
+
+The collector and the server are separate binaries: `cmd/collector` and
+`cmd/server`, run as separate containers against the same database
+(`docker-compose.yml`). The collector never imports `internal/lab` and never
+touches `lab.Cache`. Nothing the collector does writes to the cache directly.
+
+Anything described below as "populated on the tick" happens inside the **server**
+process, reacting to a Mercure notification the collector published.
+
+## The tick chain
+
+1. The collector fetches poe.ninja, inserts rows via `InsertGemSnapshots`, and
+   publishes a Mercure event on `poe/collector/gems`
+   (`internal/collector/scheduler.go`).
+2. The server's Mercure subscriber callback (`cmd/server/main.go`) validates the
+   event's league stamp and revision through `LeagueEventGuard.AcceptRaw`
+   (`internal/server/league_events.go`). A mismatched event is dropped.
+3. On the `ninja_gems` endpoint the callback starts `RunTransfigure` and
+   `RunQuality` in their own goroutines, and — in a third goroutine — runs
+   `RunV2`, then `RunFont`, then `RunDedication` **serially**. The order is
+   load-bearing: font and dedication read `GemFeatures` from the cache, so
+   running them concurrently with `RunV2` makes them read the previous cycle's
+   tier classification.
+4. Each `Run*` queries the database itself, computes, persists to Postgres, and
+   only then — guarded by `if a.cache != nil` — calls
+   `a.cache.For(scope).SetX(...)`.
+
+Each analysis kind has its own mutex on `Analyzer` (`muV2`, `muFont`, …), so
+overlapping ticks queue rather than pile up.
+
+### `RunV2` runs twice per snapshot
+
+After every `ninja_gems` event the server also schedules a **T+15-minute delayed
+recompute** that calls `RunV2` again on the same snapshot, to pick up trade data
+accumulated since. A new gem event stops and reschedules the pending timer, so
+there is at most one outstanding timer.
+
+Any cache population wired into `RunV2` must therefore be **idempotent**, not
+merely monotonic: a second pass over an unchanged snapshot has to be a no-op,
+not a duplicate append.
+
+### `league.DataLockKey` skips, it does not serialize
+
+The delayed recompute takes `league.DataLockKey` via
+`league.AcquireProcessLock` (`internal/league/advisory.go`), which is
+**non-blocking**. On contention — another server instance recomputing the same
+dataset — the callback logs a skip and returns. It does not wait for the lock.
+Do not assume a queued second run will eventually happen; assume the tick was
+dropped. (The immediate `RunV2` paths are not yet under this lock; see the
+`TODO(POE-118)` in `cmd/server/main.go`.)
+
+## Cache tenancy
+
+One `Cache` instance serves exactly one league for the whole process lifetime.
+`scope` is set at construction in `NewCache(scope)` from the process-active
+league and never changes.
+
+`For(scope)` is **not a lookup — it is a tenancy assertion.** It compares
+`scope.ID()` against the bound league and **panics** on a mismatch, then returns
+the same receiver. This is deliberate: handlers read cache-first and only fall
+through to the league-scoped repository on a miss, so a cache silently serving
+one league's rows under another league's scope would be an undetectable data
+leak. See ADR-009.
+
+Every read and write goes through `For`. There is no unscoped accessor.
+
+## The immutability contract
+
+A single `sync.RWMutex` guards every field. There is no per-field locking.
+
+Readers take the **slice or map header** under `RLock` and release the lock
+before scanning it. Stored data is therefore treated as **immutable once
+assigned** — a reader may still be walking a slice long after the lock is gone.
+
+Consequences, all of them mandatory for new fields:
+
+- Never mutate a stored slice or map in place. Not `copy(s, s[n:])`, not
+  `delete(m, k)`, not element assignment. The textbook in-place trim idiom is a
+  genuine `-race` failure here.
+- Never store a reslice of a larger array when only the tail is wanted; the
+  reslice pins the whole backing array. Allocate and copy.
+- Replace wholesale. Every `Set*` is a plain assignment under the write lock;
+  the old backing array becomes garbage on the next write.
+
+## The write discipline
+
+1. Compute the replacement value **outside** the lock — including sorting, map
+   building, and any allocation. `SetTransfigure` builds and sorts `gemNames`
+   before taking the lock; the sparkline population merges everything before
+   assigning.
+2. Take the write lock once and assign.
+3. **Never hold the lock across a query or any other slow work.** Read what is
+   needed out under `RLock`, release, do the work, then take the write lock for
+   the assignment.
+
+Existing precedent for building fresh rather than compacting in place:
+`purgeExpired` in `internal/trade/ratelimiter.go`.
+
+### Coherence
+
+Fields written by the same run — `marketContext`, `gemFeatures`, `gemSignals`,
+and the sparkline maps — each take the lock separately, so a reader can observe
+one updated and another not yet. This millisecond-wide window against a
+minutes-long tick interval is a pre-existing, accepted trade-off. New fields
+inherit it; no additional mitigation is expected.
+
+## The cold-start window
+
+The startup warm-up goroutines in `cmd/server/main.go` (seed `nextFetch` and
+`divineRate`, then `RecomputeLatestV2` → `RunFont` → `RunDedication`, plus
+`RunTransfigure` and `RunQuality`) **do not block `ListenAndServe`**. After a
+deploy the server accepts HTTP traffic against a cold cache and keeps serving
+while the warm-up runs.
+
+Every handler must therefore treat an empty cache as normal, not exceptional.
+
+## The cache-first, database-fallback pattern
+
+Handlers read the cache, check that the relevant data is actually present, and
+fall through to the repository otherwise — for example the collective and
+compare paths in `internal/server/handlers/collective.go`, which set
+`usedCache = true` only when the slices they read are non-empty, and the
+sparkline reads, which are gated on `HasSparklines()`.
+
+A bare cache read is a bug. The presence check is what makes the cold-start
+window and a failed pipeline stage degrade into a slower response instead of an
+empty one.
+
+## The sparkline cache
+
+Files: `internal/lab/sparkline_cache.go` (merge and population),
+`internal/lab/cache.go` (fields and accessors), `internal/lab/repository.go`
+(`SparklineWindow`), `internal/server/handlers/collective.go` and
+`internal/server/handlers/analysis.go` (read paths).
+
+Three fields: `sparklines` and `sparklinesCorrupted`, both
+`map[sparklineKey][]SparklinePoint` keyed by gem name plus variant, and
+`sparklineHighWater`. Prices for different variants are different markets and
+are never merged into one series.
+
+### Window and tail
+
+- `SparklineWindowHours = 12` — the rolling window served to consumers.
+- `SparklineTailPoints = 4` — the minimum a series keeps. A gem that stops
+  appearing in snapshots would otherwise decay to an empty sparkline inside the
+  window; the tail leaves its last known shape visible.
+- `sparklineMaxLookbackHours = 168` — how far back the tail may reach. Past that
+  age, showing nothing beats showing a flat line from last week. This is also
+  the span `SparklineWindow` queries, so the 168-hour trend consumer is served
+  from the same cache and each consumer trims at request time.
+
+### Population and the high-water mark
+
+`populateSparklineCache` runs at the end of `RunV2`, after `SetGemSignals`,
+guarded by `a.cache != nil`. A failure is **logged, not fatal**: handlers fall
+back to `gem_snapshots`, and the analysis output is already persisted.
+
+The read is incremental. `SparklineWindow(ctx, scope, since, hours)` fetches only
+rows newer than the cached high-water mark, except on a cold cache (both maps
+empty), where `since` is zero and the full window loads. Series that received no
+incoming points are still re-merged, so points aging out of the rolling window
+are trimmed.
+
+The mark advances **only to the newest timestamp actually observed among incoming
+points**, never to `now`. An empty read leaves it where it was.
+
+Population deliberately does **not** reuse the history `RunV2` already holds:
+`GemPriceHistoryByVariant` filters `chaos > 5`, excludes Trarthus names, and
+applies its own variant allowlist, none of which the previous sparkline path
+applied. Reusing it would silently drop points the database path returned.
+`SparklineWindow` filters only on the variant allowlist (`1`, `1/20`, `20`,
+`20/20` for non-corrupted; `21/23c` for corrupted) and `is_corrupted`, which
+closes the key space without changing series content. POE-134 may change that
+`chaos > 5` floor; the sparkline path is unaffected either way.
+
+Sparklines always use raw prices. Never source them from normalized history —
+temporal normalization was removed from this path for creating edge artifacts.
+
+### Idempotency
+
+`RunV2` runs twice per snapshot, so a repeated pass must change nothing. Three
+mechanisms combine: the incremental `since` filter reads no rows, the merge
+deduplicates on the `Time` string with the first occurrence winning, and the
+high-water mark only advances to an observed timestamp.
+
+### The three memory-safety rules
+
+Each has a concrete failure mode; none is stylistic.
+
+1. **Never store a reslice for the tail.** `points[len(points)-4:]` pins the
+   entire history backing array. Because the gem is delisted, no further append
+   ever occurs on that series, so the reallocation that would free the array
+   never comes — one full history array retained per delisted gem for the rest
+   of the league. `mergeSparklineSeries` always returns a freshly allocated
+   slice.
+2. **Never compact in place.** `copy(s, s[n:]); s = s[:len(s)-n]` mutates
+   elements a concurrent reader is already holding, breaking the immutability
+   contract above. It is a real `-race` failure, not a theoretical one. Build a
+   fresh slice per series and assign.
+3. **Never hold the lock across the query.** `sparklineSnapshot` reads both maps
+   and the mark under a single `RLock` and returns; the query, the merge, and
+   all allocation happen unlocked; `SetSparklines` then assigns both maps and
+   the mark under one write lock.
+
+Sizing, for context: roughly 56 bytes per point (32-byte struct plus the heap
+allocation behind the RFC3339 time string), a few thousand series, on the order
+of 4-7 MB total. `RunV2` already loads an order of magnitude more history
+transiently, twice per tick.
+
+## League rollover
+
+`league.Scope` is resolved once at startup from `runtime_config` and is
+immutable (`internal/league/league.go`). `LeagueEventGuard` only rejects
+mismatched incoming Mercure events; it cannot switch a live cache's league.
+
+Per ADR-011 the outgoing league's scoped tables are truncated at rollover, and
+because scope is process-fixed, rollover requires a **server restart**, which
+constructs a fresh `NewCache(scope)`. There is no stale-data leak path today and
+no field needs explicit clearing.
+
+The practical consequence for time-series fields: on a fresh post-rollover
+process `gem_snapshots` is empty, so sparklines are empty or short for the first
+hours of a new league. That is the same cold-start shape every other cache field
+has.
+
+If in-process league switching lands (POE-121), `internal/server/league_events.go`
+and `Cache.For` are the places that change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,7 @@ ADRs record decisions at a point in time. If implementation later supersedes a d
 - [Trade and Market Data Lifecycles](TRADE-LIFECYCLE.md) — mixed current/target guide with per-section labels.
 - [Overlay Guide](OVERLAY-GUIDE.md) — current click-through, positioning, lifecycle distinctions, and Windows regression guards.
 - [Collector Endpoint Guide](COLLECTOR-ENDPOINTS.md) — current endpoint extension procedure, verified against the fragments implementation.
+- [Analysis Cache Guide](ANALYSIS-CACHE.md) — current `lab.Cache` topology, tick chain, tenancy and concurrency contract, cold start, and the sparkline series cache.
 - [Historical overlay debugging notes](history/overlay-debugging-notes.md) — preserved runtime discoveries and obsolete implementation generations; not a current recipe.
 - [AI-Native Case Study](AI-NATIVE-CASE-STUDY.md) — public project/portfolio narrative, not an implementation contract.
 

--- a/internal/lab/analyzer.go
+++ b/internal/lab/analyzer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"profitofexile/internal/league"
 	"profitofexile/internal/trade"
@@ -346,6 +347,15 @@ func (a *Analyzer) RunV2(ctx context.Context, scope league.Scope) error {
 		"signals", len(signals),
 		"inserted", insertedSig,
 	)
+
+	if a.cache != nil {
+		// Serving-path optimisation only: a failure here leaves handlers on
+		// their existing gem_snapshots fallback, so it is logged rather than
+		// failing a run whose analysis output is already persisted.
+		if err := populateSparklineCache(ctx, a.repo, a.cache, scope, time.Now()); err != nil {
+			a.logger.Error("v2: failed to populate sparkline cache", "error", err)
+		}
+	}
 
 	a.logger.Info("v2 analysis complete", "snapTime", snapTime, "gems", len(gems))
 	a.throttler.Signal()

--- a/internal/lab/cache.go
+++ b/internal/lab/cache.go
@@ -394,6 +394,29 @@ func (c *Cache) SetSparklines(series, corrupted map[sparklineKey][]SparklinePoin
 	c.sparklineHighWater = highWater
 }
 
+// SetSparklinesByName replaces both sparkline maps from name-then-variant keyed
+// input. sparklineKey is unexported, so callers outside this package cannot
+// build the maps SetSparklines takes; this is their entry point.
+//
+// Both maps are converted before the lock is taken, keeping the write lock down
+// to the three assignments SetSparklines performs.
+func (c *Cache) SetSparklinesByName(series, corrupted map[string]map[string][]SparklinePoint, highWater time.Time) {
+	c.SetSparklines(keyBySparklineName(series), keyBySparklineName(corrupted), highWater)
+}
+
+// keyBySparklineName flattens name-then-variant nesting into sparklineKey keys.
+// A nil input yields an empty map, so a caller warming only one of the two
+// corpora still leaves the other addressable rather than nil.
+func keyBySparklineName(byName map[string]map[string][]SparklinePoint) map[sparklineKey][]SparklinePoint {
+	out := make(map[sparklineKey][]SparklinePoint, len(byName))
+	for name, byVariant := range byName {
+		for variant, points := range byVariant {
+			out[sparklineKey{name: name, variant: variant}] = points
+		}
+	}
+	return out
+}
+
 // Sparklines returns the cached non-corrupted series for a gem name and
 // variant (nil when absent).
 func (c *Cache) Sparklines(name, variant string) []SparklinePoint {

--- a/internal/lab/cache.go
+++ b/internal/lab/cache.go
@@ -441,12 +441,26 @@ func (c *Cache) SparklineHighWater() time.Time {
 	return c.sparklineHighWater
 }
 
-// HasSparklines reports whether the sparkline cache has been populated at all.
-// Handlers need this to tell a cold cache — where falling back to the database
-// is correct — from a warm cache where a missing key genuinely means the gem
-// has no recent points.
+// HasSparklines reports whether the NON-corrupted sparkline map has been
+// populated. Handlers need this to tell a cold cache — where falling back to the
+// database is correct — from a warm cache where a missing key genuinely means
+// the gem has no recent points.
+//
+// It reports on one corpus only. A caller reading the non-corrupted map must not
+// be told the cache is warm because the corrupted map was filled: it would serve
+// empty series with no fallback and no log. HasSparklinesCorrupted is the same
+// signal for the other corpus.
 func (c *Cache) HasSparklines() bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return len(c.sparklines) > 0 || len(c.sparklinesCorrupted) > 0
+	return len(c.sparklines) > 0
+}
+
+// HasSparklinesCorrupted reports whether the corrupted (Dedication) sparkline
+// map has been populated. See HasSparklines for why the two corpora report
+// separately.
+func (c *Cache) HasSparklinesCorrupted() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.sparklinesCorrupted) > 0
 }

--- a/internal/lab/cache.go
+++ b/internal/lab/cache.go
@@ -16,6 +16,11 @@ import (
 // Readers get a snapshot of the slice header; the underlying data is treated as
 // immutable once stored.
 //
+// The sparkline maps follow the same contract: a writer builds replacement maps
+// and series outside the lock and assigns them whole, so a reader holding a
+// series it read earlier keeps a valid, unchanging view. Series are never
+// mutated or compacted in place.
+//
 // A Cache is bound to exactly one league for its whole lifetime. scope is set
 // at construction from the process-active league and never changes (scope is
 // process-fixed until POE-121). Every read and write must go through For, which
@@ -49,6 +54,14 @@ type Cache struct {
 	marketContext *MarketContext
 	gemFeatures   []GemFeature
 	gemSignals    []GemSignal
+
+	// Rolling per-gem/variant price series, kept warm so sparkline requests do
+	// not hit gem_snapshots. sparklineHighWater is the newest snapshot time
+	// already folded in, so a repeated pass over the same snapshot only has to
+	// query newer rows.
+	sparklines          map[sparklineKey][]SparklinePoint
+	sparklinesCorrupted map[sparklineKey][]SparklinePoint
+	sparklineHighWater  time.Time
 }
 
 // NewCache creates an empty analysis cache bound to scope. The cache serves and
@@ -363,4 +376,54 @@ func (c *Cache) GemSignals() []GemSignal {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.gemSignals
+}
+
+// SetSparklines replaces both sparkline maps and the high-water mark.
+//
+// Callers build the replacement maps outside the lock (see
+// mergeSparklineSeries) and hand them over whole — this method assigns and
+// nothing more, so the write lock is held for three assignments rather than for
+// a corpus-wide merge. highWater is the newest snapshot time folded into the
+// maps; pass the max time actually observed, so a repeated pass over an
+// unchanged snapshot leaves it where it was.
+func (c *Cache) SetSparklines(series, corrupted map[sparklineKey][]SparklinePoint, highWater time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.sparklines = series
+	c.sparklinesCorrupted = corrupted
+	c.sparklineHighWater = highWater
+}
+
+// Sparklines returns the cached non-corrupted series for a gem name and
+// variant (nil when absent).
+func (c *Cache) Sparklines(name, variant string) []SparklinePoint {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.sparklines[sparklineKey{name: name, variant: variant}]
+}
+
+// SparklinesCorrupted returns the cached corrupted series for a gem name and
+// variant (nil when absent).
+func (c *Cache) SparklinesCorrupted(name, variant string) []SparklinePoint {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.sparklinesCorrupted[sparklineKey{name: name, variant: variant}]
+}
+
+// SparklineHighWater returns the newest snapshot time folded into the sparkline
+// maps (zero when never populated).
+func (c *Cache) SparklineHighWater() time.Time {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.sparklineHighWater
+}
+
+// HasSparklines reports whether the sparkline cache has been populated at all.
+// Handlers need this to tell a cold cache — where falling back to the database
+// is correct — from a warm cache where a missing key genuinely means the gem
+// has no recent points.
+func (c *Cache) HasSparklines() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.sparklines) > 0 || len(c.sparklinesCorrupted) > 0
 }

--- a/internal/lab/cache_test.go
+++ b/internal/lab/cache_test.go
@@ -2,6 +2,7 @@ package lab
 
 import (
 	"testing"
+	"time"
 
 	"profitofexile/internal/league"
 )
@@ -51,4 +52,102 @@ func TestCache_For_RejectsForeignLeague(t *testing.T) {
 	requirePanic(t, func() {
 		_ = c.For(other).Transfigure()
 	})
+}
+
+// Sparklines are keyed by name *and* variant: 1/0 and 20/20 are different
+// markets whose prices must never be served for one another.
+func TestCache_SetSparklines_RoundTripsPerNameAndVariant(t *testing.T) {
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	twenty := []SparklinePoint{{Time: "2026-07-20T11:00:00Z", Price: 120, Listings: 4}}
+	one := []SparklinePoint{{Time: "2026-07-20T11:00:00Z", Price: 3, Listings: 9}}
+	c.For(scope).SetSparklines(map[sparklineKey][]SparklinePoint{
+		{name: "Spark of Nova", variant: "20/20"}: twenty,
+		{name: "Spark of Nova", variant: "1"}:     one,
+	}, nil, time.Time{})
+
+	got := c.For(scope).Sparklines("Spark of Nova", "20/20")
+	if len(got) != 1 || got[0].Price != 120 || got[0].Listings != 4 {
+		t.Fatalf("20/20 read: got %+v, want the stored 120c point", got)
+	}
+	if got := c.For(scope).Sparklines("Spark of Nova", "1"); len(got) != 1 || got[0].Price != 3 {
+		t.Fatalf("1 read: got %+v, want the stored 3c point", got)
+	}
+}
+
+// Corrupted gems live in their own map. Serving a corrupted 21/23c series from
+// the non-corrupted read would put Dedication prices on a normal gem's chart.
+func TestCache_SetSparklines_KeepsCorruptedSeriesOutOfTheNormalRead(t *testing.T) {
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	corrupted := []SparklinePoint{{Time: "2026-07-20T11:00:00Z", Price: 400, Listings: 2}}
+	c.For(scope).SetSparklines(nil, map[sparklineKey][]SparklinePoint{
+		{name: "Spark of Nova", variant: "21/23c"}: corrupted,
+	}, time.Time{})
+
+	if got := c.For(scope).Sparklines("Spark of Nova", "21/23c"); got != nil {
+		t.Fatalf("normal read of a corrupted key: got %+v, want nil", got)
+	}
+	got := c.For(scope).SparklinesCorrupted("Spark of Nova", "21/23c")
+	if len(got) != 1 || got[0].Price != 400 {
+		t.Fatalf("corrupted read: got %+v, want the stored 400c point", got)
+	}
+}
+
+// Same tenancy gate as Transfigure: handlers read sparklines cache-first, so a
+// cache warmed under LeagueA must never serve those series under LeagueB.
+func TestCache_Sparklines_RejectsForeignLeague(t *testing.T) {
+	owner := league.Historical("LeagueA")
+	other := league.Historical("LeagueB")
+
+	c := NewCache(owner)
+	c.For(owner).SetSparklines(map[sparklineKey][]SparklinePoint{
+		{name: "Spark of Nova", variant: "20/20"}: {{Time: "2026-07-20T11:00:00Z", Price: 120}},
+	}, nil, time.Time{})
+
+	requirePanic(t, func() {
+		_ = c.For(other).Sparklines("Spark of Nova", "20/20")
+	})
+}
+
+// A cold cache must report false so handlers fall back to the database instead
+// of serving an empty sparkline for every gem.
+func TestCache_HasSparklines_FalseBeforeFirstPopulation(t *testing.T) {
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	if c.For(scope).HasSparklines() {
+		t.Fatalf("HasSparklines on a fresh cache: got true, want false")
+	}
+}
+
+// Once populated, a missing key means the gem genuinely has no recent points —
+// the signal handlers use to stop falling back.
+func TestCache_HasSparklines_TrueAfterPopulation(t *testing.T) {
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	c.For(scope).SetSparklines(map[sparklineKey][]SparklinePoint{
+		{name: "Spark of Nova", variant: "20/20"}: {{Time: "2026-07-20T11:00:00Z", Price: 120}},
+	}, nil, time.Time{})
+
+	if !c.For(scope).HasSparklines() {
+		t.Fatalf("HasSparklines after a populated write: got false, want true")
+	}
+}
+
+// The mark drives the next incremental read, so it must come back exactly as
+// stored rather than as the write's wall-clock time.
+func TestCache_SparklineHighWater_ReturnsStoredMark(t *testing.T) {
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	mark := time.Date(2026, 7, 20, 11, 30, 0, 0, time.UTC)
+	c.For(scope).SetSparklines(nil, nil, mark)
+
+	if got := c.For(scope).SparklineHighWater(); !got.Equal(mark) {
+		t.Fatalf("SparklineHighWater: got %s, want the stored %s", got, mark)
+	}
 }

--- a/internal/lab/cache_test.go
+++ b/internal/lab/cache_test.go
@@ -138,6 +138,40 @@ func TestCache_HasSparklines_TrueAfterPopulation(t *testing.T) {
 	}
 }
 
+// The two corpora report separately. Reading the non-corrupted map off a cache
+// where only the corrupted one was filled serves an empty series for every gem,
+// with no fallback and no log — so a corrupted-only write must still read cold.
+func TestCache_HasSparklines_FalseWhenOnlyTheCorruptedMapIsPopulated(t *testing.T) {
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	c.For(scope).SetSparklines(nil, map[sparklineKey][]SparklinePoint{
+		{name: "Vaal Grace", variant: "21/23c"}: {{Time: "2026-07-20T11:00:00Z", Price: 900}},
+	}, time.Time{})
+
+	if c.For(scope).HasSparklines() {
+		t.Errorf("HasSparklines with only the corrupted map populated: got true, want false")
+	}
+	if !c.For(scope).HasSparklinesCorrupted() {
+		t.Errorf("HasSparklinesCorrupted after a corrupted write: got false, want true")
+	}
+}
+
+// The mirror case: a non-corrupted-only population must not tell the Dedication
+// reader its corpus is warm.
+func TestCache_HasSparklinesCorrupted_FalseWhenOnlyTheMainMapIsPopulated(t *testing.T) {
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	c.For(scope).SetSparklines(map[sparklineKey][]SparklinePoint{
+		{name: "Spark of Nova", variant: "20/20"}: {{Time: "2026-07-20T11:00:00Z", Price: 120}},
+	}, nil, time.Time{})
+
+	if c.For(scope).HasSparklinesCorrupted() {
+		t.Errorf("HasSparklinesCorrupted with only the main map populated: got true, want false")
+	}
+}
+
 // The mark drives the next incremental read, so it must come back exactly as
 // stored rather than as the write's wall-clock time.
 func TestCache_SparklineHighWater_ReturnsStoredMark(t *testing.T) {

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -587,6 +587,88 @@ func (r *Repository) SparklineData(ctx context.Context, scope league.Scope, name
 	return result, nil
 }
 
+// sparklineVariants are the non-corrupted variants sparkline consumers ask for.
+// Prices for different variants are different markets, so the variant is part
+// of the series identity rather than something merged away.
+var sparklineVariants = []string{"1", "1/20", "20", "20/20"}
+
+// sparklineCorruptedVariant is the only corrupted variant sparklines are served
+// for — the Dedication (21/23c) pool.
+const sparklineCorruptedVariant = "21/23c"
+
+// SparklineWindow returns raw price points for every gem/variant series the
+// sparkline cache serves, in one pass. The first map holds the non-corrupted
+// series, the second the corrupted (Dedication) series.
+//
+// hours bounds the window read from the snapshot table. since drives the
+// incremental path: pass a non-zero value to read only rows newer than the
+// caller's high-water mark, or the zero time for a full window read.
+//
+// Deliberately unlike GemPriceHistoryByVariant, this applies no chaos floor and
+// no Trarthus exclusion — SparklineData has never applied either, and the chaos
+// floor is tracked separately as POE-134. It also does not filter
+// is_transfigured, because TrendAnalysis charts base gems too.
+func (r *Repository) SparklineWindow(ctx context.Context, scope league.Scope, since time.Time, hours int) (map[sparklineKey][]SparklinePoint, map[sparklineKey][]SparklinePoint, error) {
+	if err := scope.Validate(); err != nil {
+		return nil, nil, fmt.Errorf("lab repo: sparkline window: %w", err)
+	}
+
+	query := `
+		SELECT name, variant, time, COALESCE(chaos, 0), COALESCE(listings, 0), is_corrupted
+		FROM gem_snapshots
+		WHERE league = $1
+		  AND time > NOW() - make_interval(hours => $2)
+		  AND ((is_corrupted = false AND variant = ANY($3))
+		    OR (is_corrupted = true AND variant = $4))`
+	args := []any{scope.ID(), hours, sparklineVariants, sparklineCorruptedVariant}
+
+	if !since.IsZero() {
+		query += ` AND time > $5`
+		args = append(args, since)
+	}
+
+	// No row limit: the variant filters close the key space, and the time
+	// window bounds the rows per series.
+	query += ` ORDER BY name, variant, time ASC`
+
+	rows, err := r.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, nil, fmt.Errorf("lab repo: query sparkline window: %w", err)
+	}
+	defer rows.Close()
+
+	series := make(map[sparklineKey][]SparklinePoint)
+	corrupted := make(map[sparklineKey][]SparklinePoint)
+
+	for rows.Next() {
+		var name, variant string
+		var t time.Time
+		var chaos float64
+		var listings int
+		var isCorrupted bool
+		if err := rows.Scan(&name, &variant, &t, &chaos, &listings, &isCorrupted); err != nil {
+			return nil, nil, fmt.Errorf("lab repo: scan sparkline window point: %w", err)
+		}
+
+		k := sparklineKey{name: name, variant: variant}
+		pt := SparklinePoint{
+			Time:     t.UTC().Format(time.RFC3339),
+			Price:    chaos,
+			Listings: listings,
+		}
+		if isCorrupted {
+			corrupted[k] = append(corrupted[k], pt)
+			continue
+		}
+		series[k] = append(series[k], pt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, nil, fmt.Errorf("lab repo: sparkline window rows iteration: %w", err)
+	}
+
+	return series, corrupted, nil
+}
+
 // GemNamesAutocomplete returns distinct transfigured gem names matching all query words (in any order).
 func (r *Repository) GemNamesAutocomplete(ctx context.Context, scope league.Scope, query string, limit int) ([]string, error) {
 	if err := scope.Validate(); err != nil {

--- a/internal/lab/repository.go
+++ b/internal/lab/repository.go
@@ -596,40 +596,114 @@ var sparklineVariants = []string{"1", "1/20", "20", "20/20"}
 // for — the Dedication (21/23c) pool.
 const sparklineCorruptedVariant = "21/23c"
 
+// sparklineRowFilter is the row predicate every sparkline read shares: the
+// scoped league, an upper bound on row age, and the served-variant allowlist
+// split by corruption. hoursParam names the placeholder carrying the age bound,
+// so the same predicate can be reused at a different bound.
+//
+// Kept in one place because the cold read applies it three times at two
+// different bounds. The variant allowlist and corruption split must be identical
+// in all three: the tail half and the window half would otherwise cover
+// different key spaces, and their union would no longer be one coherent corpus.
+func sparklineRowFilter(hoursParam string) string {
+	return `league = $1
+		  AND time > NOW() - make_interval(hours => ` + hoursParam + `)
+		  AND ((is_corrupted = false AND variant = ANY($3))
+		    OR (is_corrupted = true AND variant = $4))`
+}
+
+// sparklineIncrementalQuery reads only rows strictly newer than the caller's
+// high-water mark ($5). On a running server that mark is one tick old, so the
+// result is a single snapshot's worth of rows and needs no further bound.
+var sparklineIncrementalQuery = `
+	SELECT name, variant, time, COALESCE(chaos, 0), COALESCE(listings, 0), is_corrupted
+	FROM gem_snapshots
+	WHERE ` + sparklineRowFilter("$2") + `
+	  AND time > $5
+	ORDER BY name, variant, time ASC`
+
+// sparklineColdQuery reads exactly what a cold cache retains and nothing more:
+// every row inside the served window ($6 hours), plus the newest $5 rows per
+// series within the $2-hour lookback.
+//
+// That union is a superset of what mergeSparklineSeries keeps. The merge keeps
+// every in-window point, and extends backwards only far enough to reach
+// SparklineTailPoints — points that are, by construction, among the newest $5
+// rows of the series. Reading the flat $2-hour window instead pulls roughly
+// fourteen times the rows for the same result, and holds them live for the whole
+// merge at the one moment (process start) the analysis pass is also loading its
+// own history.
+//
+// The two halves overlap for any series still trading; UNION collapses the
+// duplicates so each timestamp arrives once.
+var sparklineColdQuery = `
+	WITH keys AS (
+		SELECT DISTINCT name, variant, is_corrupted
+		FROM gem_snapshots
+		WHERE ` + sparklineRowFilter("$2") + `
+	),
+	tail AS (
+		SELECT t.name, t.variant, t.time, t.chaos, t.listings, t.is_corrupted
+		FROM keys k
+		CROSS JOIN LATERAL (
+			SELECT g.name, g.variant, g.time,
+			       COALESCE(g.chaos, 0) AS chaos,
+			       COALESCE(g.listings, 0) AS listings,
+			       g.is_corrupted
+			FROM gem_snapshots g
+			WHERE g.league = $1
+			  AND g.name = k.name
+			  AND g.variant = k.variant
+			  AND g.is_corrupted = k.is_corrupted
+			  AND g.time > NOW() - make_interval(hours => $2)
+			ORDER BY g.time DESC
+			LIMIT $5
+		) t
+	),
+	win AS (
+		SELECT name, variant, time,
+		       COALESCE(chaos, 0) AS chaos,
+		       COALESCE(listings, 0) AS listings,
+		       is_corrupted
+		FROM gem_snapshots
+		WHERE ` + sparklineRowFilter("$6") + `
+	)
+	SELECT name, variant, time, chaos, listings, is_corrupted
+	FROM (SELECT * FROM win UNION SELECT * FROM tail) u
+	ORDER BY name, variant, time ASC`
+
 // SparklineWindow returns raw price points for every gem/variant series the
 // sparkline cache serves, in one pass. The first map holds the non-corrupted
 // series, the second the corrupted (Dedication) series.
 //
-// hours bounds the window read from the snapshot table. since drives the
-// incremental path: pass a non-zero value to read only rows newer than the
-// caller's high-water mark, or the zero time for a full window read.
+// since selects the read shape. A non-zero value takes the incremental path and
+// returns only rows newer than the caller's high-water mark. The zero time takes
+// the cold path, which is bounded by every field of bounds — see
+// sparklineColdQuery for why a flat LookbackHours read is not used there.
+//
+// The window bound is evaluated against the database clock while the caller
+// windows against its own. Skew of a few minutes only shifts which
+// about-to-expire points arrive; the per-series tail is unconditional, so every
+// series still gets its newest TailPoints rows regardless.
 //
 // Deliberately unlike GemPriceHistoryByVariant, this applies no chaos floor and
 // no Trarthus exclusion — SparklineData has never applied either, and the chaos
 // floor is tracked separately as POE-134. It also does not filter
 // is_transfigured, because TrendAnalysis charts base gems too.
-func (r *Repository) SparklineWindow(ctx context.Context, scope league.Scope, since time.Time, hours int) (map[sparklineKey][]SparklinePoint, map[sparklineKey][]SparklinePoint, error) {
+func (r *Repository) SparklineWindow(ctx context.Context, scope league.Scope, since time.Time, bounds SparklineBounds) (map[sparklineKey][]SparklinePoint, map[sparklineKey][]SparklinePoint, error) {
 	if err := scope.Validate(); err != nil {
 		return nil, nil, fmt.Errorf("lab repo: sparkline window: %w", err)
 	}
 
-	query := `
-		SELECT name, variant, time, COALESCE(chaos, 0), COALESCE(listings, 0), is_corrupted
-		FROM gem_snapshots
-		WHERE league = $1
-		  AND time > NOW() - make_interval(hours => $2)
-		  AND ((is_corrupted = false AND variant = ANY($3))
-		    OR (is_corrupted = true AND variant = $4))`
-	args := []any{scope.ID(), hours, sparklineVariants, sparklineCorruptedVariant}
-
-	if !since.IsZero() {
-		query += ` AND time > $5`
-		args = append(args, since)
+	query := sparklineIncrementalQuery
+	args := []any{scope.ID(), bounds.LookbackHours, sparklineVariants, sparklineCorruptedVariant, since}
+	if since.IsZero() {
+		query = sparklineColdQuery
+		args = []any{
+			scope.ID(), bounds.LookbackHours, sparklineVariants, sparklineCorruptedVariant,
+			bounds.TailPoints, bounds.WindowHours,
+		}
 	}
-
-	// No row limit: the variant filters close the key space, and the time
-	// window bounds the rows per series.
-	query += ` ORDER BY name, variant, time ASC`
 
 	rows, err := r.pool.Query(ctx, query, args...)
 	if err != nil {

--- a/internal/lab/repository_integration_test.go
+++ b/internal/lab/repository_integration_test.go
@@ -227,6 +227,249 @@ func TestSparklineData_returnsOnlyScopedLeague(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// SparklineWindow — the population query behind the sparkline cache (POE-133).
+//
+// It must NOT inherit the filters GemPriceHistoryByVariant applies (chaos floor,
+// Trarthus exclusion, transfigured-only), because SparklineData never applied
+// them and the cache has to reproduce the served content exactly. It must apply
+// the filters that DO exist: league, the four-variant allowlist for the main
+// map, and the corrupted split.
+// ---------------------------------------------------------------------------
+
+func TestSparklineWindow_returnsBaseGems(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueID := "POE-133-spw-base"
+	registerLeague(t, pool, leagueID)
+
+	tm := futureTime(30)
+	cleanupAtTime(t, pool, tm, "gem_snapshots")
+
+	// is_transfigured = false: TrendAnalysis charts base gems, so a query that
+	// filters on is_transfigured (as GemPriceHistoryByVariant does) loses them.
+	const name = "POE133 Base Only Gem"
+	seedGemSnapshot(t, pool, leagueID, tm, name, "20/20", false, false, 111, 10, "BLUE")
+
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	if err != nil {
+		t.Fatalf("SparklineWindow: %v", err)
+	}
+	points, ok := series[sparklineKey{name: name, variant: "20/20"}]
+	if !ok {
+		t.Fatalf("no series for base gem %q — an is_transfigured = true filter drops it and blanks the TrendAnalysis base sparkline", name)
+	}
+	if len(points) != 1 {
+		t.Fatalf("point count = %d, want 1", len(points))
+	}
+	if !valuesClose(points[0].Price, 111) {
+		t.Errorf("price = %v, want 111", points[0].Price)
+	}
+}
+
+func TestSparklineWindow_returnsGemsBelowTheChaosFloor(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueID := "POE-133-spw-cheap"
+	registerLeague(t, pool, leagueID)
+
+	tm := futureTime(31)
+	cleanupAtTime(t, pool, tm, "gem_snapshots")
+
+	// 3 chaos is under GemPriceHistoryByVariant's `chaos > 5` floor (POE-134).
+	// SparklineData has never applied it, so the cache must not either.
+	const name = "POE133 Cheap Gem"
+	seedGemSnapshot(t, pool, leagueID, tm, name, "20/20", true, false, 3, 10, "BLUE")
+
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	if err != nil {
+		t.Fatalf("SparklineWindow: %v", err)
+	}
+	points, ok := series[sparklineKey{name: name, variant: "20/20"}]
+	if !ok {
+		t.Fatalf("no series for %q priced at 3 chaos — the query inherited the `chaos > 5` floor", name)
+	}
+	if !valuesClose(points[0].Price, 3) {
+		t.Errorf("price = %v, want 3", points[0].Price)
+	}
+}
+
+func TestSparklineWindow_returnsTrarthusGems(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueID := "POE-133-spw-trarthus"
+	registerLeague(t, pool, leagueID)
+
+	tm := futureTime(32)
+	cleanupAtTime(t, pool, tm, "gem_snapshots")
+
+	// GemPriceHistoryByVariant excludes `name NOT LIKE '%Trarthus%'`;
+	// SparklineData does not, so these gems keep their sparklines.
+	const name = "POE133 Trarthus Gem"
+	seedGemSnapshot(t, pool, leagueID, tm, name, "20/20", true, false, 111, 10, "BLUE")
+
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	if err != nil {
+		t.Fatalf("SparklineWindow: %v", err)
+	}
+	if _, ok := series[sparklineKey{name: name, variant: "20/20"}]; !ok {
+		t.Fatalf("no series for %q — the query inherited the Trarthus exclusion", name)
+	}
+}
+
+func TestSparklineWindow_putsCorruptedRowsInTheCorruptedMap(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueID := "POE-133-spw-corrupt"
+	registerLeague(t, pool, leagueID)
+
+	tm := futureTime(33)
+	cleanupAtTime(t, pool, tm, "gem_snapshots")
+
+	// Dedication serves corrupted 21/23c series from a separate map; mixing them
+	// into the main map would show corrupted prices on the collective sparkline.
+	const name = "POE133 Corrupted Gem"
+	seedGemSnapshot(t, pool, leagueID, tm, name, "21/23c", true, true, 111, 10, "BLUE")
+
+	series, corrupted, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	if err != nil {
+		t.Fatalf("SparklineWindow: %v", err)
+	}
+	key := sparklineKey{name: name, variant: "21/23c"}
+	points, ok := corrupted[key]
+	if !ok {
+		t.Fatalf("no corrupted series for %q at 21/23c", name)
+	}
+	if !valuesClose(points[0].Price, 111) {
+		t.Errorf("corrupted price = %v, want 111", points[0].Price)
+	}
+	if _, leaked := series[key]; leaked {
+		t.Errorf("corrupted row also landed in the non-corrupted map — the is_corrupted split is not applied")
+	}
+}
+
+func TestSparklineWindow_excludesVariantsOutsideTheServedSet(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueID := "POE-133-spw-variant"
+	registerLeague(t, pool, leagueID)
+
+	tm := futureTime(34)
+	cleanupAtTime(t, pool, tm, "gem_snapshots")
+
+	// The collector writes poe.ninja's variant verbatim ("default" when empty),
+	// so an unfiltered query opens the key space to variants nothing serves.
+	const name = "POE133 Variant Gem"
+	seedGemSnapshot(t, pool, leagueID, tm, name, "default", true, false, 111, 10, "BLUE")
+	seedGemSnapshot(t, pool, leagueID, tm, name, "20", true, false, 222, 20, "BLUE")
+
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	if err != nil {
+		t.Fatalf("SparklineWindow: %v", err)
+	}
+	if _, ok := series[sparklineKey{name: name, variant: "default"}]; ok {
+		t.Errorf("variant %q is outside the served set {1, 1/20, 20, 20/20} but was cached", "default")
+	}
+	if _, ok := series[sparklineKey{name: name, variant: "20"}]; !ok {
+		t.Errorf("variant %q is in the served set but is missing", "20")
+	}
+}
+
+func TestSparklineWindow_returnsOnlyRowsNewerThanSince(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueID := "POE-133-spw-since"
+	registerLeague(t, pool, leagueID)
+
+	older := futureTime(35)
+	newer := older.Add(time.Hour)
+	cleanupAtTime(t, pool, older, "gem_snapshots")
+	cleanupAtTime(t, pool, newer, "gem_snapshots")
+
+	// The incremental population path passes its high-water mark as `since`;
+	// re-reading already-merged rows would duplicate points on every tick.
+	const name = "POE133 Since Gem"
+	seedGemSnapshot(t, pool, leagueID, older, name, "20/20", true, false, 111, 10, "BLUE")
+	seedGemSnapshot(t, pool, leagueID, newer, name, "20/20", true, false, 222, 20, "BLUE")
+
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), older, 24)
+	if err != nil {
+		t.Fatalf("SparklineWindow: %v", err)
+	}
+	points := series[sparklineKey{name: name, variant: "20/20"}]
+	if len(points) != 1 {
+		t.Fatalf("point count = %d, want 1 (only the row after `since`); 2 means `since` was ignored", len(points))
+	}
+	if !valuesClose(points[0].Price, 222) {
+		t.Errorf("price = %v, want 222 (the newer row); 111 is the row at `since`, which is not strictly newer", points[0].Price)
+	}
+}
+
+func TestSparklineWindow_returnsOnlyScopedLeague(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueA, leagueB := "POE-133-spw-A", "POE-133-spw-B"
+	registerLeague(t, pool, leagueA)
+	registerLeague(t, pool, leagueB)
+
+	tm := futureTime(36)
+	cleanupAtTime(t, pool, tm, "gem_snapshots")
+
+	const name = "POE133 Scoped Gem"
+	seedGemSnapshot(t, pool, leagueA, tm, name, "20/20", true, false, 111, 10, "BLUE")
+	seedGemSnapshot(t, pool, leagueB, tm, name, "20/20", true, false, 222, 20, "BLUE")
+
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueA), time.Time{}, 24)
+	if err != nil {
+		t.Fatalf("SparklineWindow: %v", err)
+	}
+	// The map keys on (name, variant), not league, so an unscoped query folds
+	// both leagues' points into this one series.
+	points := series[sparklineKey{name: name, variant: "20/20"}]
+	if len(points) != 1 {
+		t.Fatalf("point count = %d, want 1 (only league %q)", len(points), leagueA)
+	}
+	if !valuesClose(points[0].Price, 111) {
+		t.Errorf("price = %v, want 111 (league %q); 222 means the query read league %q", points[0].Price, leagueA, leagueB)
+	}
+}
+
+func TestSparklineWindow_returnsEmptyMapsWhenNothingMatches(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	// A league registered but never collected — the shape a fresh league has for
+	// its first tick. Population must treat it as "nothing yet", not an error.
+	leagueID := "POE-133-spw-empty"
+	registerLeague(t, pool, leagueID)
+
+	series, corrupted, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	if err != nil {
+		t.Fatalf("SparklineWindow on an empty league: %v", err)
+	}
+	if series == nil || corrupted == nil {
+		t.Fatalf("maps = (%v, %v), want non-nil empties; a nil map forces every caller to nil-check", series == nil, corrupted == nil)
+	}
+	if len(series) != 0 || len(corrupted) != 0 {
+		t.Errorf("series/corrupted sizes = %d/%d, want 0/0 for a league with no snapshots", len(series), len(corrupted))
+	}
+}
+
 func TestGemNamesAutocomplete_returnsOnlyScopedLeague(t *testing.T) {
 	pool := labIntegrationPool(t)
 	ctx := context.Background()

--- a/internal/lab/repository_integration_test.go
+++ b/internal/lab/repository_integration_test.go
@@ -237,6 +237,14 @@ func TestSparklineData_returnsOnlyScopedLeague(t *testing.T) {
 // map, and the corrupted split.
 // ---------------------------------------------------------------------------
 
+// spwBounds is the read bound for the filter tests: a window wide enough that
+// every seeded row lands in the window half, so those tests observe the filters
+// alone rather than the window/tail split. The bounded-cold-read tests below set
+// their own bounds.
+func spwBounds(hours int) SparklineBounds {
+	return SparklineBounds{WindowHours: hours, TailPoints: SparklineTailPoints, LookbackHours: hours}
+}
+
 func TestSparklineWindow_returnsBaseGems(t *testing.T) {
 	pool := labIntegrationPool(t)
 	ctx := context.Background()
@@ -253,7 +261,7 @@ func TestSparklineWindow_returnsBaseGems(t *testing.T) {
 	const name = "POE133 Base Only Gem"
 	seedGemSnapshot(t, pool, leagueID, tm, name, "20/20", false, false, 111, 10, "BLUE")
 
-	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, spwBounds(24))
 	if err != nil {
 		t.Fatalf("SparklineWindow: %v", err)
 	}
@@ -285,7 +293,7 @@ func TestSparklineWindow_returnsGemsBelowTheChaosFloor(t *testing.T) {
 	const name = "POE133 Cheap Gem"
 	seedGemSnapshot(t, pool, leagueID, tm, name, "20/20", true, false, 3, 10, "BLUE")
 
-	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, spwBounds(24))
 	if err != nil {
 		t.Fatalf("SparklineWindow: %v", err)
 	}
@@ -314,7 +322,7 @@ func TestSparklineWindow_returnsTrarthusGems(t *testing.T) {
 	const name = "POE133 Trarthus Gem"
 	seedGemSnapshot(t, pool, leagueID, tm, name, "20/20", true, false, 111, 10, "BLUE")
 
-	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, spwBounds(24))
 	if err != nil {
 		t.Fatalf("SparklineWindow: %v", err)
 	}
@@ -339,7 +347,7 @@ func TestSparklineWindow_putsCorruptedRowsInTheCorruptedMap(t *testing.T) {
 	const name = "POE133 Corrupted Gem"
 	seedGemSnapshot(t, pool, leagueID, tm, name, "21/23c", true, true, 111, 10, "BLUE")
 
-	series, corrupted, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	series, corrupted, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, spwBounds(24))
 	if err != nil {
 		t.Fatalf("SparklineWindow: %v", err)
 	}
@@ -373,7 +381,7 @@ func TestSparklineWindow_excludesVariantsOutsideTheServedSet(t *testing.T) {
 	seedGemSnapshot(t, pool, leagueID, tm, name, "default", true, false, 111, 10, "BLUE")
 	seedGemSnapshot(t, pool, leagueID, tm, name, "20", true, false, 222, 20, "BLUE")
 
-	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, spwBounds(24))
 	if err != nil {
 		t.Fatalf("SparklineWindow: %v", err)
 	}
@@ -404,7 +412,7 @@ func TestSparklineWindow_returnsOnlyRowsNewerThanSince(t *testing.T) {
 	seedGemSnapshot(t, pool, leagueID, older, name, "20/20", true, false, 111, 10, "BLUE")
 	seedGemSnapshot(t, pool, leagueID, newer, name, "20/20", true, false, 222, 20, "BLUE")
 
-	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), older, 24)
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), older, spwBounds(24))
 	if err != nil {
 		t.Fatalf("SparklineWindow: %v", err)
 	}
@@ -433,7 +441,7 @@ func TestSparklineWindow_returnsOnlyScopedLeague(t *testing.T) {
 	seedGemSnapshot(t, pool, leagueA, tm, name, "20/20", true, false, 111, 10, "BLUE")
 	seedGemSnapshot(t, pool, leagueB, tm, name, "20/20", true, false, 222, 20, "BLUE")
 
-	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueA), time.Time{}, 24)
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueA), time.Time{}, spwBounds(24))
 	if err != nil {
 		t.Fatalf("SparklineWindow: %v", err)
 	}
@@ -458,7 +466,7 @@ func TestSparklineWindow_returnsEmptyMapsWhenNothingMatches(t *testing.T) {
 	leagueID := "POE-133-spw-empty"
 	registerLeague(t, pool, leagueID)
 
-	series, corrupted, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, 24)
+	series, corrupted, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, spwBounds(24))
 	if err != nil {
 		t.Fatalf("SparklineWindow on an empty league: %v", err)
 	}
@@ -467,6 +475,153 @@ func TestSparklineWindow_returnsEmptyMapsWhenNothingMatches(t *testing.T) {
 	}
 	if len(series) != 0 || len(corrupted) != 0 {
 		t.Errorf("series/corrupted sizes = %d/%d, want 0/0 for a league with no snapshots", len(series), len(corrupted))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SparklineWindow — the bounded cold read.
+//
+// The tests above seed far-future instants so every row lands inside any window;
+// these seed relative to NOW() so the window/tail split is observable. A cold
+// read must return the served window in full plus only a short per-series tail
+// beyond it, never the flat lookback: that read is roughly fourteen times the
+// rows for the same cache contents, held live for the whole merge, at the one
+// moment the analysis pass is loading its own history.
+// ---------------------------------------------------------------------------
+
+// cleanupLeagueSnapshots deletes every gem_snapshots row for one league.
+// cleanupAtTime keys on an exact instant across ALL leagues, which is safe for
+// year-2099 seeds but not for seeds relative to NOW().
+func cleanupLeagueSnapshots(t *testing.T, pool *pgxpool.Pool, leagueID string) {
+	t.Helper()
+	t.Cleanup(func() {
+		if _, err := pool.Exec(context.Background(),
+			`DELETE FROM gem_snapshots WHERE league = $1`, leagueID); err != nil {
+			t.Logf("cleanup warning: delete gem_snapshots for league %q: %v", leagueID, err)
+		}
+	})
+}
+
+// sparkAges returns how many hours before now each returned point sits, rounded
+// to the nearest hour, so an assertion names ages rather than instants.
+func sparkAges(t *testing.T, now time.Time, points []SparklinePoint) []int {
+	t.Helper()
+	out := make([]int, len(points))
+	for i, p := range points {
+		at, err := time.Parse(time.RFC3339, p.Time)
+		if err != nil {
+			t.Fatalf("point %d has unparsable time %q: %v", i, p.Time, err)
+		}
+		out[i] = int(now.Sub(at).Round(time.Hour) / time.Hour)
+	}
+	return out
+}
+
+func sameInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestSparklineWindow_coldReadKeepsTheWindowAndOnlyATailBeyondIt(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueID := "POE-133-spw-cold-bounded"
+	registerLeague(t, pool, leagueID)
+	cleanupLeagueSnapshots(t, pool, leagueID)
+
+	const name = "POE133 Bounded Gem"
+	now := time.Now().UTC().Truncate(time.Second)
+	// Three rows inside the 12-hour window, five older ones inside the lookback.
+	for _, ago := range []int{1, 5, 11, 20, 30, 40, 50, 60} {
+		seedGemSnapshot(t, pool, leagueID, now.Add(-time.Duration(ago)*time.Hour),
+			name, "20/20", true, false, float64(100+ago), 10, "BLUE")
+	}
+
+	bounds := SparklineBounds{WindowHours: 12, TailPoints: 4, LookbackHours: 72}
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, bounds)
+	if err != nil {
+		t.Fatalf("SparklineWindow: %v", err)
+	}
+
+	// The three in-window rows, plus the tail extension to four points: the 20h
+	// row is the fourth-newest. 30h and older are what an unbounded read adds.
+	want := []int{20, 11, 5, 1}
+	got := sparkAges(t, now, series[sparklineKey{name: name, variant: "20/20"}])
+	if !sameInts(got, want) {
+		t.Fatalf("point ages (hours before now) = %v, want %v; the extra rows mean the cold read fetched the flat %d-hour lookback",
+			got, want, bounds.LookbackHours)
+	}
+}
+
+func TestSparklineWindow_coldReadStillReturnsATailForASeriesWithNoInWindowRows(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueID := "POE-133-spw-cold-tail"
+	registerLeague(t, pool, leagueID)
+	cleanupLeagueSnapshots(t, pool, leagueID)
+
+	// A gem that stopped appearing in snapshots: nothing inside the window, so a
+	// window-only read blanks its sparkline instead of showing its last shape.
+	const name = "POE133 Delisted Gem"
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, ago := range []int{20, 24, 28, 32, 36} {
+		seedGemSnapshot(t, pool, leagueID, now.Add(-time.Duration(ago)*time.Hour),
+			name, "20/20", true, false, float64(100+ago), 10, "BLUE")
+	}
+
+	bounds := SparklineBounds{WindowHours: 12, TailPoints: 4, LookbackHours: 72}
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, bounds)
+	if err != nil {
+		t.Fatalf("SparklineWindow: %v", err)
+	}
+
+	want := []int{32, 28, 24, 20}
+	got := sparkAges(t, now, series[sparklineKey{name: name, variant: "20/20"}])
+	if !sameInts(got, want) {
+		t.Fatalf("point ages (hours before now) = %v, want the newest %d rows %v",
+			got, bounds.TailPoints, want)
+	}
+}
+
+func TestSparklineWindow_coldReadDropsSeriesOlderThanTheLookback(t *testing.T) {
+	pool := labIntegrationPool(t)
+	ctx := context.Background()
+	repo := NewRepository(pool)
+
+	leagueID := "POE-133-spw-cold-lookback"
+	registerLeague(t, pool, leagueID)
+	cleanupLeagueSnapshots(t, pool, leagueID)
+
+	// Past the lookback a flat line from last week is worse than nothing, so the
+	// tail must not reach these rows even though the series has fewer than
+	// TailPoints inside it.
+	const name = "POE133 Ancient Gem"
+	now := time.Now().UTC().Truncate(time.Second)
+	for _, ago := range []int{80, 100} {
+		seedGemSnapshot(t, pool, leagueID, now.Add(-time.Duration(ago)*time.Hour),
+			name, "20/20", true, false, float64(100+ago), 10, "BLUE")
+	}
+
+	bounds := SparklineBounds{WindowHours: 12, TailPoints: 4, LookbackHours: 72}
+	series, _, err := repo.SparklineWindow(ctx, league.Historical(leagueID), time.Time{}, bounds)
+	if err != nil {
+		t.Fatalf("SparklineWindow: %v", err)
+	}
+
+	if points, ok := series[sparklineKey{name: name, variant: "20/20"}]; ok {
+		t.Errorf("series has %d points %v, want no series at all — every row is older than the %d-hour lookback",
+			len(points), sparkAges(t, now, points), bounds.LookbackHours)
 	}
 }
 

--- a/internal/lab/sparkline_cache.go
+++ b/internal/lab/sparkline_cache.go
@@ -184,18 +184,30 @@ func mergeSparklineMaps(existing, incoming map[sparklineKey][]SparklinePoint, no
 				out[k] = merged
 			}
 		}
-		for _, p := range pts {
-			at, err := time.Parse(time.RFC3339, p.Time)
-			if err != nil {
-				continue
-			}
-			if at.After(newest) {
-				newest = at
-			}
+		if at := newestSparklineTime(pts); at.After(newest) {
+			newest = at
 		}
 	}
 
 	return out, newest
+}
+
+// newestSparklineTime returns the newest parsable timestamp among pts (zero
+// when pts is empty or nothing parses). Unparsable points are skipped for the
+// same reason mergeSparklineSeries drops them: they cannot be positioned in
+// time, so they must not be allowed to move the high-water mark.
+func newestSparklineTime(pts []SparklinePoint) time.Time {
+	var newest time.Time
+	for _, p := range pts {
+		at, err := time.Parse(time.RFC3339, p.Time)
+		if err != nil {
+			continue
+		}
+		if at.After(newest) {
+			newest = at
+		}
+	}
+	return newest
 }
 
 // sparklineSnapshot returns both cached maps and the high-water mark in one

--- a/internal/lab/sparkline_cache.go
+++ b/internal/lab/sparkline_cache.go
@@ -24,6 +24,32 @@ const SparklineTailPoints = 4
 // from last week.
 const sparklineMaxLookbackHours = 168
 
+// SparklineBounds bounds a sparkline read so the rows fetched match the rows the
+// merge would retain. The cold read is the only caller that needs all three: it
+// pulls WindowHours in full, then the newest TailPoints rows per series within
+// LookbackHours. Reading LookbackHours flat instead costs roughly fourteen times
+// the rows for the same cache contents.
+type SparklineBounds struct {
+	// WindowHours is the rolling window every series keeps in full.
+	WindowHours int
+	// TailPoints is the number of trailing rows a series keeps beyond the
+	// window, so a delisted gem still renders its last known shape.
+	TailPoints int
+	// LookbackHours is how far back the tail may reach.
+	LookbackHours int
+}
+
+// sparklineCacheBounds is what the cache asks the source for. It mirrors the
+// retention mergeSparklineSeries applies, so the read and the merge cannot drift
+// into fetching rows nothing keeps.
+func sparklineCacheBounds() SparklineBounds {
+	return SparklineBounds{
+		WindowHours:   SparklineWindowHours,
+		TailPoints:    SparklineTailPoints,
+		LookbackHours: sparklineMaxLookbackHours,
+	}
+}
+
 // sparklineKey identifies one cached price series: a gem name paired with the
 // variant it was priced at. Prices for different variants are different markets
 // and are never merged into one series.
@@ -116,16 +142,17 @@ func mergeSparklineSeries(existing, incoming []SparklinePoint, now time.Time) []
 // repository satisfies it; tests substitute a fake so the merge and high-water
 // logic can be exercised without a database or a live tick loop.
 type sparklineSource interface {
-	SparklineWindow(ctx context.Context, scope league.Scope, since time.Time, hours int) (map[sparklineKey][]SparklinePoint, map[sparklineKey][]SparklinePoint, error)
+	SparklineWindow(ctx context.Context, scope league.Scope, since time.Time, bounds SparklineBounds) (map[sparklineKey][]SparklinePoint, map[sparklineKey][]SparklinePoint, error)
 }
 
 // populateSparklineCache reads the sparkline window and folds it into the
 // cache, replacing both maps and the high-water mark in one assignment.
 //
 // The read is incremental: only rows newer than the cached high-water mark are
-// fetched, except on a cold cache where the full window is loaded. Series that
-// receive no incoming points are still re-merged so points aging out of the
-// rolling window are trimmed.
+// fetched. A cold cache instead reads from scratch, bounded by
+// sparklineCacheBounds to the window plus a per-series tail rather than the flat
+// lookback — see SparklineBounds. Series that receive no incoming points are
+// still re-merged so points aging out of the rolling window are trimmed.
 //
 // The call is idempotent by construction, which RunV2 requires — it runs twice
 // per snapshot (the gem tick and the T+15-minute delayed recompute). A second
@@ -143,7 +170,7 @@ func populateSparklineCache(ctx context.Context, src sparklineSource, cache *Cac
 		since = time.Time{}
 	}
 
-	incoming, incomingCorrupted, err := src.SparklineWindow(ctx, scope, since, sparklineMaxLookbackHours)
+	incoming, incomingCorrupted, err := src.SparklineWindow(ctx, scope, since, sparklineCacheBounds())
 	if err != nil {
 		return fmt.Errorf("populate sparkline cache: %w", err)
 	}

--- a/internal/lab/sparkline_cache.go
+++ b/internal/lab/sparkline_cache.go
@@ -1,0 +1,122 @@
+package lab
+
+import (
+	"sort"
+	"time"
+)
+
+// SparklineWindowHours is the rolling window served to sparkline consumers.
+// Points older than now minus this many hours are dropped on merge.
+const SparklineWindowHours = 12
+
+// SparklineTailPoints is the minimum number of points a series keeps. A gem
+// that stops appearing in snapshots (delisted, or priced out of the corpus)
+// would otherwise decay to an empty sparkline inside SparklineWindowHours;
+// keeping a short tail leaves the last known shape visible.
+const SparklineTailPoints = 4
+
+// sparklineMaxLookbackHours bounds how far back the tail may reach. Past this
+// age a series is stale enough that showing nothing beats showing a flat line
+// from last week.
+const sparklineMaxLookbackHours = 168
+
+// sparklineKey identifies one cached price series: a gem name paired with the
+// variant it was priced at. Prices for different variants are different markets
+// and are never merged into one series.
+type sparklineKey struct {
+	name    string
+	variant string
+}
+
+// sparklinePointAt pairs a point with its parsed timestamp so the merge sorts
+// and windows on an instant rather than re-parsing the RFC3339 string.
+type sparklinePointAt struct {
+	pt SparklinePoint
+	at time.Time
+}
+
+// mergeSparklineSeries folds incoming points into an existing series and
+// applies the rolling window.
+//
+// The result is sorted ascending by time and deduplicated on the Time field,
+// with the first occurrence winning — existing points are never replaced by an
+// incoming point bearing the same timestamp, so a repeated pass over the same
+// snapshot is a no-op rather than a duplicate append.
+//
+// Points with a Time that does not parse as RFC3339 are dropped: they cannot be
+// windowed, and every producer writes time.Time.Format(time.RFC3339).
+//
+// Every point newer than now minus SparklineWindowHours is kept. When that
+// leaves fewer than SparklineTailPoints, the series extends backwards into the
+// older points until it reaches that count, but never past now minus
+// sparklineMaxLookbackHours.
+//
+// The returned slice is always freshly allocated — never a reslice of either
+// input. Reslicing the tail would pin the whole history backing array for a
+// delisted gem, which never appends again and so never reallocates: a leak that
+// lasts the rest of the league. Building fresh also preserves the Cache
+// contract that stored data is immutable once assigned, which in-place
+// compaction would break for a concurrent reader holding the slice header.
+func mergeSparklineSeries(existing, incoming []SparklinePoint, now time.Time) []SparklinePoint {
+	if len(existing) == 0 && len(incoming) == 0 {
+		return nil
+	}
+
+	all := make([]sparklinePointAt, 0, len(existing)+len(incoming))
+	all = appendParsedSparklinePoints(all, existing)
+	all = appendParsedSparklinePoints(all, incoming)
+	if len(all) == 0 {
+		return nil
+	}
+
+	// Stable so that equal timestamps keep input order: existing before
+	// incoming, which is what "first occurrence wins" means below.
+	sort.SliceStable(all, func(i, j int) bool { return all[i].at.Before(all[j].at) })
+
+	seen := make(map[string]struct{}, len(all))
+	deduped := make([]sparklinePointAt, 0, len(all))
+	for _, p := range all {
+		if _, dup := seen[p.pt.Time]; dup {
+			continue
+		}
+		seen[p.pt.Time] = struct{}{}
+		deduped = append(deduped, p)
+	}
+
+	windowStart := now.Add(-SparklineWindowHours * time.Hour)
+	tailFloor := now.Add(-sparklineMaxLookbackHours * time.Hour)
+
+	// First index inside the rolling window.
+	start := sort.Search(len(deduped), func(i int) bool {
+		return deduped[i].at.After(windowStart)
+	})
+
+	// Extend backwards to the tail minimum, never past the lookback floor.
+	for len(deduped)-start < SparklineTailPoints && start > 0 && deduped[start-1].at.After(tailFloor) {
+		start--
+	}
+
+	kept := deduped[start:]
+	if len(kept) == 0 {
+		return nil
+	}
+
+	out := make([]SparklinePoint, len(kept))
+	for i, p := range kept {
+		out[i] = p.pt
+	}
+	return out
+}
+
+// appendParsedSparklinePoints appends pts to dst, dropping any point whose Time
+// is not valid RFC3339.
+func appendParsedSparklinePoints(dst []sparklinePointAt, pts []SparklinePoint) []sparklinePointAt {
+	for _, p := range pts {
+		at, err := time.Parse(time.RFC3339, p.Time)
+		if err != nil {
+			continue
+		}
+		dst = append(dst, sparklinePointAt{pt: p, at: at})
+	}
+	return dst
+}

--- a/internal/lab/sparkline_cache.go
+++ b/internal/lab/sparkline_cache.go
@@ -1,8 +1,12 @@
 package lab
 
 import (
+	"context"
+	"fmt"
 	"sort"
 	"time"
+
+	"profitofexile/internal/league"
 )
 
 // SparklineWindowHours is the rolling window served to sparkline consumers.
@@ -106,6 +110,102 @@ func mergeSparklineSeries(existing, incoming []SparklinePoint, now time.Time) []
 		out[i] = p.pt
 	}
 	return out
+}
+
+// sparklineSource is the population-time read the sparkline cache needs. The
+// repository satisfies it; tests substitute a fake so the merge and high-water
+// logic can be exercised without a database or a live tick loop.
+type sparklineSource interface {
+	SparklineWindow(ctx context.Context, scope league.Scope, since time.Time, hours int) (map[sparklineKey][]SparklinePoint, map[sparklineKey][]SparklinePoint, error)
+}
+
+// populateSparklineCache reads the sparkline window and folds it into the
+// cache, replacing both maps and the high-water mark in one assignment.
+//
+// The read is incremental: only rows newer than the cached high-water mark are
+// fetched, except on a cold cache where the full window is loaded. Series that
+// receive no incoming points are still re-merged so points aging out of the
+// rolling window are trimmed.
+//
+// The call is idempotent by construction, which RunV2 requires — it runs twice
+// per snapshot (the gem tick and the T+15-minute delayed recompute). A second
+// pass over an unchanged snapshot reads no rows, merges nothing new (and the
+// merge dedupes on timestamp regardless), observes no time past the mark, and
+// so leaves the mark where it was.
+func populateSparklineCache(ctx context.Context, src sparklineSource, cache *Cache, scope league.Scope, now time.Time) error {
+	c := cache.For(scope)
+
+	existing, existingCorrupted, highWater := c.sparklineSnapshot()
+	since := highWater
+	if len(existing) == 0 && len(existingCorrupted) == 0 {
+		// Cold cache: load the whole window rather than trusting a mark that
+		// no series backs.
+		since = time.Time{}
+	}
+
+	incoming, incomingCorrupted, err := src.SparklineWindow(ctx, scope, since, sparklineMaxLookbackHours)
+	if err != nil {
+		return fmt.Errorf("populate sparkline cache: %w", err)
+	}
+
+	merged, observed := mergeSparklineMaps(existing, incoming, now)
+	mergedCorrupted, observedCorrupted := mergeSparklineMaps(existingCorrupted, incomingCorrupted, now)
+
+	if observedCorrupted.After(observed) {
+		observed = observedCorrupted
+	}
+	// Advance only to what was actually seen; an empty read leaves the mark.
+	if observed.After(highWater) {
+		highWater = observed
+	}
+
+	c.SetSparklines(merged, mergedCorrupted, highWater)
+	return nil
+}
+
+// mergeSparklineMaps folds incoming into existing key by key, returning a fresh
+// map and the newest timestamp observed among the incoming points.
+//
+// Keys present only in existing are re-merged with no incoming points so the
+// rolling window still trims them. Keys whose merge leaves nothing are dropped
+// rather than kept as empty series.
+func mergeSparklineMaps(existing, incoming map[sparklineKey][]SparklinePoint, now time.Time) (map[sparklineKey][]SparklinePoint, time.Time) {
+	out := make(map[sparklineKey][]SparklinePoint, len(existing)+len(incoming))
+	var newest time.Time
+
+	for k, pts := range existing {
+		if merged := mergeSparklineSeries(pts, incoming[k], now); len(merged) > 0 {
+			out[k] = merged
+		}
+	}
+	for k, pts := range incoming {
+		if _, done := existing[k]; !done {
+			if merged := mergeSparklineSeries(nil, pts, now); len(merged) > 0 {
+				out[k] = merged
+			}
+		}
+		for _, p := range pts {
+			at, err := time.Parse(time.RFC3339, p.Time)
+			if err != nil {
+				continue
+			}
+			if at.After(newest) {
+				newest = at
+			}
+		}
+	}
+
+	return out, newest
+}
+
+// sparklineSnapshot returns both cached maps and the high-water mark in one
+// lock acquisition. The maps are the stored ones: callers read them and build
+// replacements, never mutate them in place — the Cache contract is that stored
+// data is immutable once assigned.
+func (c *Cache) sparklineSnapshot() (map[sparklineKey][]SparklinePoint, map[sparklineKey][]SparklinePoint, time.Time) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.sparklines, c.sparklinesCorrupted, c.sparklineHighWater
 }
 
 // appendParsedSparklinePoints appends pts to dst, dropping any point whose Time

--- a/internal/lab/sparkline_cache_test.go
+++ b/internal/lab/sparkline_cache_test.go
@@ -180,6 +180,54 @@ func TestMergeSparklineSeries_ResultDoesNotAliasExistingInput(t *testing.T) {
 	}
 }
 
+// The trim/tail path is where the alias would actually happen: once the window
+// drops the head, returning the retained tail as-is is the cheap implementation,
+// and it pins the whole history backing array for a gem that never appends
+// again. The all-in-window case above never trims, so it cannot see that.
+func TestMergeSparklineSeries_TrimmedTailDoesNotAliasExistingInput(t *testing.T) {
+	now := sparklineNow()
+
+	// 40 ascending points: 39 spaced 4h apart from 166h down to 14h, then one at
+	// 2h — the only point inside the 12h window. The trim keeps that one point
+	// and the tail extension reaches back over 14h/18h/22h to satisfy
+	// SparklineTailPoints, so the result carries exactly the last 4 points of
+	// `existing`: the same content a reslice of the tail would hand back.
+	existing := make([]SparklinePoint, 0, 40)
+	for ago := 166; ago >= 14; ago -= 4 {
+		existing = append(existing, sparkPoint(now, time.Duration(ago)*time.Hour, float64(ago)))
+	}
+	existing = append(existing, sparkPoint(now, 2*time.Hour, 2))
+
+	got := mergeSparklineSeries(existing, nil, now)
+
+	// The arrangement has to actually reach the trim/tail path; if it stops doing
+	// so the mutation below proves nothing.
+	if len(got) != SparklineTailPoints {
+		t.Fatalf("merged length: got %d (%v), want the tail minimum %d — the trim/tail path did not run",
+			len(got), sparkTimes(got), SparklineTailPoints)
+	}
+	head := existing[:len(existing)-SparklineTailPoints]
+	tail := existing[len(existing)-SparklineTailPoints:]
+	if got[0].Time != tail[0].Time {
+		t.Fatalf("oldest kept point: got %s, want %s (22h — the 4th-newest)", got[0].Time, tail[0].Time)
+	}
+
+	before := append([]SparklinePoint(nil), got...)
+
+	// Both halves: the tail catches a reslice of the retained points, the head
+	// catches a result that kept any trimmed-away point by reference.
+	for i := range head {
+		head[i].Price = 999
+	}
+	for i := range tail {
+		tail[i].Price = 999
+	}
+
+	if !reflect.DeepEqual(got, before) {
+		t.Fatalf("mutating the existing input changed the merged series:\n before: %+v\n after:  %+v", before, got)
+	}
+}
+
 // Same contract on the other input: the repository reuses its result maps across
 // consumers, so the merged series must not track later edits to the batch.
 func TestMergeSparklineSeries_ResultDoesNotAliasIncomingInput(t *testing.T) {

--- a/internal/lab/sparkline_cache_test.go
+++ b/internal/lab/sparkline_cache_test.go
@@ -317,14 +317,16 @@ func TestMergeSparklineSeries_DuplicateTimestampCollapsesToStoredPoint(t *testin
 // canned series, so the incremental-read and high-water logic can be exercised
 // without a database.
 type fakeSparklineSource struct {
-	sinceCalls []time.Time
-	series     map[sparklineKey][]SparklinePoint
-	corrupted  map[sparklineKey][]SparklinePoint
-	err        error
+	sinceCalls  []time.Time
+	boundsCalls []SparklineBounds
+	series      map[sparklineKey][]SparklinePoint
+	corrupted   map[sparklineKey][]SparklinePoint
+	err         error
 }
 
-func (f *fakeSparklineSource) SparklineWindow(_ context.Context, _ league.Scope, since time.Time, _ int) (map[sparklineKey][]SparklinePoint, map[sparklineKey][]SparklinePoint, error) {
+func (f *fakeSparklineSource) SparklineWindow(_ context.Context, _ league.Scope, since time.Time, bounds SparklineBounds) (map[sparklineKey][]SparklinePoint, map[sparklineKey][]SparklinePoint, error) {
 	f.sinceCalls = append(f.sinceCalls, since)
+	f.boundsCalls = append(f.boundsCalls, bounds)
 	if f.err != nil {
 		return nil, nil, f.err
 	}
@@ -497,6 +499,39 @@ func TestPopulateSparklineCache_ColdCacheRequestsZeroSince(t *testing.T) {
 	}
 	if !src.sinceCalls[0].IsZero() {
 		t.Fatalf("cold-cache read `since`: got %s, want the zero time (full window)", src.sinceCalls[0])
+	}
+}
+
+// The cold read happens at process start, alongside the analysis pass loading
+// its own history, and every returned point stays live for the whole merge. So
+// it must ask only for what the merge keeps — the rolling window plus a
+// per-series tail — not the flat lookback, which is fourteen times the rows for
+// the same cache contents.
+func TestPopulateSparklineCache_RequestsOnlyTheBoundsTheMergeRetains(t *testing.T) {
+	now := sparklineNow()
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	src := &fakeSparklineSource{
+		series: map[sparklineKey][]SparklinePoint{
+			{name: "Spark of Nova", variant: "20/20"}: {sparkPoint(now, time.Hour, 12)},
+		},
+	}
+	if err := populateSparklineCache(context.Background(), src, c, scope, now); err != nil {
+		t.Fatalf("populate: %v", err)
+	}
+
+	if len(src.boundsCalls) != 1 {
+		t.Fatalf("source calls: got %d, want 1", len(src.boundsCalls))
+	}
+	want := SparklineBounds{
+		WindowHours:   SparklineWindowHours,
+		TailPoints:    SparklineTailPoints,
+		LookbackHours: sparklineMaxLookbackHours,
+	}
+	if src.boundsCalls[0] != want {
+		t.Fatalf("cold read bounds: got %+v, want %+v — the read must match what mergeSparklineSeries keeps",
+			src.boundsCalls[0], want)
 	}
 }
 

--- a/internal/lab/sparkline_cache_test.go
+++ b/internal/lab/sparkline_cache_test.go
@@ -1,0 +1,551 @@
+package lab
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"profitofexile/internal/league"
+)
+
+// sparklineNow is a fixed reference instant. RFC3339 has second resolution, so a
+// truncated, explicit instant keeps every derived timestamp exactly reversible.
+func sparklineNow() time.Time {
+	return time.Date(2026, 7, 20, 12, 0, 0, 0, time.UTC)
+}
+
+// sparkPoint builds a point `ago` before now, the way the repository does:
+// RFC3339 in UTC.
+func sparkPoint(now time.Time, ago time.Duration, price float64) SparklinePoint {
+	return SparklinePoint{
+		Time:     now.Add(-ago).UTC().Format(time.RFC3339),
+		Price:    price,
+		Listings: 3,
+	}
+}
+
+// sparkTimes extracts the Time fields so a failure message names the timestamps
+// that were kept rather than dumping whole structs.
+func sparkTimes(pts []SparklinePoint) []string {
+	out := make([]string, len(pts))
+	for i, p := range pts {
+		out[i] = p.Time
+	}
+	return out
+}
+
+func hasSparkTime(pts []SparklinePoint, want string) bool {
+	for _, p := range pts {
+		if p.Time == want {
+			return true
+		}
+	}
+	return false
+}
+
+// --- mergeSparklineSeries -------------------------------------------------
+
+// A point from the newest snapshot must land at the end of the series: that is
+// the point the sparkline's right edge is drawn from.
+func TestMergeSparklineSeries_NewestIncomingPointEndsTheSeries(t *testing.T) {
+	now := sparklineNow()
+	existing := []SparklinePoint{
+		sparkPoint(now, 3*time.Hour, 10),
+		sparkPoint(now, 2*time.Hour, 11),
+		sparkPoint(now, time.Hour, 12),
+	}
+	incoming := []SparklinePoint{sparkPoint(now, 10*time.Minute, 25)}
+
+	got := mergeSparklineSeries(existing, incoming, now)
+
+	if len(got) != 4 {
+		t.Fatalf("merged length: got %d (%v), want 4", len(got), sparkTimes(got))
+	}
+	last := got[len(got)-1]
+	if last.Time != incoming[0].Time || last.Price != 25 {
+		t.Fatalf("last point: got %+v, want the incoming point %+v", last, incoming[0])
+	}
+}
+
+// Once the rolling window holds the tail minimum, older points carry no value
+// and must be dropped — otherwise the series grows for the whole league.
+func TestMergeSparklineSeries_DropsOutOfWindowPointWhenTailIsSatisfied(t *testing.T) {
+	now := sparklineNow()
+	stale := sparkPoint(now, 20*time.Hour, 99)
+	existing := []SparklinePoint{
+		stale,
+		sparkPoint(now, 4*time.Hour, 10),
+		sparkPoint(now, 3*time.Hour, 11),
+		sparkPoint(now, 2*time.Hour, 12),
+		sparkPoint(now, time.Hour, 13),
+	}
+
+	got := mergeSparklineSeries(existing, nil, now)
+
+	if len(got) != 4 {
+		t.Fatalf("merged length: got %d (%v), want the 4 in-window points", len(got), sparkTimes(got))
+	}
+	if hasSparkTime(got, stale.Time) {
+		t.Fatalf("point %s is %v old and must be dropped, got %v", stale.Time, 20*time.Hour, sparkTimes(got))
+	}
+}
+
+// A gem that stopped trading keeps a short tail so the sparkline still shows its
+// last known shape instead of collapsing to two points.
+func TestMergeSparklineSeries_ExtendsBackwardsToTailMinimum(t *testing.T) {
+	now := sparklineNow()
+	existing := []SparklinePoint{
+		sparkPoint(now, 40*time.Hour, 7),
+		sparkPoint(now, 30*time.Hour, 8),
+		sparkPoint(now, 20*time.Hour, 9),
+		sparkPoint(now, 2*time.Hour, 10),
+		sparkPoint(now, time.Hour, 11),
+	}
+
+	got := mergeSparklineSeries(existing, nil, now)
+
+	if len(got) != SparklineTailPoints {
+		t.Fatalf("merged length: got %d (%v), want the tail minimum %d",
+			len(got), sparkTimes(got), SparklineTailPoints)
+	}
+	if got[0].Time != existing[1].Time {
+		t.Fatalf("oldest kept point: got %s, want %s (30h — the 4th-newest)", got[0].Time, existing[1].Time)
+	}
+}
+
+// Past the lookback floor a flat line from last week is worse than nothing, so
+// the tail extension stops even though it leaves fewer than the tail minimum.
+func TestMergeSparklineSeries_DropsPointBeyondMaxLookbackDespiteShortTail(t *testing.T) {
+	now := sparklineNow()
+	ancient := sparkPoint(now, 200*time.Hour, 99)
+	existing := []SparklinePoint{ancient, sparkPoint(now, time.Hour, 11)}
+
+	got := mergeSparklineSeries(existing, nil, now)
+
+	if len(got) != 1 {
+		t.Fatalf("merged length: got %d (%v), want only the in-window point", len(got), sparkTimes(got))
+	}
+	if got[0].Time != existing[1].Time {
+		t.Fatalf("kept point: got %s, want %s", got[0].Time, existing[1].Time)
+	}
+}
+
+// RunV2 runs twice per snapshot (gem tick + T+15min recompute), so folding the
+// same batch a second time must be a no-op. An append without dedup doubles the
+// series here.
+func TestMergeSparklineSeries_SecondMergeOfSameBatchIsANoOp(t *testing.T) {
+	now := sparklineNow()
+	existing := []SparklinePoint{
+		sparkPoint(now, 4*time.Hour, 10),
+		sparkPoint(now, 3*time.Hour, 11),
+	}
+	incoming := []SparklinePoint{
+		sparkPoint(now, 2*time.Hour, 12),
+		sparkPoint(now, time.Hour, 13),
+	}
+
+	once := mergeSparklineSeries(existing, incoming, now)
+	twice := mergeSparklineSeries(once, incoming, now)
+
+	if !reflect.DeepEqual(once, twice) {
+		t.Fatalf("second merge of the same batch changed the series:\n once:  %v\n twice: %v",
+			sparkTimes(once), sparkTimes(twice))
+	}
+}
+
+// The cache contract is that stored data is immutable once assigned. Returning a
+// reslice of an input — which is what pinning the history backing array for the
+// tail would look like — makes the stored series follow the caller's mutation.
+func TestMergeSparklineSeries_ResultDoesNotAliasExistingInput(t *testing.T) {
+	now := sparklineNow()
+	existing := []SparklinePoint{
+		sparkPoint(now, 5*time.Hour, 10),
+		sparkPoint(now, 4*time.Hour, 11),
+		sparkPoint(now, 3*time.Hour, 12),
+		sparkPoint(now, 2*time.Hour, 13),
+		sparkPoint(now, time.Hour, 14),
+	}
+
+	got := mergeSparklineSeries(existing, nil, now)
+	wantLast := got[len(got)-1].Price
+
+	existing[len(existing)-1].Price = 999
+	existing[0].Price = 999
+
+	if got[len(got)-1].Price != wantLast {
+		t.Fatalf("mutating the existing input changed the merged series: last price %v, want %v",
+			got[len(got)-1].Price, wantLast)
+	}
+}
+
+// Same contract on the other input: the repository reuses its result maps across
+// consumers, so the merged series must not track later edits to the batch.
+func TestMergeSparklineSeries_ResultDoesNotAliasIncomingInput(t *testing.T) {
+	now := sparklineNow()
+	incoming := []SparklinePoint{
+		sparkPoint(now, 3*time.Hour, 10),
+		sparkPoint(now, 2*time.Hour, 11),
+		sparkPoint(now, time.Hour, 12),
+	}
+
+	got := mergeSparklineSeries(nil, incoming, now)
+
+	incoming[0].Price = 999
+
+	if got[0].Price != 10 {
+		t.Fatalf("mutating the incoming input changed the merged series: first price %v, want 10", got[0].Price)
+	}
+}
+
+// A tick that brings no new points for a gem still has to trim it, otherwise a
+// long-lived series never shrinks.
+func TestMergeSparklineSeries_EmptyIncomingStillTrimsToWindow(t *testing.T) {
+	now := sparklineNow()
+	existing := make([]SparklinePoint, 0, 40)
+	for ago := 40; ago >= 1; ago-- {
+		existing = append(existing, sparkPoint(now, time.Duration(ago)*time.Hour, float64(ago)))
+	}
+
+	got := mergeSparklineSeries(existing, nil, now)
+
+	// 11 hourly points fall strictly inside the 12h window (1h .. 11h ago).
+	if len(got) != 11 {
+		t.Fatalf("merged length: got %d (%v), want the 11 in-window points", len(got), sparkTimes(got))
+	}
+	oldest, err := time.Parse(time.RFC3339, got[0].Time)
+	if err != nil {
+		t.Fatalf("oldest kept point has unparsable time %q: %v", got[0].Time, err)
+	}
+	if !oldest.After(now.Add(-SparklineWindowHours * time.Hour)) {
+		t.Fatalf("oldest kept point %s is outside the %dh window", got[0].Time, SparklineWindowHours)
+	}
+}
+
+// The repository orders by time, but the merge combines two sources; the drawn
+// series is only correct if the result is ascending regardless of input order.
+func TestMergeSparklineSeries_OutOfOrderPointsProduceAscendingSeries(t *testing.T) {
+	now := sparklineNow()
+	incoming := []SparklinePoint{
+		sparkPoint(now, time.Hour, 13),
+		sparkPoint(now, 4*time.Hour, 10),
+		sparkPoint(now, 2*time.Hour, 12),
+		sparkPoint(now, 3*time.Hour, 11),
+	}
+
+	got := mergeSparklineSeries(nil, incoming, now)
+
+	if len(got) != 4 {
+		t.Fatalf("merged length: got %d (%v), want 4", len(got), sparkTimes(got))
+	}
+	for i := 1; i < len(got); i++ {
+		if got[i].Time <= got[i-1].Time {
+			t.Fatalf("series is not ascending at index %d: %v", i, sparkTimes(got))
+		}
+	}
+}
+
+// Overlapping reads of the same snapshot deliver the same timestamp twice; the
+// series must carry it once, keeping the already-stored point.
+func TestMergeSparklineSeries_DuplicateTimestampCollapsesToStoredPoint(t *testing.T) {
+	now := sparklineNow()
+	existing := []SparklinePoint{sparkPoint(now, time.Hour, 10)}
+	duplicate := sparkPoint(now, time.Hour, 77)
+
+	got := mergeSparklineSeries(existing, []SparklinePoint{duplicate}, now)
+
+	if len(got) != 1 {
+		t.Fatalf("merged length: got %d (%v), want the duplicate collapsed to 1", len(got), sparkTimes(got))
+	}
+	if got[0].Price != 10 {
+		t.Fatalf("duplicate timestamp: got price %v, want the stored 10 (first occurrence wins)", got[0].Price)
+	}
+}
+
+// --- populateSparklineCache -----------------------------------------------
+
+// fakeSparklineSource records the `since` argument of every call and replays
+// canned series, so the incremental-read and high-water logic can be exercised
+// without a database.
+type fakeSparklineSource struct {
+	sinceCalls []time.Time
+	series     map[sparklineKey][]SparklinePoint
+	corrupted  map[sparklineKey][]SparklinePoint
+	err        error
+}
+
+func (f *fakeSparklineSource) SparklineWindow(_ context.Context, _ league.Scope, since time.Time, _ int) (map[sparklineKey][]SparklinePoint, map[sparklineKey][]SparklinePoint, error) {
+	f.sinceCalls = append(f.sinceCalls, since)
+	if f.err != nil {
+		return nil, nil, f.err
+	}
+	return cloneSparklineTestMap(f.series), cloneSparklineTestMap(f.corrupted), nil
+}
+
+// cloneSparklineTestMap hands each call its own slices, matching a repository
+// that builds fresh results per query — so a test never accidentally proves
+// idempotency via shared memory.
+func cloneSparklineTestMap(in map[sparklineKey][]SparklinePoint) map[sparklineKey][]SparklinePoint {
+	if in == nil {
+		return map[sparklineKey][]SparklinePoint{}
+	}
+	out := make(map[sparklineKey][]SparklinePoint, len(in))
+	for k, pts := range in {
+		cp := make([]SparklinePoint, len(pts))
+		copy(cp, pts)
+		out[k] = cp
+	}
+	return out
+}
+
+func TestPopulateSparklineCache_ColdCacheStoresEveryReturnedSeries(t *testing.T) {
+	now := sparklineNow()
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	spark := sparkPoint(now, time.Hour, 12)
+	src := &fakeSparklineSource{
+		series: map[sparklineKey][]SparklinePoint{
+			{name: "Spark of Nova", variant: "20/20"}: {spark},
+			{name: "Spark of Nova", variant: "1"}:     {sparkPoint(now, time.Hour, 3)},
+		},
+		corrupted: map[sparklineKey][]SparklinePoint{
+			{name: "Spark of Nova", variant: "21/23c"}: {sparkPoint(now, time.Hour, 40)},
+		},
+	}
+
+	if err := populateSparklineCache(context.Background(), src, c, scope, now); err != nil {
+		t.Fatalf("populate: %v", err)
+	}
+
+	got := c.For(scope).Sparklines("Spark of Nova", "20/20")
+	if len(got) != 1 || got[0].Price != 12 || got[0].Time != spark.Time {
+		t.Fatalf("20/20 series: got %+v, want the stored point %+v", got, spark)
+	}
+	if got := c.For(scope).Sparklines("Spark of Nova", "1"); len(got) != 1 || got[0].Price != 3 {
+		t.Fatalf("1 series: got %+v, want the 3c point", got)
+	}
+	if got := c.For(scope).SparklinesCorrupted("Spark of Nova", "21/23c"); len(got) != 1 || got[0].Price != 40 {
+		t.Fatalf("corrupted series: got %+v, want the 40c point", got)
+	}
+}
+
+// RunV2 runs twice per snapshot. A second pass over unchanged source data must
+// leave the series byte-identical — appending without dedup doubles them.
+func TestPopulateSparklineCache_SecondPassLeavesContentIdentical(t *testing.T) {
+	now := sparklineNow()
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+	key := sparklineKey{name: "Spark of Nova", variant: "20/20"}
+
+	src := &fakeSparklineSource{
+		series: map[sparklineKey][]SparklinePoint{
+			key: {sparkPoint(now, 2*time.Hour, 11), sparkPoint(now, time.Hour, 12)},
+		},
+	}
+
+	if err := populateSparklineCache(context.Background(), src, c, scope, now); err != nil {
+		t.Fatalf("first populate: %v", err)
+	}
+	first := c.For(scope).Sparklines(key.name, key.variant)
+
+	if err := populateSparklineCache(context.Background(), src, c, scope, now); err != nil {
+		t.Fatalf("second populate: %v", err)
+	}
+	second := c.For(scope).Sparklines(key.name, key.variant)
+
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("second pass changed the cached series:\n first:  %v\n second: %v",
+			sparkTimes(first), sparkTimes(second))
+	}
+}
+
+// An empty incremental read means nothing new was collected, so the mark must
+// stay put rather than jump to the wall clock and skip future rows.
+func TestPopulateSparklineCache_EmptySecondReadLeavesHighWaterUnchanged(t *testing.T) {
+	now := sparklineNow()
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+	key := sparklineKey{name: "Spark of Nova", variant: "20/20"}
+
+	src := &fakeSparklineSource{
+		series: map[sparklineKey][]SparklinePoint{key: {sparkPoint(now, time.Hour, 12)}},
+	}
+	if err := populateSparklineCache(context.Background(), src, c, scope, now); err != nil {
+		t.Fatalf("first populate: %v", err)
+	}
+	mark := c.For(scope).SparklineHighWater()
+
+	src.series = map[sparklineKey][]SparklinePoint{}
+	if err := populateSparklineCache(context.Background(), src, c, scope, now); err != nil {
+		t.Fatalf("second populate: %v", err)
+	}
+
+	if got := c.For(scope).SparklineHighWater(); !got.Equal(mark) {
+		t.Fatalf("high-water after an empty read: got %s, want the unchanged %s", got, mark)
+	}
+}
+
+// The whole point of the mark is that the second read is incremental: it must
+// ask for rows after the newest point already folded in.
+func TestPopulateSparklineCache_SecondPassRequestsSinceEqualToStoredMark(t *testing.T) {
+	now := sparklineNow()
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	src := &fakeSparklineSource{
+		series: map[sparklineKey][]SparklinePoint{
+			{name: "Spark of Nova", variant: "20/20"}: {sparkPoint(now, time.Hour, 12)},
+		},
+	}
+	if err := populateSparklineCache(context.Background(), src, c, scope, now); err != nil {
+		t.Fatalf("first populate: %v", err)
+	}
+	mark := c.For(scope).SparklineHighWater()
+
+	if err := populateSparklineCache(context.Background(), src, c, scope, now); err != nil {
+		t.Fatalf("second populate: %v", err)
+	}
+
+	if len(src.sinceCalls) != 2 {
+		t.Fatalf("source calls: got %d, want 2", len(src.sinceCalls))
+	}
+	if src.sinceCalls[1].IsZero() {
+		t.Fatalf("second read asked for a zero `since` — the read is not incremental")
+	}
+	if !src.sinceCalls[1].Equal(mark) {
+		t.Fatalf("second read `since`: got %s, want the stored mark %s", src.sinceCalls[1], mark)
+	}
+}
+
+// A cache whose series have all aged out still carries the old mark. Reading
+// incrementally from it would leave the cache permanently empty, so an empty
+// cache must reload the full window regardless of the mark.
+func TestPopulateSparklineCache_ColdCacheRequestsZeroSince(t *testing.T) {
+	now := sparklineNow()
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	staleMark := now.Add(-200 * time.Hour)
+	c.For(scope).SetSparklines(
+		map[sparklineKey][]SparklinePoint{},
+		map[sparklineKey][]SparklinePoint{},
+		staleMark,
+	)
+
+	src := &fakeSparklineSource{
+		series: map[sparklineKey][]SparklinePoint{
+			{name: "Spark of Nova", variant: "20/20"}: {sparkPoint(now, time.Hour, 12)},
+		},
+	}
+
+	if err := populateSparklineCache(context.Background(), src, c, scope, now); err != nil {
+		t.Fatalf("populate: %v", err)
+	}
+
+	if len(src.sinceCalls) != 1 {
+		t.Fatalf("source calls: got %d, want 1", len(src.sinceCalls))
+	}
+	if !src.sinceCalls[0].IsZero() {
+		t.Fatalf("cold-cache read `since`: got %s, want the zero time (full window)", src.sinceCalls[0])
+	}
+}
+
+// Snapshots lag the clock. Advancing the mark to `now` would skip every row
+// written between the newest observed point and the read.
+func TestPopulateSparklineCache_HighWaterAdvancesToNewestPointNotWallClock(t *testing.T) {
+	now := sparklineNow()
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+
+	newest := now.Add(-3 * time.Hour)
+	src := &fakeSparklineSource{
+		series: map[sparklineKey][]SparklinePoint{
+			{name: "Spark of Nova", variant: "20/20"}: {
+				sparkPoint(now, 5*time.Hour, 10),
+				sparkPoint(now, 3*time.Hour, 12),
+			},
+		},
+	}
+
+	if err := populateSparklineCache(context.Background(), src, c, scope, now); err != nil {
+		t.Fatalf("populate: %v", err)
+	}
+
+	if got := c.For(scope).SparklineHighWater(); !got.Equal(newest) {
+		t.Fatalf("high-water: got %s, want the newest observed point %s", got, newest)
+	}
+}
+
+// A gem that stops appearing in snapshots still has to age out; the merge must
+// run for cached keys the read did not return.
+func TestPopulateSparklineCache_UntouchedSeriesIsRemergedAndTrimmed(t *testing.T) {
+	now := sparklineNow()
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+	stale := sparklineKey{name: "Delisted Gem", variant: "20/20"}
+
+	aged := []SparklinePoint{
+		sparkPoint(now, 30*time.Hour, 5),
+		sparkPoint(now, 29*time.Hour, 6),
+		sparkPoint(now, 28*time.Hour, 7),
+		sparkPoint(now, 27*time.Hour, 8),
+		sparkPoint(now, 26*time.Hour, 9),
+		sparkPoint(now, 25*time.Hour, 10),
+	}
+	c.For(scope).SetSparklines(
+		map[sparklineKey][]SparklinePoint{stale: aged},
+		map[sparklineKey][]SparklinePoint{},
+		now.Add(-25*time.Hour),
+	)
+
+	src := &fakeSparklineSource{
+		series: map[sparklineKey][]SparklinePoint{
+			{name: "Spark of Nova", variant: "20/20"}: {sparkPoint(now, time.Hour, 12)},
+		},
+	}
+	if err := populateSparklineCache(context.Background(), src, c, scope, now); err != nil {
+		t.Fatalf("populate: %v", err)
+	}
+
+	got := c.For(scope).Sparklines(stale.name, stale.variant)
+	if len(got) != SparklineTailPoints {
+		t.Fatalf("untouched series: got %d points (%v), want it trimmed to the tail minimum %d",
+			len(got), sparkTimes(got), SparklineTailPoints)
+	}
+	if hasSparkTime(got, aged[0].Time) {
+		t.Fatalf("untouched series kept its oldest point %s: %v", aged[0].Time, sparkTimes(got))
+	}
+}
+
+// A failed read must leave the warm cache serving what it had, not blank it.
+func TestPopulateSparklineCache_SourceErrorLeavesCacheAndMarkUnchanged(t *testing.T) {
+	now := sparklineNow()
+	scope := league.Historical("LeagueA")
+	c := NewCache(scope)
+	key := sparklineKey{name: "Spark of Nova", variant: "20/20"}
+
+	seeded := []SparklinePoint{sparkPoint(now, time.Hour, 12)}
+	mark := now.Add(-time.Hour)
+	c.For(scope).SetSparklines(
+		map[sparklineKey][]SparklinePoint{key: seeded},
+		map[sparklineKey][]SparklinePoint{},
+		mark,
+	)
+
+	src := &fakeSparklineSource{err: errors.New("query gem_snapshots: connection refused")}
+	err := populateSparklineCache(context.Background(), src, c, scope, now)
+
+	if err == nil {
+		t.Fatalf("populate: got nil error, want the source error surfaced")
+	}
+	got := c.For(scope).Sparklines(key.name, key.variant)
+	if !reflect.DeepEqual(got, seeded) {
+		t.Fatalf("cached series after a failed read: got %v, want the untouched %v",
+			sparkTimes(got), sparkTimes(seeded))
+	}
+	if hw := c.For(scope).SparklineHighWater(); !hw.Equal(mark) {
+		t.Fatalf("high-water after a failed read: got %s, want the untouched %s", hw, mark)
+	}
+}

--- a/internal/server/handlers/analysis.go
+++ b/internal/server/handlers/analysis.go
@@ -495,15 +495,6 @@ func TrendAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Scope) h
 			}
 		}
 
-		// Load MarketContext for sparkline normalization.
-		var trendMC *lab.MarketContext
-		if cache != nil {
-			trendMC = cache.For(scope).MarketContext()
-		}
-		if trendMC == nil {
-			trendMC, _ = repo.LatestMarketContext(r.Context(), scope)
-		}
-
 		// Batch fetch sparkline data grouped by variant.
 		type trendData struct {
 			prices, listings, baseListings []int
@@ -542,22 +533,32 @@ func TrendAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Scope) h
 				return pts
 			}
 
-			for v, g := range groups {
-				transSparklines, err := repo.SparklineData(r.Context(), scope, g.transNames, v, 24*7)
-				if err != nil {
-					slog.Warn("trend analysis: trans sparkline batch failed", "variant", v, "error", err)
-					transSparklines = make(map[string][]lab.SparklinePoint)
-				}
-				// Normalize trans sparkline prices with temporal coefficients.
-				// Raw prices — normalization creates edge artifacts
+			// A warm cache holds the full series each group needs, so no
+			// gem_snapshots query is issued; last4 trims to the points the row
+			// actually shows. Raw prices either way — normalization creates
+			// edge artifacts.
+			warmSparklines := cache != nil && cache.For(scope).HasSparklines()
 
-				baseSparklines, err := repo.SparklineData(r.Context(), scope, g.baseNames, v, 24*7)
-				if err != nil {
-					slog.Warn("trend analysis: base sparkline batch failed", "variant", v, "error", err)
-					baseSparklines = make(map[string][]lab.SparklinePoint)
+			for v, g := range groups {
+				var transSparklines, baseSparklines map[string][]lab.SparklinePoint
+
+				if warmSparklines {
+					transSparklines = cachedSparklines(cache, scope, g.transNames, v, 0)
+					baseSparklines = cachedSparklines(cache, scope, g.baseNames, v, 0)
+				} else {
+					var err error
+					transSparklines, err = repo.SparklineData(r.Context(), scope, g.transNames, v, 24*7)
+					if err != nil {
+						slog.Warn("trend analysis: trans sparkline batch failed", "variant", v, "error", err)
+						transSparklines = make(map[string][]lab.SparklinePoint)
+					}
+
+					baseSparklines, err = repo.SparklineData(r.Context(), scope, g.baseNames, v, 24*7)
+					if err != nil {
+						slog.Warn("trend analysis: base sparkline batch failed", "variant", v, "error", err)
+						baseSparklines = make(map[string][]lab.SparklinePoint)
+					}
 				}
-				// Normalize base sparklines consistently with trans sparklines.
-				// Raw prices — normalization creates edge artifacts
 
 				for idx, key := range g.gems {
 					td := trendData{}
@@ -1179,42 +1180,6 @@ func GemSignalsAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Sco
 			slog.Error("gem signals: encode response", "error", err)
 		}
 	}
-}
-
-// normalizeSparklines applies temporal normalization to sparkline price data
-// so the sparkline visually matches what the signal classifier sees.
-// The repository returns raw prices; this function divides each price by
-// the temporal coefficient for that point's timestamp and variant.
-// mc may be nil — in that case the data is returned unchanged.
-func normalizeSparklines(sparklines map[string][]lab.SparklinePoint, mc *lab.MarketContext, variant string) map[string][]lab.SparklinePoint {
-	if mc == nil || mc.TemporalMode == "none" || mc.TemporalMode == "" || len(mc.TemporalBuckets) == 0 {
-		return sparklines
-	}
-
-	// Parse bucket data ONCE — CoefficientAt parses JSON on every call which is
-	// too expensive when iterating thousands of sparkline points.
-	var bucketData map[string][]lab.TemporalBucket
-	if err := json.Unmarshal(mc.TemporalBuckets, &bucketData); err != nil {
-		return sparklines
-	}
-
-	result := make(map[string][]lab.SparklinePoint, len(sparklines))
-	for name, pts := range sparklines {
-		normalized := make([]lab.SparklinePoint, len(pts))
-		for i, p := range pts {
-			normalized[i] = p
-			t, err := time.Parse(time.RFC3339, p.Time)
-			if err != nil {
-				continue // keep raw price on parse error
-			}
-			coeff := lab.LookupCoefficient(bucketData, mc.TemporalMode, t, variant)
-			if coeff > 0 {
-				normalized[i].Price = p.Price / coeff
-			}
-		}
-		result[name] = normalized
-	}
-	return result
 }
 
 // MarketOverview returns an aggregated market overview built from cached data.

--- a/internal/server/handlers/collective.go
+++ b/internal/server/handlers/collective.go
@@ -43,8 +43,7 @@ type collectiveRow struct {
 	SellReason           string               `json:"sellReason"`
 	Sellability          int                  `json:"sellability"`
 	SellabilityLabel     string               `json:"sellabilityLabel"`
-	Sparkline            []lab.SparklinePoint  `json:"sparkline"`
-	SparklineListings    []lab.SparklinePoint  `json:"sparklineListings,omitempty"`
+	Sparkline            []lab.SparklinePoint `json:"sparkline"`
 	Low7Days             float64              `json:"low7d"`
 	High7Days            float64              `json:"high7d"`
 	SellConfidence       string               `json:"sellConfidence"`
@@ -53,6 +52,71 @@ type collectiveRow struct {
 	GCPRecipeCost        float64              `json:"gcpRecipeCost,omitempty"`
 	GCPRecipeBase        float64              `json:"gcpRecipeBase,omitempty"`
 	GCPRecipeSaves       float64              `json:"gcpRecipeSaves,omitempty"`
+}
+
+// sparklineWindowHours is the window sparkline responses have always covered.
+// The lab cache stores a longer series than this — up to a 168-hour tail for
+// gems that stopped appearing in snapshots — so the window is applied when the
+// response is built, not when the cache is filled.
+const sparklineWindowHours = 12
+
+// trimSparkline returns the suffix of pts newer than hours ago. Points are
+// stored ascending by time, so the first point inside the window starts the
+// suffix. hours <= 0 means "no trim" (the caller serves the full cached series).
+func trimSparkline(pts []lab.SparklinePoint, hours int) []lab.SparklinePoint {
+	if hours <= 0 || len(pts) == 0 {
+		return pts
+	}
+	cutoff := time.Now().Add(-time.Duration(hours) * time.Hour)
+	for i, p := range pts {
+		t, err := time.Parse(time.RFC3339, p.Time)
+		if err != nil {
+			continue
+		}
+		if t.After(cutoff) {
+			return pts[i:]
+		}
+	}
+	return nil
+}
+
+// cachedSparklines collects the cached non-corrupted series for names at a
+// single variant, keyed by name so the result is a drop-in for what
+// Repository.SparklineData returns. Names with no cached points are omitted:
+// on a warm cache that means the gem genuinely has no recent points, which is
+// the same empty series the query would have produced.
+func cachedSparklines(cache *lab.Cache, scope league.Scope, names []string, variant string, hours int) map[string][]lab.SparklinePoint {
+	c := cache.For(scope)
+	out := make(map[string][]lab.SparklinePoint, len(names))
+	for _, n := range names {
+		if pts := trimSparkline(c.Sparklines(n, variant), hours); len(pts) > 0 {
+			out[n] = pts
+		}
+	}
+	return out
+}
+
+// cachedCorruptedVariant is the only corrupted variant the lab cache stores
+// series for — the Dedication (21/23c) pool. It mirrors the population query's
+// filter in internal/lab.
+const cachedCorruptedVariant = "21/23c"
+
+// cachedCorruptedSparklines collects cached corrupted series for names, keyed
+// by name. The second return reports whether the cache could serve the request
+// at all: a cold cache, or a variant the cache never populates, must go to the
+// database rather than hand back an empty series.
+func cachedCorruptedSparklines(cache *lab.Cache, scope league.Scope, names []string, variant string, hours int) (map[string][]lab.SparklinePoint, bool) {
+	if cache == nil || variant != cachedCorruptedVariant || !cache.For(scope).HasSparklines() {
+		return nil, false
+	}
+	c := cache.For(scope)
+	out := make(map[string][]lab.SparklinePoint, len(names))
+	for _, n := range names {
+		if pts := trimSparkline(c.SparklinesCorrupted(n, variant), hours); len(pts) > 0 {
+			out[n] = pts
+		}
+	}
+	return out, true
 }
 
 // CollectiveAnalysis returns a ranked "what to farm now" list combining
@@ -182,29 +246,35 @@ func CollectiveAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Sco
 			slog.Warn("collective: GCP price not cached, using fallback", "fallback", gcpPrice)
 		}
 
-		// Fetch sparkline data for the result gems.
-		// When a specific variant is selected, one query suffices. When "ALL
-		// variants", group gems by their own variant and query per group so
-		// sparklines don't mix different variant prices.
+		// Sparkline data for the result gems.
+		// Warm cache: every gem/variant series the pipeline populates is in
+		// memory, so no gem_snapshots query is issued — not even for a gem the
+		// cache has no series for, which genuinely has no recent points.
+		// Cold cache: fall back to the queries. When a specific variant is
+		// selected one query suffices; when "ALL variants", group gems by their
+		// own variant and query per group so sparklines don't mix variant prices.
 		sparkVariant := r.URL.Query().Get("variant")
 		sparklines := make(map[string][]lab.SparklinePoint)
 
-		// Load MarketContext for sparkline normalization.
-		var mc *lab.MarketContext
-		if cache != nil {
-			mc = cache.For(scope).MarketContext()
-		}
-		if mc == nil {
-			mc, _ = repo.LatestMarketContext(r.Context(), scope)
-		}
-
-		if sparkVariant != "" {
+		if cache != nil && cache.For(scope).HasSparklines() {
+			c := cache.For(scope)
+			for _, cr := range results {
+				v := sparkVariant
+				if v == "" {
+					v = cr.Variant
+				}
+				// Raw prices — normalization creates edge artifacts
+				if pts := trimSparkline(c.Sparklines(cr.TransfiguredName, v), sparklineWindowHours); len(pts) > 0 {
+					sparklines[cr.TransfiguredName] = pts
+				}
+			}
+		} else if sparkVariant != "" {
 			// Single variant — one query for all gems.
 			sparkNames := make([]string, 0, len(results))
 			for _, cr := range results {
 				sparkNames = append(sparkNames, cr.TransfiguredName)
 			}
-			sp, err := repo.SparklineData(r.Context(), scope, sparkNames, sparkVariant, 12)
+			sp, err := repo.SparklineData(r.Context(), scope, sparkNames, sparkVariant, sparklineWindowHours)
 			if err != nil {
 				slog.Error("collective analysis: sparkline query failed", "error", err)
 			} else {
@@ -217,7 +287,7 @@ func CollectiveAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Sco
 				byVariant[cr.Variant] = append(byVariant[cr.Variant], cr.TransfiguredName)
 			}
 			for v, names := range byVariant {
-				sp, err := repo.SparklineData(r.Context(), scope, names, v, 12)
+				sp, err := repo.SparklineData(r.Context(), scope, names, v, sparklineWindowHours)
 				if err != nil {
 					slog.Error("collective analysis: sparkline query failed", "variant", v, "error", err)
 					continue
@@ -345,8 +415,6 @@ func serveDedicationCollective(w http.ResponseWriter, r *http.Request, repo *lab
 			Confidence:           cr.Confidence,
 			SellConfidence:       cr.SellConfidence,
 			LowConfidence:        cr.LowConfidence,
-			Sparkline:            []lab.SparklinePoint{},
-			SparklineListings:    []lab.SparklinePoint{},
 		})
 	}
 
@@ -494,18 +562,27 @@ func CompareAnalysis(repo *lab.Repository, cache *lab.Cache, tradeCache *trade.T
 			}
 		}
 
-		// Load sparkline data (last 12 hours) and normalize with temporal coefficients.
+		// Load sparkline data (last 12 hours).
 		var warnings []string
 		// NOTE: sparkline failure logs + appends a warning then CONTINUES (no early return),
 		// so spMs reflects the actual query duration even on error (not zero).
 		spStart := time.Now()
-		sparklines, err := repo.SparklineData(r.Context(), scope, names, variant, 12)
-		spMs = time.Since(spStart).Milliseconds()
-		if err != nil {
-			slog.Error("compare analysis: sparkline query failed", "error", err)
-			sparklines = make(map[string][]lab.SparklinePoint)
-			warnings = append(warnings, "Sparkline data temporarily unavailable")
+		var sparklines map[string][]lab.SparklinePoint
+		// The cache keys a series by name AND variant, so it cannot reproduce
+		// the mixed-variant series an empty variant returns today — that case
+		// stays on the query.
+		if variant != "" && cache != nil && cache.For(scope).HasSparklines() {
+			sparklines = cachedSparklines(cache, scope, names, variant, sparklineWindowHours)
+		} else {
+			sp, err := repo.SparklineData(r.Context(), scope, names, variant, sparklineWindowHours)
+			if err != nil {
+				slog.Error("compare analysis: sparkline query failed", "error", err)
+				sp = make(map[string][]lab.SparklinePoint)
+				warnings = append(warnings, "Sparkline data temporarily unavailable")
+			}
+			sparklines = sp
 		}
+		spMs = time.Since(spStart).Milliseconds()
 
 		// Sparkline normalization removed — temporal coefficients create edge artifacts
 
@@ -570,12 +647,20 @@ func serveDedicationCompare(w http.ResponseWriter, r *http.Request, repo *lab.Re
 	}
 
 	// Load sparkline data for corrupted gems (last 12 hours).
+	// The cache populates corrupted series for the Dedication variant only, so
+	// the read is guarded on it: any other variant has no cached series and must
+	// go to the query rather than read an empty series out of a warm cache.
+	const dedicationSparklineVariant = "21/23c"
 	var warnings []string
-	sparklines, err := repo.SparklineDataCorrupted(r.Context(), scope, names, "21/23c", 12)
-	if err != nil {
-		slog.Error("compare analysis (dedication): sparkline query failed", "error", err)
-		sparklines = make(map[string][]lab.SparklinePoint)
-		warnings = append(warnings, "Sparkline data temporarily unavailable")
+	sparklines, cached := cachedCorruptedSparklines(cache, scope, names, dedicationSparklineVariant, sparklineWindowHours)
+	if !cached {
+		sp, err := repo.SparklineDataCorrupted(r.Context(), scope, names, dedicationSparklineVariant, sparklineWindowHours)
+		if err != nil {
+			slog.Error("compare analysis (dedication): sparkline query failed", "error", err)
+			sp = make(map[string][]lab.SparklinePoint)
+			warnings = append(warnings, "Sparkline data temporarily unavailable")
+		}
+		sparklines = sp
 	}
 
 	results := lab.BuildDedicationCompareResults(names, gemPrices, dedicationResults, sparklines)

--- a/internal/server/handlers/collective.go
+++ b/internal/server/handlers/collective.go
@@ -97,6 +97,18 @@ func cachedSparklines(cache *lab.Cache, scope league.Scope, names []string, vari
 	return out
 }
 
+// nonNilSparkline returns pts, or an empty slice when pts is nil.
+//
+// collectiveRow.Sparkline carries no omitempty, so a nil slice marshals as
+// `null` while an empty one marshals as `[]`. Both collective modes must emit
+// the same shape, so every row literal runs its series through this.
+func nonNilSparkline(pts []lab.SparklinePoint) []lab.SparklinePoint {
+	if pts == nil {
+		return []lab.SparklinePoint{}
+	}
+	return pts
+}
+
 // cachedCorruptedVariant is the only corrupted variant the lab cache stores
 // series for — the Dedication (21/23c) pool. It mirrors the population query's
 // filter in internal/lab.
@@ -111,7 +123,9 @@ func cachedCorruptedSparklines(cache *lab.Cache, scope league.Scope, names []str
 		return nil, false
 	}
 	c := cache.For(scope)
-	if !c.HasSparklines() {
+	// The corrupted corpus specifically: a populated non-corrupted map says
+	// nothing about whether this one can serve the request.
+	if !c.HasSparklinesCorrupted() {
 		return nil, false
 	}
 	out := make(map[string][]lab.SparklinePoint, len(names))
@@ -332,7 +346,7 @@ func CollectiveAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Sco
 				SellReason:           cr.SellReason,
 				Sellability:          cr.Sellability,
 				SellabilityLabel:     cr.SellabilityLabel,
-				Sparkline:            sparklines[cr.TransfiguredName],
+				Sparkline:            nonNilSparkline(sparklines[cr.TransfiguredName]),
 				Low7Days:             cr.Low7Days,
 				High7Days:            cr.High7Days,
 				SellConfidence:       cr.SellConfidence,
@@ -352,9 +366,6 @@ func CollectiveAnalysis(repo *lab.Repository, cache *lab.Cache, scope league.Sco
 			}
 
 			rows = append(rows, r)
-			if rows[len(rows)-1].Sparkline == nil {
-				rows[len(rows)-1].Sparkline = []lab.SparklinePoint{}
-			}
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -419,6 +430,10 @@ func serveDedicationCollective(w http.ResponseWriter, r *http.Request, repo *lab
 			Confidence:           cr.Confidence,
 			SellConfidence:       cr.SellConfidence,
 			LowConfidence:        cr.LowConfidence,
+			// Dedication rows carry no series, but the field has no omitempty:
+			// without this the endpoint emits `null` where the Normal mode
+			// emits `[]`.
+			Sparkline: nonNilSparkline(nil),
 		})
 	}
 

--- a/internal/server/handlers/collective.go
+++ b/internal/server/handlers/collective.go
@@ -57,8 +57,9 @@ type collectiveRow struct {
 // sparklineWindowHours is the window sparkline responses have always covered.
 // The lab cache stores a longer series than this — up to a 168-hour tail for
 // gems that stopped appearing in snapshots — so the window is applied when the
-// response is built, not when the cache is filled.
-const sparklineWindowHours = 12
+// response is built, not when the cache is filled. Aliased from the lab
+// constant so the served window and the populated window cannot drift apart.
+const sparklineWindowHours = lab.SparklineWindowHours
 
 // trimSparkline returns the suffix of pts newer than hours ago. Points are
 // stored ascending by time, so the first point inside the window starts the
@@ -106,10 +107,13 @@ const cachedCorruptedVariant = "21/23c"
 // at all: a cold cache, or a variant the cache never populates, must go to the
 // database rather than hand back an empty series.
 func cachedCorruptedSparklines(cache *lab.Cache, scope league.Scope, names []string, variant string, hours int) (map[string][]lab.SparklinePoint, bool) {
-	if cache == nil || variant != cachedCorruptedVariant || !cache.For(scope).HasSparklines() {
+	if cache == nil || variant != cachedCorruptedVariant {
 		return nil, false
 	}
 	c := cache.For(scope)
+	if !c.HasSparklines() {
+		return nil, false
+	}
 	out := make(map[string][]lab.SparklinePoint, len(names))
 	for _, n := range names {
 		if pts := trimSparkline(c.SparklinesCorrupted(n, variant), hours); len(pts) > 0 {
@@ -650,11 +654,10 @@ func serveDedicationCompare(w http.ResponseWriter, r *http.Request, repo *lab.Re
 	// The cache populates corrupted series for the Dedication variant only, so
 	// the read is guarded on it: any other variant has no cached series and must
 	// go to the query rather than read an empty series out of a warm cache.
-	const dedicationSparklineVariant = "21/23c"
 	var warnings []string
-	sparklines, cached := cachedCorruptedSparklines(cache, scope, names, dedicationSparklineVariant, sparklineWindowHours)
+	sparklines, cached := cachedCorruptedSparklines(cache, scope, names, cachedCorruptedVariant, sparklineWindowHours)
 	if !cached {
-		sp, err := repo.SparklineDataCorrupted(r.Context(), scope, names, dedicationSparklineVariant, sparklineWindowHours)
+		sp, err := repo.SparklineDataCorrupted(r.Context(), scope, names, cachedCorruptedVariant, sparklineWindowHours)
 		if err != nil {
 			slog.Error("compare analysis (dedication): sparkline query failed", "error", err)
 			sp = make(map[string][]lab.SparklinePoint)

--- a/internal/server/handlers/collective_sparkline_test.go
+++ b/internal/server/handlers/collective_sparkline_test.go
@@ -441,6 +441,21 @@ func TestCachedCorruptedSparklines_NonDedicationVariantDefersToTheQuery(t *testi
 	}
 }
 
+// The corrupted map is the one this call reads. A cache warmed only on the
+// non-corrupted side is cold for this request, and reporting it warm would hand
+// back an empty series for every Dedication gem with no fallback and no log.
+func TestCachedCorruptedSparklines_NonCorruptedOnlyCacheDefersToTheQuery(t *testing.T) {
+	now := time.Now()
+	cache := lab.NewCache(sparklineScope)
+	warmSparklines(t, cache, map[string]map[string][]lab.SparklinePoint{
+		"Spark of Nova": {"20/20": {sparkAt(now, time.Hour, 125, 26)}},
+	}, nil)
+
+	if _, cached := cachedCorruptedSparklines(cache, sparklineScope, []string{"Vaal Grace"}, "21/23c", sparklineWindowHours); cached {
+		t.Error("cached = true with only the non-corrupted map populated, want the query")
+	}
+}
+
 func TestCachedCorruptedSparklines_ColdCacheDefersToTheQuery(t *testing.T) {
 	cache := lab.NewCache(sparklineScope)
 
@@ -452,6 +467,29 @@ func TestCachedCorruptedSparklines_ColdCacheDefersToTheQuery(t *testing.T) {
 func TestCachedCorruptedSparklines_NilCacheDefersToTheQuery(t *testing.T) {
 	if _, cached := cachedCorruptedSparklines(nil, sparklineScope, []string{"Vaal Grace"}, "21/23c", sparklineWindowHours); cached {
 		t.Error("cached = true with no cache, want the query")
+	}
+}
+
+// collectiveRow.Sparkline carries no omitempty, so a row left with a nil series
+// marshals as `null` while a populated one marshals as an array. Both collective
+// modes share this row type, and the Dedication mode never populates the field —
+// leaving it unset there makes the two endpoints disagree on response shape.
+func TestCollectiveRow_SparklineWithoutPointsMarshalsAsEmptyArray(t *testing.T) {
+	encoded, err := json.Marshal(collectiveRow{Sparkline: nonNilSparkline(nil)})
+	if err != nil {
+		t.Fatalf("marshal collectiveRow: %v", err)
+	}
+
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(encoded, &fields); err != nil {
+		t.Fatalf("unmarshal collectiveRow: %v", err)
+	}
+	got, ok := fields["sparkline"]
+	if !ok {
+		t.Fatalf("response has no sparkline field: %s", encoded)
+	}
+	if string(got) != "[]" {
+		t.Errorf("sparkline = %s, want []", got)
 	}
 }
 

--- a/internal/server/handlers/collective_sparkline_test.go
+++ b/internal/server/handlers/collective_sparkline_test.go
@@ -1,0 +1,465 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"profitofexile/internal/lab"
+	"profitofexile/internal/league"
+)
+
+// The sparkline handlers are constructed with a nil *lab.Repository throughout
+// this file. A nil repository is not an error value: every query method
+// dereferences r.pool, so a surviving database call panics. That panic is the
+// observable this file asserts on — "served without touching gem_snapshots" is
+// the acceptance criterion for the sparkline cache, and a nil repository is the
+// only seam the current handler signatures offer to observe it.
+
+var sparklineScope = league.Historical("Mirage")
+
+// sparkAt builds one point ago before now, so cached series land inside the
+// 12-hour response window without depending on wall-clock alignment.
+func sparkAt(now time.Time, ago time.Duration, price float64, listings int) lab.SparklinePoint {
+	return lab.SparklinePoint{
+		Time:     now.Add(-ago).UTC().Format(time.RFC3339),
+		Price:    price,
+		Listings: listings,
+	}
+}
+
+// sparklineGem is one gem's worth of ranking input: enough transfigure, signal
+// and feature data for RankCollective to emit a row for it.
+type sparklineGem struct {
+	name         string
+	variant      string
+	roi          float64
+	windowSignal string
+}
+
+// warmAnalysisCache returns a cache warm enough that CollectiveAnalysis,
+// CompareAnalysis and TrendAnalysis all take their cache-first path for
+// rankings. Sparklines are populated separately so a test can hold the ranking
+// data warm while leaving the sparkline cache cold.
+func warmAnalysisCache(t *testing.T, gems ...sparklineGem) *lab.Cache {
+	t.Helper()
+	c := lab.NewCache(sparklineScope)
+	now := time.Now()
+
+	transfigure := make([]lab.TransfigureResult, 0, len(gems))
+	signals := make([]lab.GemSignal, 0, len(gems))
+	features := make([]lab.GemFeature, 0, len(gems))
+	for _, g := range gems {
+		transfigure = append(transfigure, lab.TransfigureResult{
+			Time:                 now,
+			BaseName:             "Spark",
+			TransfiguredName:     g.name,
+			Variant:              g.variant,
+			BasePrice:            10,
+			TransfiguredPrice:    10 + g.roi,
+			ROI:                  g.roi,
+			ROIPct:               g.roi * 10,
+			BaseListings:         25,
+			TransfiguredListings: 25,
+			GemColor:             "BLUE",
+			Confidence:           "OK",
+		})
+		signals = append(signals, lab.GemSignal{
+			Time:             now,
+			Name:             g.name,
+			Variant:          g.variant,
+			Signal:           "STABLE",
+			Confidence:       80,
+			Sellability:      70,
+			SellabilityLabel: "GOOD",
+			WindowSignal:     g.windowSignal,
+			Tier:             "MID",
+		})
+		features = append(features, lab.GemFeature{
+			Time:     now,
+			Name:     g.name,
+			Variant:  g.variant,
+			Chaos:    10 + g.roi,
+			Listings: 25,
+			GemColor: "BLUE",
+		})
+	}
+
+	c.For(sparklineScope).SetTransfigure(transfigure)
+	c.For(sparklineScope).SetGemSignals(signals)
+	c.For(sparklineScope).SetGemFeatures(features)
+	return c
+}
+
+// warmSparklines installs series into the cache keyed by gem name and variant.
+func warmSparklines(t *testing.T, c *lab.Cache, series, corrupted map[string]map[string][]lab.SparklinePoint) {
+	t.Helper()
+	c.For(sparklineScope).SetSparklinesByName(series, corrupted, time.Now())
+}
+
+// serveWithoutRepository serves target and fails the test if the handler
+// dereferenced the nil repository, naming that as a database call.
+func serveWithoutRepository(t *testing.T, h http.HandlerFunc, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, target, nil)
+	w := httptest.NewRecorder()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("handler queried the repository while serving %s (nil repository dereferenced: %v)", target, r)
+		}
+	}()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+// queriedRepository reports whether serving target reached the repository.
+func queriedRepository(h http.HandlerFunc, target string) (queried bool) {
+	defer func() {
+		if recover() != nil {
+			queried = true
+		}
+	}()
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, target, nil))
+	return false
+}
+
+type sparklineRow struct {
+	TransfiguredName string               `json:"transfiguredName"`
+	Variant          string               `json:"variant"`
+	Sparkline        []lab.SparklinePoint `json:"sparkline"`
+}
+
+// decodeSparklineRows decodes a collective or compare response into rows keyed
+// by gem name.
+func decodeSparklineRows(t *testing.T, w *httptest.ResponseRecorder) map[string]sparklineRow {
+	t.Helper()
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp struct {
+		Count int            `json:"count"`
+		Data  []sparklineRow `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	out := make(map[string]sparklineRow, len(resp.Data))
+	for _, row := range resp.Data {
+		out[row.TransfiguredName] = row
+	}
+	return out
+}
+
+func assertSparkline(t *testing.T, got, want []lab.SparklinePoint) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("sparkline has %d points, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("sparkline[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// This is the acceptance criterion for POE-133: a warm cache serves the
+// sparkline series with no gem_snapshots query. Routing any one call site back
+// through the repository makes it fail on the nil-pool panic.
+func TestCollectiveAnalysis_WarmCacheServesSparklinesWithoutQuerying(t *testing.T) {
+	now := time.Now()
+	cache := warmAnalysisCache(t, sparklineGem{name: "Spark of Nova", variant: "20/20", roi: 40})
+	want := []lab.SparklinePoint{
+		sparkAt(now, 4*time.Hour, 100, 30),
+		sparkAt(now, 2*time.Hour, 110, 28),
+		sparkAt(now, time.Hour, 125, 26),
+	}
+	warmSparklines(t, cache, map[string]map[string][]lab.SparklinePoint{
+		"Spark of Nova": {"20/20": want},
+	}, nil)
+
+	w := serveWithoutRepository(t, CollectiveAnalysis(nil, cache, sparklineScope),
+		"/api/analysis/collective?variant=20/20")
+
+	rows := decodeSparklineRows(t, w)
+	row, ok := rows["Spark of Nova"]
+	if !ok {
+		t.Fatalf("response has no row for Spark of Nova: %v", rows)
+	}
+	assertSparkline(t, row.Sparkline, want)
+}
+
+// A gem the warm cache has no series for is a gem with no recent points, not a
+// cache miss: it gets an empty series and still no query.
+func TestCollectiveAnalysis_WarmCacheGemWithoutSeriesServesEmptySparkline(t *testing.T) {
+	now := time.Now()
+	cache := warmAnalysisCache(t,
+		sparklineGem{name: "Spark of Nova", variant: "20/20", roi: 40},
+		sparklineGem{name: "Ice Nova of Frostbolts", variant: "20/20", roi: 30},
+	)
+	warmSparklines(t, cache, map[string]map[string][]lab.SparklinePoint{
+		"Spark of Nova": {"20/20": {sparkAt(now, time.Hour, 125, 26)}},
+	}, nil)
+
+	w := serveWithoutRepository(t, CollectiveAnalysis(nil, cache, sparklineScope),
+		"/api/analysis/collective?variant=20/20")
+
+	rows := decodeSparklineRows(t, w)
+	row, ok := rows["Ice Nova of Frostbolts"]
+	if !ok {
+		t.Fatalf("response has no row for Ice Nova of Frostbolts: %v", rows)
+	}
+	if row.Sparkline == nil {
+		t.Fatal("sparkline = null, want an empty array")
+	}
+	if len(row.Sparkline) != 0 {
+		t.Errorf("sparkline = %+v, want empty", row.Sparkline)
+	}
+}
+
+// The cache holds a longer series than a response shows — up to a 168-hour tail
+// for a gem that stopped appearing in snapshots. The 12-hour window is applied
+// when the response is built.
+func TestCollectiveAnalysis_WarmCacheDropsPointsOlderThanTheResponseWindow(t *testing.T) {
+	now := time.Now()
+	recent := sparkAt(now, time.Hour, 125, 26)
+	cache := warmAnalysisCache(t, sparklineGem{name: "Spark of Nova", variant: "20/20", roi: 40})
+	warmSparklines(t, cache, map[string]map[string][]lab.SparklinePoint{
+		"Spark of Nova": {"20/20": {
+			sparkAt(now, 100*time.Hour, 60, 40),
+			sparkAt(now, 30*time.Hour, 80, 35),
+			recent,
+		}},
+	}, nil)
+
+	w := serveWithoutRepository(t, CollectiveAnalysis(nil, cache, sparklineScope),
+		"/api/analysis/collective?variant=20/20")
+
+	rows := decodeSparklineRows(t, w)
+	assertSparkline(t, rows["Spark of Nova"].Sparkline, []lab.SparklinePoint{recent})
+}
+
+// Without a variant parameter each gem's series must come from its own variant.
+// 20/20 and 1/20 are different markets: reading both rows at one variant, or at
+// the empty request variant, serves the wrong prices.
+//
+// The two gems carry different names because the response map is keyed by gem
+// name alone — see the note on the response-shape limitation at the bottom of
+// this file.
+func TestCollectiveAnalysis_AllVariantsWarmCacheUsesEachGemsOwnVariant(t *testing.T) {
+	now := time.Now()
+	twentyTwenty := []lab.SparklinePoint{sparkAt(now, time.Hour, 125, 26)}
+	oneTwenty := []lab.SparklinePoint{sparkAt(now, time.Hour, 9, 90)}
+	cache := warmAnalysisCache(t,
+		sparklineGem{name: "Spark of Nova", variant: "20/20", roi: 40},
+		sparklineGem{name: "Ice Nova of Frostbolts", variant: "1/20", roi: 30},
+	)
+	warmSparklines(t, cache, map[string]map[string][]lab.SparklinePoint{
+		"Spark of Nova":          {"20/20": twentyTwenty, "1/20": oneTwenty},
+		"Ice Nova of Frostbolts": {"20/20": twentyTwenty, "1/20": oneTwenty},
+	}, nil)
+
+	w := serveWithoutRepository(t, CollectiveAnalysis(nil, cache, sparklineScope),
+		"/api/analysis/collective")
+
+	rows := decodeSparklineRows(t, w)
+	if rows["Spark of Nova"].Variant != "20/20" || rows["Ice Nova of Frostbolts"].Variant != "1/20" {
+		t.Fatalf("unexpected variants in response: %+v", rows)
+	}
+	assertSparkline(t, rows["Spark of Nova"].Sparkline, twentyTwenty)
+	assertSparkline(t, rows["Ice Nova of Frostbolts"].Sparkline, oneTwenty)
+}
+
+// A cold sparkline cache must still reach the database, even when the rest of
+// the cache is warm — otherwise a restarted server serves empty sparklines
+// until the first tick lands.
+func TestCollectiveAnalysis_ColdSparklineCacheFallsBackToRepository(t *testing.T) {
+	cache := warmAnalysisCache(t, sparklineGem{name: "Spark of Nova", variant: "20/20", roi: 40})
+	// Rankings warm, sparklines never populated.
+
+	if !queriedRepository(CollectiveAnalysis(nil, cache, sparklineScope),
+		"/api/analysis/collective?variant=20/20") {
+		t.Error("cold sparkline cache served without a repository query, want the database fallback")
+	}
+}
+
+func TestCompareAnalysis_WarmCacheServesSparklinesWithoutQuerying(t *testing.T) {
+	now := time.Now()
+	cache := warmAnalysisCache(t, sparklineGem{name: "Spark of Nova", variant: "20/20", roi: 40})
+	want := []lab.SparklinePoint{
+		sparkAt(now, 3*time.Hour, 100, 30),
+		sparkAt(now, time.Hour, 125, 26),
+	}
+	warmSparklines(t, cache, map[string]map[string][]lab.SparklinePoint{
+		"Spark of Nova": {"20/20": want},
+	}, nil)
+
+	w := serveWithoutRepository(t, CompareAnalysis(nil, cache, nil, sparklineScope),
+		"/api/analysis/compare?gems=Spark+of+Nova&variant=20/20")
+
+	rows := decodeSparklineRows(t, w)
+	row, ok := rows["Spark of Nova"]
+	if !ok {
+		t.Fatalf("response has no row for Spark of Nova: %v", rows)
+	}
+	assertSparkline(t, row.Sparkline, want)
+}
+
+// The cache keys a series by name AND variant, so it cannot reproduce the
+// mixed-variant series an empty variant returns. That request stays on the
+// query even against a warm cache.
+func TestCompareAnalysis_EmptyVariantQueriesRepositoryDespiteWarmCache(t *testing.T) {
+	now := time.Now()
+	cache := warmAnalysisCache(t, sparklineGem{name: "Spark of Nova", variant: "20/20", roi: 40})
+	warmSparklines(t, cache, map[string]map[string][]lab.SparklinePoint{
+		"Spark of Nova": {"20/20": {sparkAt(now, time.Hour, 125, 26)}},
+	}, nil)
+
+	if !queriedRepository(CompareAnalysis(nil, cache, nil, sparklineScope),
+		"/api/analysis/compare?gems=Spark+of+Nova") {
+		t.Error("empty variant served from cache, want the mixed-variant query")
+	}
+}
+
+// TrendAnalysis shows the last four points of the full cached series; it is the
+// one consumer whose window is 168 hours rather than 12, so the cached series
+// must not be trimmed to the shorter window before it is cut to four.
+func TestTrendAnalysis_WarmCacheServesLastFourPointsWithoutQuerying(t *testing.T) {
+	now := time.Now()
+	cache := warmAnalysisCache(t, sparklineGem{
+		name: "Spark of Nova", variant: "20/20", roi: 40, windowSignal: "OPEN",
+	})
+	warmSparklines(t, cache, map[string]map[string][]lab.SparklinePoint{
+		"Spark of Nova": {"20/20": {
+			sparkAt(now, 120*time.Hour, 50, 60),
+			sparkAt(now, 96*time.Hour, 60, 55),
+			sparkAt(now, 72*time.Hour, 70, 50),
+			sparkAt(now, 48*time.Hour, 80, 45),
+			sparkAt(now, 24*time.Hour, 90, 40),
+			sparkAt(now, time.Hour, 125, 26),
+		}},
+	}, nil)
+
+	w := serveWithoutRepository(t, TrendAnalysis(nil, cache, sparklineScope),
+		"/api/analysis/trends?variant=20/20")
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp struct {
+		Data []struct {
+			Name          string `json:"name"`
+			PriceTrend    []int  `json:"priceTrend"`
+			ListingsTrend []int  `json:"listingsTrend"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp.Data) != 1 {
+		t.Fatalf("response has %d rows, want 1", len(resp.Data))
+	}
+	got := resp.Data[0]
+	wantPrices := []int{70, 80, 90, 125}
+	wantListings := []int{50, 45, 40, 26}
+	if len(got.PriceTrend) != len(wantPrices) {
+		t.Fatalf("priceTrend = %v, want %v", got.PriceTrend, wantPrices)
+	}
+	for i := range wantPrices {
+		if got.PriceTrend[i] != wantPrices[i] {
+			t.Errorf("priceTrend[%d] = %d, want %d", i, got.PriceTrend[i], wantPrices[i])
+		}
+	}
+	for i := range wantListings {
+		if got.ListingsTrend[i] != wantListings[i] {
+			t.Errorf("listingsTrend[%d] = %d, want %d", i, got.ListingsTrend[i], wantListings[i])
+		}
+	}
+}
+
+func TestTrimSparkline(t *testing.T) {
+	now := time.Now()
+	old := sparkAt(now, 20*time.Hour, 60, 40)
+	recent := sparkAt(now, time.Hour, 125, 26)
+
+	tests := []struct {
+		name  string
+		pts   []lab.SparklinePoint
+		hours int
+		want  []lab.SparklinePoint
+	}{
+		{"keeps points inside the window", []lab.SparklinePoint{old, recent}, 12, []lab.SparklinePoint{recent}},
+		{"drops everything older than the window", []lab.SparklinePoint{old}, 12, nil},
+		{"no window keeps the whole series", []lab.SparklinePoint{old, recent}, 0, []lab.SparklinePoint{old, recent}},
+		{"unparseable times are skipped, not kept", []lab.SparklinePoint{{Time: "not-a-time", Price: 1}, recent}, 12, []lab.SparklinePoint{recent}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := trimSparkline(tt.pts, tt.hours)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d points %+v, want %d", len(got), got, len(tt.want))
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Errorf("point[%d] = %+v, want %+v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// serveDedicationCompare queries corrupted gem prices before it ever reaches a
+// sparkline, so its cache read is covered here at the function it delegates to.
+func TestCachedCorruptedSparklines_DedicationVariantReadsTheCorruptedCache(t *testing.T) {
+	now := time.Now()
+	want := []lab.SparklinePoint{sparkAt(now, time.Hour, 900, 5)}
+	cache := lab.NewCache(sparklineScope)
+	warmSparklines(t, cache, nil, map[string]map[string][]lab.SparklinePoint{
+		"Vaal Grace": {"21/23c": want},
+	})
+
+	got, cached := cachedCorruptedSparklines(cache, sparklineScope, []string{"Vaal Grace"}, "21/23c", sparklineWindowHours)
+	if !cached {
+		t.Fatal("cached = false, want the warm corrupted cache to serve the request")
+	}
+	assertSparkline(t, got["Vaal Grace"], want)
+}
+
+func TestCachedCorruptedSparklines_NonDedicationVariantDefersToTheQuery(t *testing.T) {
+	now := time.Now()
+	cache := lab.NewCache(sparklineScope)
+	warmSparklines(t, cache, nil, map[string]map[string][]lab.SparklinePoint{
+		"Vaal Grace": {"21/23c": {sparkAt(now, time.Hour, 900, 5)}},
+	})
+
+	// The cache populates corrupted series for the Dedication variant only, so
+	// any other variant must reach the database rather than read an empty
+	// series out of a warm cache.
+	if _, cached := cachedCorruptedSparklines(cache, sparklineScope, []string{"Vaal Grace"}, "20/20", sparklineWindowHours); cached {
+		t.Error("cached = true for variant 20/20, want the query")
+	}
+}
+
+func TestCachedCorruptedSparklines_ColdCacheDefersToTheQuery(t *testing.T) {
+	cache := lab.NewCache(sparklineScope)
+
+	if _, cached := cachedCorruptedSparklines(cache, sparklineScope, []string{"Vaal Grace"}, "21/23c", sparklineWindowHours); cached {
+		t.Error("cached = true on a cold cache, want the query")
+	}
+}
+
+func TestCachedCorruptedSparklines_NilCacheDefersToTheQuery(t *testing.T) {
+	if _, cached := cachedCorruptedSparklines(nil, sparklineScope, []string{"Vaal Grace"}, "21/23c", sparklineWindowHours); cached {
+		t.Error("cached = true with no cache, want the query")
+	}
+}
+
+// Response-shape limitation, pre-existing and not introduced by the sparkline
+// cache: CollectiveAnalysis collects series into a map keyed by gem name alone,
+// then reads it back per row. When one gem appears at two variants in the same
+// response — the default "all variants" request — the second lookup overwrites
+// the first and both rows render the same series. The cache path and the query
+// path share the defect, because both fill the same name-keyed map. Fixing it
+// means keying that map by name and variant; no test here asserts the current
+// behaviour, so a fix will not have to break one.


### PR DESCRIPTION
## Why

`/api/analysis/collective` served its analysis inputs from the in-memory `lab.Cache` but still queried `gem_snapshots` on every request to build sparklines. Three consumers paid for it: `CollectiveAnalysis`, `CompareAnalysis`, and `TrendAnalysis`.

The cost was not only latency. `SparklineData` capped results at `LIMIT 10000` **total rows**, ordered `name, time ASC`. That cap is reached in practice — the `search` path passes up to 1000 gem names, and `TrendAnalysis` batches a 168-hour window per variant group. When it tripped, alphabetically-late gems silently received no sparkline, and `TrendAnalysis`'s `last4` returned points from the middle of the window instead of the end. This removes that failure class outright.

Prerequisite for POE-132, whose per-variant fan-out would otherwise multiply the query count.

## What changed

- New sparkline fields on `lab.Cache`, holding a 12-hour rolling window per `(gem name, variant)` plus a guaranteed tail of the last 4 points within 168 hours.
- Population runs inside `Analyzer.RunV2`, extracted as `populateSparklineCache` behind a narrow `sparklineSource` interface so idempotency is testable without a live tick loop.
- New `Repository.SparklineWindow`. The incremental path fetches only rows past the high-water mark; the cold path runs a bounded union — the full 12-hour window plus a `DISTINCT ON (name, variant)` tail query — rather than materialising the whole 168-hour lookback at process start.
- All five sparkline call sites read cache-first with a database fallback.
- Dead code removed: `normalizeSparklines` (no callers), the unused `MarketContext` fetches in `CollectiveAnalysis` and `TrendAnalysis`, and the never-populated `collectiveRow.SparklineListings`.
- New `docs/ANALYSIS-CACHE.md`, indexed from `docs/README.md` and `AGENTS.md`.

No schema change. No migration. No API contract change.

## Design decisions worth knowing

**Population runs in the server, not the collector.** They are separate processes and the collector never imports `internal/lab`. The trigger is the collector's Mercure `poe/collector/gems` event, which the server's subscriber turns into a `RunV2` call.

**The population query is dedicated, not reused.** `RunV2` already holds 168 hours of history, but `GemPriceHistoryByVariant` filters `chaos > 5`, excludes Trarthus, and requires `is_transfigured`. `SparklineData` applied none of those. Reusing it would have silently dropped points — including every base gem `TrendAnalysis` reads.

**Window plus tail, not a flat 168 hours.** Nothing reads a full 168-hour series: collective and compare read the window, `TrendAnalysis` reads `last4`. Measured against production, a flat cache costs roughly 45 MB at steady state; this shape costs about 5 MB and serves all three.

**Corrupted gems cache variant `21/23c` only** — the sole variant any reader requests. Any other corrupted variant falls back to the database rather than silently returning empty.

**`chaos > 5` is deliberately untouched.** It is a genuine bug (at league start, 5c is a real price), but it changes analysis *inputs* — features, signals, rankings. Tracked separately as POE-134. This branch sidesteps it with its own unfiltered query, which stays correct either way.

## Memory safety

A dedicated audit confirmed nothing in the server leaks today, and produced three constraints this change had to honour:

1. Never store a reslice as the 4-point tail. `points[len(points)-4:]` pins the whole backing array, and a delisted gem never appends again, so the reallocation that would free it never comes.
2. Never compact in place. `copy(s, s[n:])` mutates elements a concurrent reader holds, violating the cache's documented immutability contract.
3. Build a fresh slice per series and assign it, computing the merge outside the lock.

Constraint 1 is covered by a mutation-verified test: injecting `return existing[len(existing)-SparklineTailPoints:]` into `mergeSparklineSeries` makes `TestMergeSparklineSeries_TrimmedTailDoesNotAliasExistingInput` fail, and removing it goes green. The first version of that test did not exercise the trim path and passed with the leak present — review caught it.

## Idempotency

`RunV2` runs twice per snapshot: once on the Mercure gem tick, once from the T+15-minute delayed recompute. The second pass must be a no-op. The merge dedupes on `(name, variant, time)` and the high-water mark advances only to the maximum point time actually observed.

## Verification

- `go test -race ./...` green.
- Integration suite run against local TimescaleDB, including three new cases covering the window ∪ tail union, a delisted series with no in-window rows still getting its tail, and rows past the lookback being dropped.
- Fidelity audit: PASS, 5/5 items preserved — filters, window semantics, deletions, ALL-variants separation, and the empty-variant compare path all verified against the pre-change behavior.
- Delivery audit: content parity, zero-query-on-warm, idempotency, memory-safety invariants, and scope discipline all confirmed against the final diff.

## Deferred

Three suggestion-level findings are recorded on POE-133 rather than fixed here: the high-water mark loses sub-second precision so each incremental read re-fetches one snapshot (wasted I/O, not incorrect), `SetSparklinesByName` is a test-only export that would be cleaner as an exported key type, and the warm read path has no observability for a silently-empty population.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
