### PR TITLE
POE-131: rank thin-market gems as low-confidence instead of dropping them

### DIFF
--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -125,7 +125,10 @@ impl Default for Settings {
             lab_mode: default_lab_mode(),
             autoclear_minutes: default_autoclear_minutes(),
             dedication_pool: default_dedication_pool(),
-            show_low_confidence: false,
+            // Default ON — see the note in the web BestPlays component: at
+            // 20-level variants a thin market is normal, so hiding flagged gems
+            // by default reproduces the POE-131 ranking gap.
+            show_low_confidence: true,
         }
     }
 }

--- a/desktop/src/routes/(app)/components/BestPlays.svelte
+++ b/desktop/src/routes/(app)/components/BestPlays.svelte
@@ -89,7 +89,9 @@
 			searchResults = null;
 		}
 	}
-	let showLowConf = $state(false);
+	// Default ON to match the Rust-side setting default; the stored value below
+	// overwrites it on mount. Starting false would flash a filtered list first.
+	let showLowConf = $state(true);
 	// Load from Tauri settings on mount
 	$effect(() => {
 		invoke<boolean>('get_show_low_confidence').then(v => { showLowConf = v; })

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -67,12 +67,16 @@ project's release cadence. **If a deploy matters, verify it by hand.**
 
 ## Verifying a deploy landed
 
-`<prod-host>` and `<server-service-id>` are placeholders — this is a public
+`PROD_HOST` and `SERVER_SERVICE_ID` are placeholders — this is a public
 repository, so the real host alias and Coolify service ids live in the private
-ops notes, not here.
+ops notes, not here. Set them once, then the commands below paste as-is (angle
+brackets would be read by the shell as redirects):
 
 ```
-ssh <prod-host> 'docker ps --format "{{.Status}} | {{.Image}}" -f name=<server-service-id>'
+PROD_HOST=...           # see private ops notes
+SERVER_SERVICE_ID=...
+
+ssh "$PROD_HOST" "docker ps --format '{{.Status}} | {{.Image}}' -f name=$SERVER_SERVICE_ID"
 ```
 
 Look the service up by its stable id prefix, never by a full container name:

--- a/docs/GEM-ICONS.md
+++ b/docs/GEM-ICONS.md
@@ -42,20 +42,20 @@ name, cannot fetch it, and returns `502`.
    To pull only new entries, hand it a JSON file containing just those keys.
 
 4. **Seed the production volume** — from a machine poewiki does not block.
-   `<prod-host>` and `<server-service-id>` are placeholders; this repository is
+   `PROD_HOST` and `SERVER_SERVICE_ID` are placeholders; this repository is
    public, so the real values live in the private ops notes. See
    [Deployment](DEPLOY.md).
 
    ```
    tar czf new-icons.tgz -C gem-icons-cache .
-   scp new-icons.tgz <prod-host>:/tmp/
-   ssh <prod-host> 'C=$(docker ps -q -f name=<server-service-id>); \
+   scp new-icons.tgz "$PROD_HOST":/tmp/
+   ssh "$PROD_HOST" "C=\$(docker ps -q -f name=$SERVER_SERVICE_ID); \
      mkdir -p /tmp/ni && tar xzf /tmp/new-icons.tgz -C /tmp/ni && \
-     for f in /tmp/ni/*.png; do docker cp "$f" "$C:/data/gem-icons-cache/"; done'
+     for f in /tmp/ni/*.png; do docker cp \"\$f\" \"\$C:/data/gem-icons-cache/\"; done"
    ```
 
    The server image has no shell, so `docker cp` is the way in. The volume is
-   `<server-service-id>-profitofexile-gem-icons` mounted at
+   `$SERVER_SERVICE_ID-profitofexile-gem-icons` mounted at
    `/data/gem-icons-cache`.
 
 5. **Deploy** — the map is embedded, so the icon only resolves once the new binary

--- a/frontend/src/routes/lab/components/BestPlays.svelte
+++ b/frontend/src/routes/lab/components/BestPlays.svelte
@@ -90,7 +90,11 @@
 			searchResults = null;
 		}
 	}
