### PR TITLE
POE-132: fetch rankings per variant instead of one global top-100

### DIFF
--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -253,6 +253,13 @@ async function get<T>(path: string, params?: Record<string, string>): Promise<T>
 // --- Mapping helpers ---
 
 /**
+ * The four non-corrupted gem variants, in display format. Shared so the dashboard's
+ * per-variant fetch and the By Variant tabs cannot drift apart. Dedication mode does
+ * not use these — it pools by skill/transfigured at a single 21/23 variant.
+ */
+export const VARIANTS = ['1/0', '1/20', '20/0', '20/20'] as const;
+
+/**
  * Convert a backend variant ("1", "20") to the UI's display format ("1/0", "20/0").
  * The backend stores zero-quality variants without the quality suffix and normalizes
  * "/0" away on inbound query params, but never restores it on responses — so UI code

--- a/desktop/src/lib/pages/LabPage.svelte
+++ b/desktop/src/lib/pages/LabPage.svelte
@@ -5,6 +5,7 @@
 	import {
 		fetchStatus,
 		fetchBestPlays,
+		VARIANTS,
 		fetchMarketOverview,
 		connectMercure,
 		type StatusData,
@@ -44,11 +45,28 @@
 		}).catch(e => console.warn('[LabPage] get_lab_mode failed:', e));
 	});
 
+	// Rankings are fetched per variant, not as one global top-100. The server ranks
+	// across all variants, so a single capped list let the best-ranking variants
+	// crowd the others out and By Variant showed a starved slice (POE-132). The
+	// merged result is a superset of the old global list.
+	//
+	// Dedication mode is excluded: it has a single 21/23 variant and pools by
+	// skill/transfigured instead, so the per-variant split does not apply.
+	async function loadBestPlays(dedication: boolean): Promise<GemPlay[]> {
+		if (dedication) {
+			return fetchBestPlays(undefined, undefined, undefined, 100, undefined, 'dedication');
+		}
+		const perVariant = await Promise.all(
+			VARIANTS.map(v => fetchBestPlays(v, undefined, undefined, 100)),
+		);
+		return perVariant.flat();
+	}
+
 	function handleLabModeChange(mode: LabMode) {
 		labMode = mode;
 		invoke('set_lab_mode', { mode }).catch(e => console.warn('[LabPage] set_lab_mode failed:', e));
 		// Re-fetch rankings for the new mode.
-		fetchBestPlays(undefined, undefined, undefined, 100, undefined, mode === 'Dedication' ? 'dedication' : undefined)
+		loadBestPlays(mode === 'Dedication')
 			.then(bp => { bestPlays = bp; })
 			.catch(e => console.warn('[LabPage] re-fetch bestPlays failed:', e));
 	}
@@ -186,7 +204,7 @@
 			error = '';
 			const [s, bp, mo] = await Promise.all([
 				fetchStatus(),
-				fetchBestPlays(undefined, undefined, undefined, 100, undefined, isDedication ? 'dedication' : undefined),
+				loadBestPlays(isDedication),
 				fetchMarketOverview(),
 			]);
 			status = s;

--- a/desktop/src/routes/(app)/components/ByVariant.svelte
+++ b/desktop/src/routes/(app)/components/ByVariant.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { invoke } from '@tauri-apps/api/core';
-	import type { GemPlay } from '$lib/api';
+	import { VARIANTS, type GemPlay } from '$lib/api';
 	import BestPlays from './BestPlays.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import Select from '$lib/components/Select.svelte';
@@ -9,7 +9,6 @@
 
 	const isDedication = $derived(labMode === 'dedication');
 
-	const VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
 	const NORMAL_TABS = ['ALL', ...VARIANTS];
 	const DEDICATION_POOLS = ['skill', 'transfigured'];
 	const DEDICATION_POOL_LABELS: Record<string, string> = { skill: 'Skills', transfigured: 'Transfigured' };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -224,6 +224,13 @@ async function get<T>(path: string, params?: Record<string, string>): Promise<T>
 // --- Mapping helpers ---
 
 /**
+ * The four non-corrupted gem variants, in display format. Shared so the dashboard's
+ * per-variant fetch and the By Variant tabs cannot drift apart — a variant fetched
+ * but not tabbed (or the reverse) is invisible until someone notices missing rows.
+ */
+export const VARIANTS = ['1/0', '1/20', '20/0', '20/20'] as const;
+
+/**
  * Convert a backend variant ("1", "20") to the UI's display format ("1/0", "20/0").
  * The backend stores zero-quality variants without the quality suffix and normalizes
  * "/0" away on inbound query params, but never restores it on responses — so UI code

--- a/frontend/src/routes/lab/+page.svelte
+++ b/frontend/src/routes/lab/+page.svelte
@@ -4,6 +4,7 @@
 		fetchBestPlays,
 		fetchMarketOverview,
 		connectMercure,
+		VARIANTS,
 		type StatusData,
 		type GemPlay,
 		type MarketOverviewData,
@@ -126,13 +127,24 @@
 	async function loadAll() {
 		try {
 			error = '';
-			const [s, bp, mo] = await Promise.all([
+			// Fetch per variant rather than one global top-100. The server ranks
+			// across all variants, so a single capped list let the best-ranking
+			// variants crowd the others out — By Variant then showed 23 of 88
+			// available rows for 1/0 while 1/20 took 60 slots (POE-132). Merging
+			// four per-variant lists is a superset of the old global list, so the
+			// Best Plays section is unaffected beyond seeing more candidates.
+			//
+			// Four requests, not one per tab: this replaces the global fetch rather
+			// than adding to it, so page load goes from 3 concurrent requests to 6.
+			// Commit 3e2f28d removed a 10+ request fan-out that caused
+			// ERR_INSUFFICIENT_RESOURCES; six stays well under that.
+			const [s, mo, ...perVariant] = await Promise.all([
 				fetchStatus(),
-				fetchBestPlays(undefined, undefined, undefined, 100),
 				fetchMarketOverview(),
+				...VARIANTS.map((v) => fetchBestPlays(v, undefined, undefined, 100)),
 			]);
 			status = s;
-			bestPlays = bp;
+			bestPlays = perVariant.flat();
 			marketOverview = mo;
 
 			// Update connection status from Mercure

--- a/frontend/src/routes/lab/components/ByVariant.svelte
+++ b/frontend/src/routes/lab/components/ByVariant.svelte
@@ -1,12 +1,11 @@
 <script lang="ts">
-	import type { GemPlay } from '$lib/api';
+	import { VARIANTS, type GemPlay } from '$lib/api';
 	import BestPlays from './BestPlays.svelte';
 	import InfoTooltip from './InfoTooltip.svelte';
 	import Select from '$lib/components/Select.svelte';
 
 	let { allPlays = [], league = '' }: { allPlays?: GemPlay[]; league?: string } = $props();
 
-	const VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
 	const TABS = ['ALL', ...VARIANTS];
 	const COLORS = ['ALL', 'RED', 'GREEN', 'BLUE'];
 	const LIMIT_OPTIONS = [


### PR DESCRIPTION
## The bug

By Variant's "Show: 10/20/50" selector could not be honoured, because the data it filtered had already been truncated to a single global top-100.

The dashboard made one call — `fetchBestPlays(undefined, undefined, undefined, 100)` — and `ByVariant` filtered that shared array client-side. The server ranks globally by weighted ROI and caps at 100, so variants that rank well crowded out the rest. The per-variant split was an artifact of the global ranking, not of each variant's own pool.

Measured against production before POE-131 landed:

| variant | rows in the shared top-100 | rows the API returns per variant |
|---------|----------------------------|-----------------------------------|
| 1/0     | 23                         | 88                                |
| 1/20    | 60                         | 78                                |
| 20/0    | 9                          | 9                                 |
| 20/20   | 8                          | 9                                 |

## The fix

Fetch each variant separately and merge. The result is a **superset** of the old global list, so Best Plays is unaffected beyond seeing more candidates, and `ByVariant` needs no change at all — its existing filter now sees a full per-variant list.

## Why four requests and not one per tab

The four replace the global fetch rather than adding to it, so page load goes from 3 concurrent requests to 6.

This constraint is load-bearing. Commit `3e2f28d` is what introduced the bug, and it did so for a good reason: `ByVariant` used to fetch per variant, and that produced a 10+ request fan-out causing `ERR_INSUFFICIENT_RESOURCES`. Any fix has to stay well clear of that. Lazy per-tab fetching would have been fewer requests on load but needed its own cache plus invalidation on every Mercure tick — more moving parts for no gain at six.

## Desktop

Same bug, in both `LabPage`'s initial load and its lab-mode-change path. Both now route through one `loadBestPlays()` helper.

Dedication mode is deliberately excluded: it has a single `21/23` variant and pools by skill/transfigured rather than by variant, so the split does not apply there.

## Drift guard

`VARIANTS` moves into `api.ts` on both clients. The fetch list and the tab list are now the same constant — previously they were two independent literals, and a variant present in one but not the other would silently show an empty tab with no error.

## Relationship to POE-131

Independent, and complementary. POE-131 (merged) raised how many gems exist to rank — 20/20 went from ~9 candidates to ~87. This one governs how many of them reach each tab. Neither alone fixes the reported symptom.

## Verification

`go test -race ./...` green, `svelte-check` clean on desktop (274 files, 0 errors), frontend builds, desktop `api.test.ts` passes. Real effect is measured against prod after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)