-	let showLowConf = $state(typeof localStorage !== 'undefined' && localStorage.getItem('poe-show-low-conf') === 'true');
+	// Default ON. At 20-level variants a thin transfigured market is normal, not
+	// anomalous, so the flag covers most of the pool there — a default that hid it
+	// would reproduce the ranking gap this toggle exists to make visible (POE-131).
+	// An explicit opt-out is still respected; only an unset value defaults on.
+	let showLowConf = $state(typeof localStorage === 'undefined' || localStorage.getItem('poe-show-low-conf') !== 'false');
 	$effect(() => {
 		localStorage.setItem('poe-show-low-conf', String(showLowConf));
 	});

--- a/internal/lab/collective.go
+++ b/internal/lab/collective.go
@@ -161,7 +161,7 @@ func RankCollective(transfigure []TransfigureResult, signals []GemSignal, featur
 			if tr.TransfiguredPrice <= 0 {
 				continue
 			}
-		} else if tr.ROI <= 0 || tr.Confidence != "OK" {
+		} else if tr.ROI <= 0 {
 			continue
 		}
 
@@ -211,6 +211,18 @@ func RankCollective(transfigure []TransfigureResult, signals []GemSignal, featur
 			cr.High7Days = f.High7Days
 			cr.LowConfidence = f.LowConfidence
 			cr.LiquidityTier = liquidityTier(f.MarketDepth)
+		}
+
+		// A thin transfigure market marks the row low-confidence rather than
+		// removing it. AnalyzeTransfigure gates Confidence on an absolute
+		// listings >= 5 on both sides, which is a mature-market assumption: at
+		// 20/20 the transfigured side averages 2 listings, so dropping LOW rows
+		// hid 78 of 93 positive-ROI gems from the ranking entirely.
+		//
+		// Set after the feature join, which assigns LowConfidence rather than
+		// OR-ing it — the join would otherwise clobber this.
+		if tr.Confidence == "LOW" {
+			cr.LowConfidence = true
 		}
 
 		// Exclude TRAP gems entirely — no actionable signal.

--- a/internal/lab/collective_test.go
+++ b/internal/lab/collective_test.go
@@ -77,12 +77,11 @@ func TestRankCollective_BudgetFilter(t *testing.T) {
 	}
 }
 
-func TestRankCollective_ExcludesNegativeROIAndLowConfidence(t *testing.T) {
+func TestRankCollective_ExcludesNegativeROI(t *testing.T) {
 	now := time.Now()
 	transfigure := []TransfigureResult{
 		{Time: now, TransfiguredName: "Good Gem", Variant: "20/20", ROI: 50, Confidence: "OK"},
 		{Time: now, TransfiguredName: "Negative ROI", Variant: "20/20", ROI: -10, Confidence: "OK"},
-		{Time: now, TransfiguredName: "Low Confidence", Variant: "20/20", ROI: 80, Confidence: "LOW"},
 	}
 
 	results := RankCollective(transfigure, nil, nil, 0, 50, "")
@@ -92,6 +91,61 @@ func TestRankCollective_ExcludesNegativeROIAndLowConfidence(t *testing.T) {
 	}
 	if results[0].TransfiguredName != "Good Gem" {
 		t.Errorf("got %s, want Good Gem", results[0].TransfiguredName)
+	}
+}
+
+func TestRankCollective_ThinMarketRankedAsLowConfidence(t *testing.T) {
+	now := time.Now()
+	transfigure := []TransfigureResult{
+		{Time: now, TransfiguredName: "Thick Market", Variant: "20/20", ROI: 50, Confidence: "OK"},
+		{Time: now, TransfiguredName: "Thin Market", Variant: "20/20", ROI: 80, Confidence: "LOW"},
+	}
+
+	results := RankCollective(transfigure, nil, nil, 0, 50, "")
+
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2 — a thin market is flagged, not dropped", len(results))
+	}
+
+	byName := make(map[string]CollectiveResult, len(results))
+	for _, r := range results {
+		byName[r.TransfiguredName] = r
+	}
+
+	thin, ok := byName["Thin Market"]
+	if !ok {
+		t.Fatal("thin-market gem missing from the ranking")
+	}
+	if !thin.LowConfidence {
+		t.Error("thin-market gem is not flagged LowConfidence, so the UI toggle cannot hide it")
+	}
+	if thin.Confidence != "LOW" {
+		t.Errorf("thin-market gem Confidence = %q, want LOW preserved for callers that distinguish", thin.Confidence)
+	}
+
+	if thick := byName["Thick Market"]; thick.LowConfidence {
+		t.Error("liquid gem wrongly flagged LowConfidence")
+	}
+}
+
+// A LOW transfigure confidence must survive the gem-feature join, which assigns
+// LowConfidence rather than OR-ing it.
+func TestRankCollective_ThinMarketFlagSurvivesFeatureJoin(t *testing.T) {
+	now := time.Now()
+	transfigure := []TransfigureResult{
+		{Time: now, TransfiguredName: "Thin Market", Variant: "20/20", ROI: 80, Confidence: "LOW"},
+	}
+	features := []GemFeature{
+		{Name: "Thin Market", Variant: "20/20", LowConfidence: false},
+	}
+
+	results := RankCollective(transfigure, nil, features, 0, 50, "")
+
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if !results[0].LowConfidence {
+		t.Error("feature join cleared the thin-market flag")
 	}
 }
 


### PR DESCRIPTION
## The bug

By Variant showed **8 gems at 20/20** while Pool Overview reported **93 priced** for the same variant.

`RankCollective` required `Confidence == "OK"` (`internal/lab/collective.go`), and `AnalyzeTransfigure` sets that from an absolute `listings >= 5` on **both** sides (`internal/lab/transfigure.go:141`). That threshold encodes a mature-market assumption.

Measured on the production snapshot (2026-07-26):

| variant | positive-ROI + OK | positive-ROI + LOW (dropped) | avg transfigured listings |
|---------|-------------------|------------------------------|---------------------------|
| 1       | 88                | 0                            | 135                       |
| 1/20    | 79                | 84                           | 6                         |
| 20      | 9                 | 57                           | 3                         |
| 20/20   | 8                 | 78                           | 2                         |

Every dropped row at 20/20 failed on the **transfigured** side (64 trans-only thin, 19 both, 0 base-only). The gate wasn't detecting bad data — it was encoding "20/20 gems are rarely listed", which is a permanent property of that market, not an anomaly.

## The fix

Thin listings now mark the row `LowConfidence` instead of removing it. That flag already existed: it's the per-variant relative measure on `GemFeature`, already exposed as `lowConfidence` on the API, and already wired to a user toggle. There were two competing thin-market filters; the relative one flags and lets the user decide, the absolute one silently deleted the row before the toggle could ever see it.

`Confidence` stays `LOW` on the row so callers that want to distinguish "the sale is unreliable" from "the ROI is unreliable" still can.

## The toggle default changed too

`showLowConf` defaulted to **off**, so the backend fix alone would have left the 20/20 view unchanged — moving the bug from "deleted" to "hidden". At 20-level variants the flag covers roughly 85% of the pool, and a default that hides 85% of a variant is the same gap wearing a checkbox.

Default is now on, in both web (`localStorage` unset → on) and desktop (Rust setting + matching initial state, so there's no filtered flash before the stored value loads). An explicit opt-out is preserved — only an unset value defaults on.

## Tests

`TestRankCollective_ExcludesNegativeROIAndLowConfidence` asserted the old behaviour and was split: negative-ROI exclusion still holds, and two new tests cover the new contract. Both are mutation-verified — restoring the `Confidence != "OK"` gate fails them, and so does dropping the flag assignment.

The second test exists because the gem-feature join **assigns** `LowConfidence` rather than OR-ing it, so a thin-market flag set before the join would be silently cleared. That ordering is load-bearing and now has a test.

## Not in scope

The `chaos > 5` floor in `GemPriceHistoryByVariant` is the same anti-pattern one level up and is tracked as POE-134. POE-132 (By Variant starvation from the shared top-100 fetch) is independent — this fix raises how many gems exist to rank; that one governs how many reach each tab.

Also folded in: the deploy/icon docs' `<angle bracket>` placeholders become shell-safe variables, since pasted angle brackets are read by the shell as redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)