### PR TITLE
POE-163: Variant selection SSOT — one market/pool across top bar, Rankings and Pool Overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ desktop/.svelte-kit/
 desktop/build/
 .superpowers/
 .claude/worktrees/
+# Pipeforge writes per-run triage state here. Untracked and unignored, it made
+# the pipeline's own `git status --porcelain` precheck report a dirty tree and
+# stop before doing any work.
+.claude/pipeforge/
 
 # Tauri signing keys (private key MUST NOT be committed)
 desktop/.tauri/

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test: ## Run all Go tests with race detection
 test-integration: ## Run Go integration tests (build tag: integration) against a throwaway database
 	./scripts/integration-test.sh
 
-qa: test desktop-test-js ## Run the Go suite and the desktop vitest suite
+qa: test desktop-test desktop-test-js ## Run the Go suite, the desktop Rust suite and the desktop vitest suite
 
 up: ## Start dev environment (Docker Compose)
 	docker compose up -d --build

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,16 @@ test-integration: ## Run Go integration tests (build tag: integration) against a
 # out for build cost: measured 37s for the whole qa run with its 119 Rust tests
 # included. Accepted trade-off — the gate pays a warm cargo build so the desktop
 # Rust tests run somewhere. Revisit if a cold build makes qa too slow to run.
-qa: test desktop-test desktop-test-js ## Run the Go suite, the desktop Rust suite and the desktop vitest suite
+qa: test desktop-test desktop-test-js deps-check ## Run the Go suite, the desktop Rust suite, the desktop vitest suite and the dependency-contract check
+
+# `npm ls --all` exits non-zero when an installed package violates a declared
+# peer range. That state is otherwise invisible until it misbehaves: the
+# vite-plugin-svelte 4 / Vite 6 mismatch bundled Svelte's *server* runtime into
+# the desktop dev build, turning every `untrack` into a no-op — tests kept
+# passing, only real typing broke. Nothing else in the gate reads peer ranges.
+deps-check: ## Fail if installed npm deps violate declared peer ranges
+	docker compose run --rm -w /app/desktop desktop sh -c 'npm ls --all >/dev/null'
+	docker compose run --rm frontend sh -c 'cd /app && npm ls --all >/dev/null'
 
 up: ## Start dev environment (Docker Compose)
 	docker compose up -d --build

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ test: ## Run all Go tests with race detection
 test-integration: ## Run Go integration tests (build tag: integration) against a throwaway database
 	./scripts/integration-test.sh
 
+# desktop-test (cargo) is in the gate despite the earlier decision to keep it
+# out for build cost: measured 37s for the whole qa run with its 119 Rust tests
+# included. Accepted trade-off — the gate pays a warm cargo build so the desktop
+# Rust tests run somewhere. Revisit if a cold build makes qa too slow to run.
 qa: test desktop-test desktop-test-js ## Run the Go suite, the desktop Rust suite and the desktop vitest suite
 
 up: ## Start dev environment (Docker Compose)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help build test test-integration qa up down migrate migrate-down migrate-force migration build-collector shell-collector logs-collector desktop-check desktop-test desktop-build desktop-deploy desktop-sync desktop-watch
+.PHONY: help build test test-integration qa up down migrate migrate-down migrate-force migration build-collector shell-collector logs-collector desktop-check desktop-test desktop-test-js desktop-build desktop-deploy desktop-sync desktop-watch
 
 help: ## Show available commands
 	@grep -E '^[a-zA-Z_-]+:.*## ' Makefile | sed 's/:.*## /\t/' | awk -F '\t' '{printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -16,7 +16,7 @@ test: ## Run all Go tests with race detection
 test-integration: ## Run Go integration tests (build tag: integration) against a throwaway database
 	./scripts/integration-test.sh
 
-qa: test ## Alias for test
+qa: test desktop-test-js ## Run the Go suite and the desktop vitest suite
 
 up: ## Start dev environment (Docker Compose)
 	docker compose up -d --build
@@ -61,6 +61,9 @@ desktop-check: ## Cargo check desktop (Rust)
 
 desktop-test: ## Run desktop Rust tests
 	docker compose run --rm -w /app/desktop/src-tauri desktop cargo test
+
+desktop-test-js: ## Run desktop JS/TS tests (vitest)
+	docker compose run --rm -w /app/desktop desktop sh -c '[ -x node_modules/.bin/vitest ] || npm ci; npm test'
 
 desktop-build: ## Build desktop release binary
 	docker compose run --rm -w /app/desktop/src-tauri desktop cargo build --release

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "profitofexile-desktop",
-  "version": "0.6.1",
+  "version": "0.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "profitofexile-desktop",
-      "version": "0.6.1",
+      "version": "0.7.5",
       "dependencies": {
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.0"
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.0",
         "@sveltejs/kit": "^2.0.0",
-        "@sveltejs/vite-plugin-svelte": "^4.0.0",
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tauri-apps/api": "^2.0.0",
         "@tauri-apps/cli": "^2.0.0",
         "svelte": "^5.0.0",
@@ -943,31 +943,31 @@
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-4.0.4.tgz",
-      "integrity": "sha512-0ba1RQ/PHen5FGpdSrW7Y3fAMQjrXantECALeOiOdBdzR5+5vPP6HVZRLmZaQL+W8m++o+haIAKq5qT+MiZ7VA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-5.1.1.tgz",
+      "integrity": "sha512-Y1Cs7hhTc+a5E9Va/xwKlAJoariQyHY+5zBgCZg4PFWNYQ1nMN9sjK1zhw1gK69DuqVP++sht/1GZg1aRwmAXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sveltejs/vite-plugin-svelte-inspector": "^3.0.0-next.0||^3.0.0",
-        "debug": "^4.3.7",
+        "@sveltejs/vite-plugin-svelte-inspector": "^4.0.1",
+        "debug": "^4.4.1",
         "deepmerge": "^4.3.1",
         "kleur": "^4.1.5",
-        "magic-string": "^0.30.12",
-        "vitefu": "^1.0.3"
+        "magic-string": "^0.30.17",
+        "vitefu": "^1.0.6"
       },
       "engines": {
         "node": "^18.0.0 || ^20.0.0 || >=22"
       },
       "peerDependencies": {
-        "svelte": "^5.0.0-next.96 || ^5.0.0",
-        "vite": "^5.0.0"
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
       }
     },
     "node_modules/@sveltejs/vite-plugin-svelte-inspector": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-3.0.1.tgz",
-      "integrity": "sha512-2CKypmj1sM4GE7HjllT7UKmo4Q6L5xFRd7VMGEWhYnZ+wc6AUVU01IBd7yUi6WnFndEwWoMNOd6e8UjoN0nbvQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-4.0.1.tgz",
+      "integrity": "sha512-J/Nmb2Q2y7mck2hyCX4ckVHcR5tu2J+MtBEQqpDrrgELZ2uvraQcK/ioCV61AqkdXFgriksOKIceDcQmqnGhVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -977,9 +977,9 @@
         "node": "^18.0.0 || ^20.0.0 || >=22"
       },
       "peerDependencies": {
-        "@sveltejs/vite-plugin-svelte": "^4.0.0-next.0||^4.0.0",
-        "svelte": "^5.0.0-next.96 || ^5.0.0",
-        "vite": "^5.0.0"
+        "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "svelte": "^5.0.0",
+        "vite": "^6.0.0"
       }
     },
     "node_modules/@tauri-apps/api": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.0",
     "@sveltejs/kit": "^2.0.0",
-    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tauri-apps/api": "^2.0.0",
     "@tauri-apps/cli": "^2.0.0",
     "svelte": "^5.0.0",

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -150,6 +150,10 @@ pub struct AppState {
     pub dedication_variant: Mutex<String>,
     pub normal_variant: Mutex<String>,
     pub show_low_confidence: Mutex<bool>,
+    /// Schema-less UI view preferences (sort mode, colour filter, row limit…).
+    /// The frontend owns the keys; Rust only stores and persists the map. A
+    /// typed Settings field is warranted only when Rust itself reads the value.
+    pub ui_prefs: Mutex<std::collections::HashMap<String, String>>,
     /// App-wide cross-window state SSOT (POE-128). Rust-owned; overlays read it
     /// by polling the `get_ssot` command. See src/ssot.rs.
     pub ssot: Mutex<ssot::AppSsotSnapshot>,
@@ -1637,6 +1641,20 @@ fn set_show_low_confidence(show: bool, app: AppHandle) {
 }
 
 #[tauri::command]
+fn get_ui_prefs(app: AppHandle) -> std::collections::HashMap<String, String> {
+    let state = app.state::<AppState>();
+    let prefs = state.ui_prefs.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    prefs
+}
+
+#[tauri::command]
+fn set_ui_pref(key: String, value: String, app: AppHandle) {
+    let state = app.state::<AppState>();
+    state.ui_prefs.lock().unwrap_or_else(|e| e.into_inner()).insert(key, value);
+    persist_settings(&app);
+}
+
+#[tauri::command]
 fn get_logs(state: tauri::State<AppState>) -> Vec<String> {
     state.logs.lock().unwrap_or_else(|e| e.into_inner()).clone()
 }
@@ -2919,6 +2937,7 @@ pub fn run() {
         dedication_variant: Mutex::new(String::from("21/23")),
         normal_variant: Mutex::new(String::from("20/20")),
         show_low_confidence: Mutex::new(false),
+        ui_prefs: Mutex::new(std::collections::HashMap::new()),
         ssot: Mutex::new(ssot::AppSsotSnapshot::default()),
     };
 
@@ -2997,6 +3016,8 @@ pub fn run() {
             set_normal_variant,
             get_show_low_confidence,
             set_show_low_confidence,
+            get_ui_prefs,
+            set_ui_pref,
             discard_font_session,
         ])
         .setup(|app| {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -55,6 +55,9 @@ pub struct AppStatus {
     pub trade_auto_refresh_secs: u32,
     pub auto_trade_enabled: bool,
     pub device_id: String,
+    /// Sealed rounds accumulated in the current font session. Drives the
+    /// discard affordance: zero means there is nothing to throw away.
+    pub font_session_rounds: usize,
 }
 
 /// Accumulated font session data — shared between font scan loop and event handlers.
@@ -173,6 +176,7 @@ fn build_status(state: &AppState) -> AppStatus {
         trade_auto_refresh_secs: *state.trade_auto_refresh_secs.lock().unwrap_or_else(|e| e.into_inner()),
         auto_trade_enabled: *state.auto_trade_enabled.lock().unwrap_or_else(|e| e.into_inner()),
         device_id: state.device_id.clone(),
+        font_session_rounds: state.font_session.lock().unwrap_or_else(|e| e.into_inner()).rounds.len(),
     }
 }
 
@@ -2180,6 +2184,28 @@ fn seal_font_round(app: &AppHandle) -> bool {
     is_last
 }
 
+/// Throw away the accumulated font session without sending it (POE-163 D4).
+///
+/// The escape hatch for a session captured against the wrong market: the
+/// stamp is read once at send time, so an unwanted run has to be discarded
+/// rather than corrected after the fact.
+///
+/// Deliberately does NOT touch `font_scan_generation` (discarding data must
+/// not stop an in-progress scan) or `lab_state` (the player may still be in
+/// the lab).
+#[tauri::command]
+fn discard_font_session(app: AppHandle) {
+    let state = app.state::<AppState>();
+    let discarded = {
+        let mut session = state.font_session.lock().unwrap_or_else(|e| e.into_inner());
+        let discarded = session.rounds.len();
+        *session = FontSessionData::default();
+        discarded
+    };
+    app_log(&app, format!("Font session discarded ({} rounds)", discarded));
+    emit_status(&app);
+}
+
 /// Send accumulated font session to the server and reset.
 fn send_font_session_data(app: &AppHandle) {
     let state = app.state::<AppState>();
@@ -2937,6 +2963,7 @@ pub fn run() {
             set_normal_variant,
             get_show_low_confidence,
             set_show_low_confidence,
+            discard_font_session,
         ])
         .setup(|app| {
             let handle = app.handle().clone();

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -2019,10 +2019,15 @@ fn spawn_font_scan(app: &AppHandle) {
     let state = app.state::<AppState>();
     let gen = state.font_scan_generation.fetch_add(1, Ordering::SeqCst) + 1;
 
-    // Reset font session for the new scan.
+    // Reset font session for the new scan. The temporary guard is dropped at the
+    // end of this statement, so the emit below cannot self-deadlock on
+    // `build_status` re-reading `font_session`.
     *state.font_session.lock().unwrap_or_else(|e| e.into_inner()) = FontSessionData::default();
 
     app_log(app, format!("Font scan started (gen={})", gen));
+    // `font_session_rounds` dropped back to 0 — clear the Discard affordance
+    // left over from the previous run instead of waiting for the next emit.
+    emit_status(app);
 
     let app_capture = app.clone();
     std::thread::spawn(move || {
@@ -2152,34 +2157,51 @@ fn font_scan_loop(app: AppHandle, generation: u64) {
 /// Moves current_options into the rounds list. Returns true if this was the last craft.
 fn seal_font_round(app: &AppHandle) -> bool {
     let state = app.state::<AppState>();
-    let mut session = state.font_session.lock().unwrap_or_else(|e| e.into_inner());
 
-    let options = match session.current_options.take() {
-        Some(opts) => opts,
-        None => {
-            app_log(app, "Font round seal skipped — OCR did not capture options before CRAFT click".to_string());
-            return false;
-        }
+    // The guard lives in this block only: `emit_status` -> `build_status` locks
+    // `font_session` to read `font_session_rounds`, and std Mutex is not
+    // re-entrant, so emitting while the guard is alive deadlocks this thread.
+    let is_last = {
+        let mut session = state.font_session.lock().unwrap_or_else(|e| e.into_inner());
+
+        let options = match session.current_options.take() {
+            Some(opts) => opts,
+            None => {
+                app_log(app, "Font round seal skipped — OCR did not capture options before CRAFT click".to_string());
+                // Nothing was appended to `rounds`, so the status the frontend
+                // already holds is still accurate — no emit needed.
+                return false;
+            }
+        };
+
+        let crafts_remaining = session.current_crafts_remaining.take();
+        // is_last: only true if we've already used at least one craft AND no "Crafts Remaining"
+        // text was detected. On the first craft, None could mean single-craft OR OCR missed it —
+        // so don't assume last on first round (prevents blocking multi-craft labs).
+        let is_last = crafts_remaining.is_none() && !session.rounds.is_empty();
+
+        let round_num = session.rounds.len() + 1;
+        app_log(app, format!(
+            "Font round {} sealed ({} options{})",
+            round_num,
+            options.len(),
+            if is_last { ", last craft" } else { "" },
+        ));
+
+        session.rounds.push(FontRound {
+            options,
+            crafts_remaining,
+        });
+
+        is_last
     };
 
-    let crafts_remaining = session.current_crafts_remaining.take();
-    // is_last: only true if we've already used at least one craft AND no "Crafts Remaining"
-    // text was detected. On the first craft, None could mean single-craft OR OCR missed it —
-    // so don't assume last on first round (prevents blocking multi-craft labs).
-    let is_last = crafts_remaining.is_none() && !session.rounds.is_empty();
-
-    let round_num = session.rounds.len() + 1;
-    app_log(app, format!(
-        "Font round {} sealed ({} options{})",
-        round_num,
-        options.len(),
-        if is_last { ", last craft" } else { "" },
-    ));
-
-    session.rounds.push(FontRound {
-        options,
-        crafts_remaining,
-    });
+    // `rounds` just grew, and `font_session_rounds` is what gates the Discard
+    // affordance and its round count. Nothing else emits after this on the
+    // CRAFT path: `spawn_gem_scan` emits before the seal, the per-gem emit only
+    // fires when OCR actually matches a gem, and CONFIRM bumps the scan
+    // generation so `gem_scan_loop`'s terminal idle emit is skipped.
+    emit_status(app);
 
     is_last
 }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -1379,6 +1379,17 @@ fn force_show_overlays(app: AppHandle) {
 }
 
 #[tauri::command]
+fn set_devtools(open: bool, window: tauri::WebviewWindow) {
+    // Devtools has no JS API in Tauri 2 — calling `openDevtools()` on the
+    // WebviewWindow object throws synchronously. This command is the only path.
+    if open {
+        window.open_devtools();
+    } else {
+        window.close_devtools();
+    }
+}
+
+#[tauri::command]
 fn set_comparator_data(payload: serde_json::Value, app: AppHandle) {
     let state = app.state::<AppState>();
     *state.comparator_data.lock().unwrap_or_else(|e| e.into_inner()) = payload;
@@ -2947,6 +2958,7 @@ pub fn run() {
             send_test_gems,
             test_ocr_on_image,
             force_show_overlays,
+            set_devtools,
             set_comparator_data,
             set_overlay_has_content,
             set_overlay_interactive_width,

--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -70,6 +70,11 @@ pub struct Settings {
     /// Show low-confidence gems in rankings (default: false).
     #[serde(default)]
     pub show_low_confidence: bool,
+    /// Schema-less UI view preferences (sort mode, colour filter, row limit…).
+    /// The frontend owns the keys and values; Rust stores and persists the map
+    /// blindly. Add a typed field here only when Rust itself reads the value.
+    #[serde(default)]
+    pub ui_prefs: std::collections::HashMap<String, String>,
 }
 
 fn default_lab_mode() -> String {
@@ -150,6 +155,7 @@ impl Default for Settings {
             // 20-level variants a thin market is normal, so hiding flagged gems
             // by default reproduces the POE-131 ranking gap.
             show_low_confidence: true,
+            ui_prefs: std::collections::HashMap::new(),
         }
     }
 }
@@ -255,6 +261,7 @@ pub fn from_state(state: &crate::AppState) -> Settings {
         dedication_variant: state.dedication_variant.lock().unwrap_or_else(|e| e.into_inner()).clone(),
         normal_variant: state.normal_variant.lock().unwrap_or_else(|e| e.into_inner()).clone(),
         show_low_confidence: *state.show_low_confidence.lock().unwrap_or_else(|e| e.into_inner()),
+        ui_prefs: state.ui_prefs.lock().unwrap_or_else(|e| e.into_inner()).clone(),
     }
 }
 
@@ -370,4 +377,5 @@ pub fn apply_to_state(settings: &Settings, state: &crate::AppState) {
     *state.dedication_variant.lock().unwrap_or_else(|e| e.into_inner()) = settings.dedication_variant.clone();
     *state.normal_variant.lock().unwrap_or_else(|e| e.into_inner()) = settings.normal_variant.clone();
     *state.show_low_confidence.lock().unwrap_or_else(|e| e.into_inner()) = settings.show_low_confidence;
+    *state.ui_prefs.lock().unwrap_or_else(|e| e.into_inner()) = settings.ui_prefs.clone();
 }

--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -218,8 +218,16 @@ pub fn save(app: &tauri::AppHandle, settings: &Settings) {
     };
     match serde_json::to_string_pretty(settings) {
         Ok(json) => {
-            if let Err(e) = fs::write(&path, &json) {
-                log::error!("Failed to write settings to {:?}: {}", path, e);
+            // Write-temp-then-rename: a plain fs::write leaves a truncated
+            // settings file if the process dies mid-write, and this path runs
+            // on every persisted preference change, not just discrete toggles.
+            let tmp = path.with_extension("json.tmp");
+            if let Err(e) = fs::write(&tmp, &json) {
+                log::error!("Failed to write settings to {:?}: {}", tmp, e);
+                return;
+            }
+            if let Err(e) = fs::rename(&tmp, &path) {
+                log::error!("Failed to move settings into place at {:?}: {}", path, e);
             }
         }
         Err(e) => {

--- a/desktop/src-tauri/src/ssot.rs
+++ b/desktop/src-tauri/src/ssot.rs
@@ -64,6 +64,7 @@ pub struct LeagueSlice {
 /// The `Default` gives `league.name == None` (fail-closed) — locked by the
 /// unit test below. Future slices are added as sibling fields here.
 #[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppSsotSnapshot {
     pub league: LeagueSlice,
     /// A league resolve is currently in flight (the bounded-retry fetch task is
@@ -80,7 +81,63 @@ pub struct AppSsotSnapshot {
     /// fresh "Resolving…" flash (Refresh disabled). Cleared on the next
     /// successful fetch. `Default` is `false`.
     pub unreachable: bool,
+    /// The selected Normal-mode market ("20/20", "20/0", "1/20", "1/0").
+    ///
+    /// Composed at read time from `AppState.normal_variant`, which stays the
+    /// owner — this field is NOT stored in `AppState.ssot`, so there is no
+    /// second copy to keep in sync on every `set_normal_variant`. `Default` is
+    /// the empty string, which the webview must reject as "unknown".
+    pub normal_variant: String,
+    /// The selected Dedication corrupted market ("21/23", "21/20").
+    ///
+    /// Composed at read time from `AppState.dedication_variant`, which stays
+    /// the owner — not stored in `AppState.ssot`. `Default` is the empty
+    /// string, which the webview must reject as "unknown".
+    pub dedication_variant: String,
+    /// The selected Dedication rankings pool ("skill", "transfigured").
+    ///
+    /// Composed at read time from `AppState.dedication_pool`, which stays the
+    /// owner — not stored in `AppState.ssot`. `Default` is the empty string,
+    /// which the webview must reject as "unknown".
+    pub dedication_pool: String,
     // future slices (e.g. account, config) added here as later tasks land.
+}
+
+/// Return `base` with the three market fields replaced by the given values.
+///
+/// Pure so the composition is unit-testable without an `AppHandle` or a full
+/// `AppState` — same reason `should_flag_unreachable` and
+/// `clear_resolution_flags` are extracted.
+fn compose_snapshot(
+    base: AppSsotSnapshot,
+    normal_variant: String,
+    dedication_variant: String,
+    dedication_pool: String,
+) -> AppSsotSnapshot {
+    AppSsotSnapshot {
+        normal_variant,
+        dedication_variant,
+        dedication_pool,
+        ..base
+    }
+}
+
+/// Build the full snapshot: the stored `AppState.ssot` slice plus the market
+/// fields composed from their owning `AppState` Mutexes.
+///
+/// The `ssot` guard is dropped before the market Mutexes are locked (never two
+/// guards at once), matching the lock-then-emit discipline documented on
+/// `emit_ssot`. Both `get_ssot` and `emit_ssot` go through here so the two
+/// paths cannot compose different snapshots.
+pub fn build_snapshot(state: &AppState) -> AppSsotSnapshot {
+    let base = {
+        let guard = state.ssot.lock().unwrap_or_else(|e| e.into_inner());
+        guard.clone()
+    };
+    let normal_variant = state.normal_variant.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    let dedication_variant = state.dedication_variant.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    let dedication_pool = state.dedication_pool.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    compose_snapshot(base, normal_variant, dedication_variant, dedication_pool)
 }
 
 /// Whether `consecutive_failures` failed fetch attempts should flip the SSOT to
@@ -109,19 +166,18 @@ fn clear_resolution_flags(ssot: &std::sync::Mutex<AppSsotSnapshot>) {
 pub fn emit_ssot(app: &AppHandle) {
     let snapshot = {
         let state = app.state::<AppState>();
-        let guard = state.ssot.lock().unwrap_or_else(|e| e.into_inner());
-        guard.clone()
+        build_snapshot(&state)
     };
     if let Err(e) = app.emit("ssot-changed", snapshot) {
         log::warn!("emit ssot-changed failed: {}", e);
     }
 }
 
-/// Poll target for overlay windows: lock, clone the snapshot, drop the guard,
-/// return the clone. Serialized to the webview.
+/// Poll target for overlay windows: compose the snapshot from the stored slice
+/// plus the market fields, and return it. Serialized to the webview.
 #[tauri::command]
 pub fn get_ssot(state: tauri::State<AppState>) -> AppSsotSnapshot {
-    state.ssot.lock().unwrap_or_else(|e| e.into_inner()).clone()
+    build_snapshot(&state)
 }
 
 /// Dual-write the resolved league into both sources of truth.
@@ -554,5 +610,100 @@ mod tests {
             parse_league_from_status(&serde_json::json!({ "league": 42 })),
             None,
         );
+    }
+
+    /// The composition contract: every one of the three market values lands in
+    /// the returned snapshot, each in its own field. Distinct values so a
+    /// crossed assignment (pool into variant, etc.) fails instead of passing.
+    #[test]
+    fn compose_snapshot_writes_all_three_market_values() {
+        let out = compose_snapshot(
+            AppSsotSnapshot::default(),
+            "1/20".to_string(),
+            "21/20".to_string(),
+            "transfigured".to_string(),
+        );
+
+        assert_eq!(out.normal_variant, "1/20");
+        assert_eq!(out.dedication_variant, "21/20");
+        assert_eq!(out.dedication_pool, "transfigured");
+    }
+
+    /// Composition must not disturb the league slice it wraps: the stored
+    /// `AppState.ssot` fields survive the market overlay untouched, so a poll
+    /// never trades a resolved league for a market selection.
+    #[test]
+    fn compose_snapshot_preserves_the_stored_league_slice() {
+        let base = AppSsotSnapshot {
+            league: LeagueSlice { name: Some("Mirage".to_string()) },
+            resolving: true,
+            unreachable: true,
+            ..Default::default()
+        };
+
+        let out = compose_snapshot(
+            base,
+            "20/20".to_string(),
+            "21/23".to_string(),
+            "skill".to_string(),
+        );
+
+        assert_eq!(out.league.name, Some("Mirage".to_string()));
+        assert!(out.resolving, "resolving must survive composition");
+        assert!(out.unreachable, "unreachable must survive composition");
+    }
+
+    /// Wire contract: the TypeScript store reads camelCase keys, and the Rust
+    /// field names are snake_case — the `rename_all` attribute is what bridges
+    /// them. Dropping it renames these keys and silently breaks the store.
+    #[test]
+    fn snapshot_serializes_market_fields_as_camel_case() {
+        let snap = compose_snapshot(
+            AppSsotSnapshot::default(),
+            "20/0".to_string(),
+            "21/20".to_string(),
+            "transfigured".to_string(),
+        );
+
+        let json = serde_json::to_value(&snap).unwrap();
+
+        assert_eq!(json.get("normalVariant").and_then(|v| v.as_str()), Some("20/0"));
+        assert_eq!(json.get("dedicationVariant").and_then(|v| v.as_str()), Some("21/20"));
+        assert_eq!(json.get("dedicationPool").and_then(|v| v.as_str()), Some("transfigured"));
+    }
+
+    /// The same `rename_all` must leave the pre-existing keys alone — they are
+    /// single words, so camelCase is a no-op on them. The store already reads
+    /// `league` / `resolving` / `unreachable` by these exact names.
+    #[test]
+    fn snapshot_serialization_keeps_the_existing_league_keys() {
+        let snap = AppSsotSnapshot {
+            league: LeagueSlice { name: Some("Mirage".to_string()) },
+            resolving: true,
+            unreachable: true,
+            ..Default::default()
+        };
+
+        let json = serde_json::to_value(&snap).unwrap();
+
+        assert_eq!(
+            json.get("league").and_then(|v| v.get("name")).and_then(|v| v.as_str()),
+            Some("Mirage"),
+        );
+        assert_eq!(json.get("resolving").and_then(|v| v.as_bool()), Some(true));
+        assert_eq!(json.get("unreachable").and_then(|v| v.as_bool()), Some(true));
+    }
+
+    /// Fail-closed default: a snapshot that was never composed from `AppState`
+    /// carries empty markets, never a plausible-looking "20/20". The webview
+    /// treats empty as unknown, so a default can't be mistaken for a real
+    /// selection.
+    #[test]
+    fn default_snapshot_has_no_market_selection() {
+        let snap = AppSsotSnapshot::default();
+
+        assert_eq!(snap.normal_variant, "");
+        assert_eq!(snap.dedication_variant, "");
+        assert_eq!(snap.dedication_pool, "");
     }
 }

--- a/desktop/src/lib/README.md
+++ b/desktop/src/lib/README.md
@@ -7,6 +7,7 @@ Component registry for the ProfitOfExile desktop app. Read this first before cre
 | File | Export | Description |
 |------|--------|-------------|
 | `stores/status.svelte.ts` | `store`, `initStatusStore()` | Shared app state — event-driven from Rust backend. No polling. Call `initStatusStore()` once from root layout. Read `store.status` and `store.logs` reactively. |
+| `stores/ssot.svelte.ts` | `ssot`, `startSsotStore()`, `setNormalVariant()`, `setDedicationVariant()`, `setDedicationPool()`, `setDedicationSelection()` | Rust-owned single source of truth for market selection, polled every 3000 ms. Read `ssot.league` / `ssot.normalVariant` / `ssot.dedicationVariant` / `ssot.dedicationPool` reactively; write through the exported setters (never assign the fields directly or keep a local copy). |
 | `stores/navigation.svelte.ts` | `nav` | Global view toggle. `nav.view` is `'lab' \| 'settings' \| 'dev'`. All pages are always mounted (hidden via CSS) — do not use SvelteKit routing for main views because it unmounts their listeners. |
 
 ## Components
@@ -19,6 +20,7 @@ Component registry for the ProfitOfExile desktop app. Read this first before cre
 | `components/IdentifyDialog.svelte` | `open` (bindable) | Device identify dialog — shows short device ID, alias input, POST to `/api/device/identify`. Triggered by Ctrl+Shift+I. |
 | `components/Button.svelte` | `variant` (`'default'`/`'save'`/`'danger'`), `disabled`, `title`, `onclick`, children | Small action button — default (neutral), save (green), danger (red). Disabled state dims to 35% opacity. |
 | `components/Toggle.svelte` | `checked` (bindable) | On/off toggle switch — dark-themed, animated knob. |
+| `components/SegmentedButtons.svelte` | `value`, `options`, `onselect`, `title` | Horizontal segmented button group — one bordered container, flat buttons, active segment filled. `value` is not bindable: the owning store stays the source of truth and `onselect` reports the pick. |
 | `components/RangeSlider.svelte` | `value` (bindable), `min`, `max`, `step`, `formatValue` | Range slider with value display — optional format function for labels (e.g., `v => \`${v}%\``). |
 | `components/Tooltip.svelte` | `content`, `position`, children | Reusable tooltip wrapper for desktop controls. |
 

--- a/desktop/src/lib/api.ts
+++ b/desktop/src/lib/api.ts
@@ -153,6 +153,29 @@ export interface DedicationEVResponse {
 export const DEDICATION_VARIANTS = ['21/20', '21/23'] as const;
 export type DedicationVariant = typeof DEDICATION_VARIANTS[number];
 
+/**
+ * The two Dedication gem pools, in the canon spelling — the one Rust, the
+ * settings file and the database use. The Font EV JSON wire format spells the
+ * first one `skills`; that boundary is translated in FontEVCompare rather than
+ * renamed here, because the web frontend shares the wire key.
+ */
+export const DEDICATION_POOLS = ['skill', 'transfigured'] as const;
+export type DedicationPool = typeof DEDICATION_POOLS[number];
+
+/**
+ * Display labels for the pools. Every surface that names a pool reads them from
+ * here — they were previously written out at each call site, so renaming one
+ * label meant finding six of them.
+ *
+ * "Non-Transfigured" rather than "Normal": the top bar already labels the lab
+ * mode Normal, and two adjacent buttons both reading Normal would name two
+ * different things.
+ */
+export const DEDICATION_POOL_LABELS: Record<DedicationPool, string> = {
+	skill: 'Non-Transfigured',
+	transfigured: 'Transfigured',
+};
+
 export interface MarketOverviewData {
 	avgTransPrice: number;
 	avgTransPriceDelta: number;

--- a/desktop/src/lib/components/SegmentedButtons.svelte
+++ b/desktop/src/lib/components/SegmentedButtons.svelte
@@ -12,11 +12,12 @@
 	} = $props();
 </script>
 
-<div class="segmented" {title}>
-	{#each options as option}
+<div class="segmented" role="group" {title}>
+	{#each options as option (option.value)}
 		<button
 			class="segmented-btn"
 			class:active={option.value === value}
+			aria-pressed={option.value === value}
 			onclick={() => onselect(option.value)}
 		>
 			{option.label}

--- a/desktop/src/lib/components/SegmentedButtons.svelte
+++ b/desktop/src/lib/components/SegmentedButtons.svelte
@@ -1,0 +1,54 @@
+<script lang="ts">
+	let {
+		value,
+		options,
+		onselect,
+		title,
+	}: {
+		value: string;
+		options: { value: string; label: string }[];
+		onselect: (value: string) => void;
+		title?: string;
+	} = $props();
+</script>
+
+<div class="segmented" {title}>
+	{#each options as option}
+		<button
+			class="segmented-btn"
+			class:active={option.value === value}
+			onclick={() => onselect(option.value)}
+		>
+			{option.label}
+		</button>
+	{/each}
+</div>
+
+<style>
+	.segmented {
+		display: flex;
+		gap: 0;
+		border: 1px solid var(--color-lab-border);
+		border-radius: 4px;
+		overflow: hidden;
+	}
+	.segmented-btn {
+		background: transparent;
+		border: none;
+		color: var(--color-lab-text-secondary);
+		padding: 4px 10px;
+		font-size: 0.6875rem;
+		font-weight: 600;
+		cursor: pointer;
+		font-family: inherit;
+		transition: background 0.15s, color 0.15s;
+	}
+	.segmented-btn:hover {
+		color: var(--color-lab-text);
+		background: rgba(255, 255, 255, 0.05);
+	}
+	.segmented-btn.active {
+		color: var(--color-lab-text);
+		background: rgba(99, 102, 241, 0.2);
+	}
+</style>

--- a/desktop/src/lib/pages/LabPage.svelte
+++ b/desktop/src/lib/pages/LabPage.svelte
@@ -517,6 +517,13 @@
 		display: flex;
 		align-items: center;
 		justify-content: space-between;
+		/* Wrap: this row holds six nav tabs, the lab-mode buttons, and in
+		   Dedication mode a market picker AND a pool picker, plus the scan
+		   controls. Nothing in it can shrink below its content, and the default
+		   window is 1024px (src-tauri/tauri.conf.json), so a no-wrap row pushed
+		   the Scan button out of reach. */
+		flex-wrap: wrap;
+		gap: 8px;
 		background: var(--color-lab-surface);
 		border: 1px solid var(--color-lab-border);
 		padding: 0 16px;
@@ -726,8 +733,13 @@
 		padding-left: 4px !important;
 		white-space: nowrap;
 	}
+	/* 65px was sized for the old "Skill Gems" label, whose longest token is
+	   "Skill". "Non-Transfigured" breaks to "Transfigured" (~90px), and with
+	   border-collapse: separate and no table-layout: fixed, min-content beats the
+	   width, so the column silently widened and squeezed the three colour
+	   columns. Allow the wider label rather than pretend 65px holds it. */
 	.dashboard :global(.var) {
-		width: 65px !important;
+		width: 110px !important;
 		text-align: center !important;
 		padding: 2px 2px !important;
 		font-size: 1rem;

--- a/desktop/src/lib/pages/LabPage.svelte
+++ b/desktop/src/lib/pages/LabPage.svelte
@@ -3,6 +3,7 @@
 	import { listen } from '@tauri-apps/api/event';
 	import { untrack } from 'svelte';
 	import { store } from '$lib/stores/status.svelte';
+	import { ssot, fetchSsot, setNormalVariant, setDedicationSelection } from '$lib/stores/ssot.svelte';
 	import { setDivineRate } from '$lib/price.svelte';
 	import {
 		fetchStatus,
@@ -11,13 +12,14 @@
 		DEDICATION_VARIANTS,
 		fetchMarketOverview,
 		connectMercure,
-		type DedicationVariant,
 		type StatusData,
 		type GemPlay,
 		type MarketOverviewData,
 		type MercureConnection,
 	} from '$lib/api';
 	import type { TradeLookupResult } from '$lib/tradeApi';
+	import SegmentedButtons from '$lib/components/SegmentedButtons.svelte';
+	import Button from '$lib/components/Button.svelte';
 
 	import Header from '../../routes/(app)/components/Header.svelte';
 	import Comparator from '../../routes/(app)/components/Comparator.svelte';
@@ -40,83 +42,28 @@
 	let isDedication = $derived(labMode === 'Dedication');
 	let labModeForChild = $derived<'normal' | 'dedication'>(isDedication ? 'dedication' : 'normal');
 
-	// --- Dedication variant ---
-	// 21/23 and 21/20 are separate corrupted markets, and every analysis surface
-	// now shows both at once. This selection is what Rust stamps onto uploaded
-	// font sessions (lib.rs send_font_session), so it records which market the
-	// player is actually feeding the font — it is not a view filter.
-	let dedVariant = $state<DedicationVariant>('21/23');
-
-	// --- Normal-mode market ---
-	// The Normal counterpart of dedVariant, and Rust-owned for the same reason:
-	// it is the market OCR'd gems are priced against, so the paired web view has
-	// to be able to read it. It used to live only inside the comparator, which
-	// left the web view pricing at a hardcoded 20/20 whatever was selected here.
-	const NORMAL_VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
-	let normalVariant = $state('20/20');
-
-	// Rust is the owner; these are its mirror. A pick made before the restore
-	// resolves is the newer truth — applying the restore over it would leave the
-	// picker showing one market while Rust stamps scans with another, with no way
-	// back short of picking a different market and returning.
-	let pickedDedVariant = false;
-	let pickedNormalVariant = false;
-
-	/**
-	 * Pull mode and both markets from Rust into the mirror.
-	 *
-	 * `authoritative` is for a reset, which replaces what the player picked:
-	 * the ordinary mount-time restore defers to a pick that already happened.
-	 */
-	function restoreFromRust(authoritative = false) {
+	// The market lives in the ssot store (POE-163) — this page reads `ssot.*` and
+	// writes through its setters. Lab mode is the only selection still restored
+	// from Rust here: it is not part of the SSOT snapshot.
+	function restoreFromRust() {
 		invoke<string>('get_lab_mode')
 			.then((mode) => {
 				if (mode === 'Normal' || mode === 'Dedication') labMode = mode;
 			})
 			.catch(e => console.warn('[LabPage] get_lab_mode failed:', e));
-
-		invoke<string>('get_dedication_variant')
-			.then((v) => {
-				if (pickedDedVariant && !authoritative) return;
-				if ((DEDICATION_VARIANTS as readonly string[]).includes(v)) {
-					dedVariant = v as DedicationVariant;
-				} else if (v) {
-					// Correct the stored value too. The UI refuses to display it, but
-					// Rust keeps stamping it onto every uploaded font session, which
-					// would attribute recorded runs to a market nobody was shown.
-					console.warn('[LabPage] ignoring unknown persisted dedication variant:', v);
-					invoke('set_dedication_variant', { variant: dedVariant })
-						.catch(e => console.warn('[LabPage] set_dedication_variant failed:', e));
-				}
-			})
-			.catch(e => console.warn('[LabPage] get_dedication_variant failed:', e));
-
-		invoke<string>('get_normal_variant')
-			.then((v) => {
-				if (pickedNormalVariant && !authoritative) return;
-				if (NORMAL_VARIANTS.includes(v)) {
-					normalVariant = v;
-				} else if (v) {
-					console.warn('[LabPage] ignoring unknown persisted normal variant:', v);
-					invoke('set_normal_variant', { variant: normalVariant })
-						.catch(e => console.warn('[LabPage] set_normal_variant failed:', e));
-				}
-			})
-			.catch(e => console.warn('[LabPage] get_normal_variant failed:', e));
 	}
 
 	restoreFromRust();
 
-	// Reset Everything rewrites mode and both markets in Rust. This page reads
-	// them once, so without re-reading the mirror would keep showing the
-	// pre-reset market while every scan carried the reset one.
+	// Reset Everything rewrites mode and both markets in Rust. The store's poll
+	// would pick the markets up within an interval, but the top bar would show
+	// the pre-reset selection until then, so pull both immediately.
 	$effect(() => {
 		let cancelled = false;
 		const unlistenPromise = listen('settings-reset', () => {
 			if (cancelled) return;
-			pickedDedVariant = false;
-			pickedNormalVariant = false;
-			restoreFromRust(true);
+			restoreFromRust();
+			fetchSsot();
 		});
 		return () => {
 			cancelled = true;
@@ -124,20 +71,47 @@
 		};
 	});
 
-	function handleNormalVariantChange(variant: string) {
-		pickedNormalVariant = true;
-		if (variant === normalVariant) return;
-		normalVariant = variant;
-		invoke('set_normal_variant', { variant }).catch(e => console.warn('[LabPage] set_normal_variant failed:', e));
+	const LAB_MODE_OPTIONS = LAB_MODES.map((m) => ({ value: m, label: m }));
+	const NORMAL_MARKET_OPTIONS = VARIANTS.map((v) => ({ value: v, label: v }));
+	const DEDICATION_MARKET_OPTIONS = DEDICATION_VARIANTS.map((v) => ({ value: v, label: v }));
+	const POOL_OPTIONS = [
+		{ value: 'skill', label: 'Skills' },
+		{ value: 'transfigured', label: 'Transfigured' },
+	];
+
+	const MARKET_TOOLTIP =
+		'Market you are farming. Rankings and Pool Overview follow it, and the run is stamped with it when it uploads.';
+
+	// --- Discard the pending font session ---
+	// The stamp is taken once, at send time, so any market click before the send
+	// re-stamps the whole accumulated session. Two-step confirm because this
+	// button sits beside the frequently clicked market buttons and a discarded
+	// run cannot be recaptured.
+	let discardArmed = $state(false);
+	let discardTimer: ReturnType<typeof setTimeout> | null = null;
+	const DISCARD_ARM_MS = 4000;
+
+	function handleDiscardFontSession() {
+		if (discardArmed) {
+			if (discardTimer) clearTimeout(discardTimer);
+			discardTimer = null;
+			discardArmed = false;
+			invoke('discard_font_session')
+				.catch(e => console.warn('[LabPage] discard_font_session failed:', e));
+			return;
+		}
+		discardArmed = true;
+		if (discardTimer) clearTimeout(discardTimer);
+		discardTimer = setTimeout(() => {
+			discardTimer = null;
+			discardArmed = false;
+		}, DISCARD_ARM_MS);
 	}
 
-	function handleDedVariantChange(variant: DedicationVariant) {
-		pickedDedVariant = true;
-		if (variant === dedVariant) return;
-		dedVariant = variant;
-		invoke('set_dedication_variant', { variant }).catch(e => console.warn('[LabPage] set_dedication_variant failed:', e));
-		// No re-fetch: the rankings hold both markets and filter locally now.
-	}
+	$effect(() => () => {
+		if (discardTimer) clearTimeout(discardTimer);
+		discardTimer = null;
+	});
 
 	// Rankings generation guard + failure surfacing. A re-fetch that loses a race
 	// or fails silently would leave the previous mode's rows on screen, and the
@@ -440,21 +414,40 @@
 			{/each}
 		</div>
 		<div class="bar-right">
-			<div class="lab-mode-selector">
-				{#each LAB_MODES as mode}
-					<button class="lab-mode-btn" class:active={labMode === mode} onclick={() => handleLabModeChange(mode)}>
-						{mode}
-					</button>
-				{/each}
-			</div>
+			<SegmentedButtons
+				value={labMode}
+				options={LAB_MODE_OPTIONS}
+				onselect={(mode) => handleLabModeChange(mode as LabMode)}
+			/>
 			{#if isDedication}
-				<div class="lab-mode-selector" title="Market you are farming — recorded on uploaded runs. Every analysis surface shows both markets regardless.">
-					{#each DEDICATION_VARIANTS as variant}
-						<button class="lab-mode-btn" class:active={dedVariant === variant} onclick={() => handleDedVariantChange(variant)}>
-							{variant}
-						</button>
-					{/each}
-				</div>
+				<SegmentedButtons
+					value={ssot.dedicationVariant}
+					options={DEDICATION_MARKET_OPTIONS}
+					onselect={(variant) => setDedicationSelection(variant, ssot.dedicationPool)}
+					title={MARKET_TOOLTIP}
+				/>
+				<SegmentedButtons
+					value={ssot.dedicationPool}
+					options={POOL_OPTIONS}
+					onselect={(pool) => setDedicationSelection(ssot.dedicationVariant, pool)}
+					title="Gem pool you are farming — Rankings and Pool Overview follow it."
+				/>
+			{:else}
+				<SegmentedButtons
+					value={ssot.normalVariant}
+					options={NORMAL_MARKET_OPTIONS}
+					onselect={(variant) => setNormalVariant(variant)}
+					title={MARKET_TOOLTIP}
+				/>
+			{/if}
+			{#if (store.status?.font_session_rounds ?? 0) > 0}
+				<Button
+					variant={discardArmed ? 'danger' : 'default'}
+					onclick={handleDiscardFontSession}
+					title="The captured font session uploads stamped with the currently selected market. Discard it if it was captured against the wrong one."
+				>
+					{discardArmed ? 'Confirm discard' : `Discard font session (${store.status?.font_session_rounds ?? 0})`}
+				</Button>
 			{/if}
 			<div class="scan-controls">
 				<span class="scan-state" class:picking={store.status?.state === 'PickingGems'}>{store.status?.state || '...'}</span>
@@ -489,10 +482,6 @@
 				divineRate={status?.divinePrice || 0}
 				onQueueGem={handleQueueGem}
 				labMode={labModeForChild}
-				dedicationVariant={dedVariant}
-				onDedicationVariantChange={(v) => handleDedVariantChange(v as DedicationVariant)}
-				normalVariant={normalVariant}
-				onNormalVariantChange={handleNormalVariantChange}
 			/>
 			<SessionQueue
 				queue={sessionQueue}
@@ -561,32 +550,6 @@
 		display: flex;
 		align-items: center;
 		gap: 12px;
-	}
-	.lab-mode-selector {
-		display: flex;
-		gap: 0;
-		border: 1px solid var(--color-lab-border);
-		border-radius: 4px;
-		overflow: hidden;
-	}
-	.lab-mode-btn {
-		background: transparent;
-		border: none;
-		color: var(--color-lab-text-secondary);
-		padding: 4px 10px;
-		font-size: 0.6875rem;
-		font-weight: 600;
-		cursor: pointer;
-		font-family: inherit;
-		transition: background 0.15s, color 0.15s;
-	}
-	.lab-mode-btn:hover {
-		color: var(--color-lab-text);
-		background: rgba(255, 255, 255, 0.05);
-	}
-	.lab-mode-btn.active {
-		color: var(--color-lab-text);
-		background: rgba(99, 102, 241, 0.2);
 	}
 	.scan-controls {
 		display: flex;

--- a/desktop/src/lib/pages/LabPage.svelte
+++ b/desktop/src/lib/pages/LabPage.svelte
@@ -10,6 +10,8 @@
 		fetchBestPlays,
 		VARIANTS,
 		DEDICATION_VARIANTS,
+		DEDICATION_POOLS,
+		DEDICATION_POOL_LABELS,
 		fetchMarketOverview,
 		connectMercure,
 		type StatusData,
@@ -74,10 +76,7 @@
 	const LAB_MODE_OPTIONS = LAB_MODES.map((m) => ({ value: m, label: m }));
 	const NORMAL_MARKET_OPTIONS = VARIANTS.map((v) => ({ value: v, label: v }));
 	const DEDICATION_MARKET_OPTIONS = DEDICATION_VARIANTS.map((v) => ({ value: v, label: v }));
-	const POOL_OPTIONS = [
-		{ value: 'skill', label: 'Skills' },
-		{ value: 'transfigured', label: 'Transfigured' },
-	];
+	const POOL_OPTIONS = DEDICATION_POOLS.map((p) => ({ value: p, label: DEDICATION_POOL_LABELS[p] }));
 
 	const MARKET_TOOLTIP =
 		'Market you are farming. Rankings and Pool Overview follow it, and the run is stamped with it when it uploads.';

--- a/desktop/src/lib/pages/RunHistoryPage.svelte
+++ b/desktop/src/lib/pages/RunHistoryPage.svelte
@@ -2,10 +2,12 @@
 	import { invoke } from '@tauri-apps/api/core';
 	import { store } from '$lib/stores/status.svelte';
 	import Select from '$lib/components/Select.svelte';
+	import { persisted } from '$lib/prefs.svelte';
 
 	let runs = $state<any[]>([]);
 	let stats = $state<{ avg_seconds: number; best_seconds: number; avg_kill_seconds: number; best_kill_seconds: number; total_runs: number }>({ avg_seconds: 0, best_seconds: 0, avg_kill_seconds: 0, best_kill_seconds: 0, total_runs: 0 });
-	let difficulty = $state('');
+	// Persisted (ADR-013): the difficulty filter survives restarts.
+	const difficulty = persisted('runsDifficulty', '');
 	let loading = $state(false);
 	let error = $state('');
 
@@ -40,7 +42,7 @@
 		error = '';
 		try {
 			const params = new URLSearchParams({ limit: '50' });
-			if (difficulty) params.set('difficulty', difficulty);
+			if (difficulty.value) params.set('difficulty', difficulty.value);
 			const res = await fetch(`${serverUrl}/api/lab/runs?${params}`, {
 				headers: {
 					'X-Device-ID': deviceId,
@@ -62,7 +64,7 @@
 
 	// Fetch on mount and when filter changes
 	$effect(() => {
-		const _ = difficulty;
+		const _ = difficulty.value;
 		const url = store.status?.server_url;
 		if (url) fetchRuns();
 	});
@@ -71,7 +73,7 @@
 <div class="runs-page">
 	<div class="runs-header">
 		<h1>Run History</h1>
-		<Select bind:value={difficulty} options={difficultyOptions} onchange={fetchRuns} />
+		<Select bind:value={difficulty.value} options={difficultyOptions} onchange={fetchRuns} />
 	</div>
 
 	{#if stats.total_runs > 0}

--- a/desktop/src/lib/pages/RunHistoryPage.svelte
+++ b/desktop/src/lib/pages/RunHistoryPage.svelte
@@ -109,7 +109,7 @@
 	{:else if runs.length === 0}
 		<div class="empty">
 			<p>No runs recorded yet.</p>
-			<p class="hint">Complete a lab run with the timer overlay enabled to start tracking.</p>
+			<p class="hint">Complete a lab run to start tracking — runs are recorded automatically.</p>
 		</div>
 	{:else}
 		<div class="table-wrap">

--- a/desktop/src/lib/prefs.svelte.ts
+++ b/desktop/src/lib/prefs.svelte.ts
@@ -1,0 +1,56 @@
+/**
+ * Persisted UI picks — sort mode, colour filter, row limit, and every other
+ * select the user can set and expects to find set on the next launch.
+ *
+ * Backed by the Rust `ui_prefs` settings map (see docs/adr/013). The frontend
+ * owns the keys; Rust stores the map blindly and persists it with the rest of
+ * the settings file. Search-style transient inputs stay out of this.
+ *
+ * The map is fetched once at first use. Components mount before that fetch
+ * resolves, so each `persisted()` value starts at its default and is overwritten
+ * when the load lands — the same start-default-then-overwrite pattern the
+ * low-confidence toggle already uses. A value the user changes before the load
+ * resolves wins over the loaded one.
+ */
+import { invoke } from '@tauri-apps/api/core';
+
+let loaded: Record<string, string> | null = null;
+let loadPromise: Promise<void> | null = null;
+
+function ensureLoaded(): Promise<void> {
+	if (!loadPromise) {
+		loadPromise = invoke<Record<string, string>>('get_ui_prefs')
+			.then((p) => { loaded = p; })
+			.catch((e) => { console.warn('[prefs] get_ui_prefs failed:', e); loaded = {}; });
+	}
+	return loadPromise;
+}
+
+export interface PersistedString {
+	value: string;
+}
+
+/**
+ * A string preference that survives restarts. Bind it like state:
+ * `bind:value={pref.value}` — writes go through to Rust, reads are reactive.
+ */
+export function persisted(key: string, initial: string): PersistedString {
+	let value = $state(initial);
+	let dirty = false;
+	void ensureLoaded().then(() => {
+		if (!dirty && loaded && key in loaded) value = loaded[key];
+	});
+	return {
+		get value() { return value; },
+		set value(v: string) {
+			if (v === value && dirty) return;
+			value = v;
+			dirty = true;
+			// Keep the module cache current: a component remounted later (tab
+			// switch) seeds a fresh persisted() from `loaded`, not from Rust.
+			if (loaded) loaded[key] = v;
+			invoke('set_ui_pref', { key, value: v })
+				.catch((e) => console.warn('[prefs] set_ui_pref failed:', key, e));
+		},
+	};
+}

--- a/desktop/src/lib/prefs.svelte.ts
+++ b/desktop/src/lib/prefs.svelte.ts
@@ -10,20 +10,46 @@
  * resolves, so each `persisted()` value starts at its default and is overwritten
  * when the load lands — the same start-default-then-overwrite pattern the
  * low-confidence toggle already uses. A value the user changes before the load
- * resolves wins over the loaded one.
+ * resolves wins over the loaded one, including for components mounted later:
+ * pre-load writes are buffered and re-applied on top of the loaded map.
+ *
+ * Writes are debounced per key: every write persists the whole settings file
+ * on the Rust side, and a text input bound to a pref fires per keystroke.
+ * Accepted trade-off: a pick changed within the debounce window of closing
+ * the app is lost — it degrades to the previous value, never corrupts.
  */
 import { invoke } from '@tauri-apps/api/core';
 
+const WRITE_DEBOUNCE_MS = 300;
+
 let loaded: Record<string, string> | null = null;
 let loadPromise: Promise<void> | null = null;
+const pendingWrites = new Map<string, string>();
+const writeTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 function ensureLoaded(): Promise<void> {
 	if (!loadPromise) {
 		loadPromise = invoke<Record<string, string>>('get_ui_prefs')
 			.then((p) => { loaded = p; })
-			.catch((e) => { console.warn('[prefs] get_ui_prefs failed:', e); loaded = {}; });
+			.catch((e) => { console.warn('[prefs] get_ui_prefs failed:', e); loaded = {}; })
+			.then(() => {
+				// Writes made before the load landed win over the loaded values —
+				// both here and for any component that seeds from `loaded` later.
+				for (const [k, v] of pendingWrites) loaded![k] = v;
+				pendingWrites.clear();
+			});
 	}
 	return loadPromise;
+}
+
+function scheduleWrite(key: string, v: string) {
+	const prior = writeTimers.get(key);
+	if (prior) clearTimeout(prior);
+	writeTimers.set(key, setTimeout(() => {
+		writeTimers.delete(key);
+		invoke('set_ui_pref', { key, value: v })
+			.catch((e) => console.warn('[prefs] set_ui_pref failed:', key, e));
+	}, WRITE_DEBOUNCE_MS));
 }
 
 export interface PersistedString {
@@ -49,8 +75,8 @@ export function persisted(key: string, initial: string): PersistedString {
 			// Keep the module cache current: a component remounted later (tab
 			// switch) seeds a fresh persisted() from `loaded`, not from Rust.
 			if (loaded) loaded[key] = v;
-			invoke('set_ui_pref', { key, value: v })
-				.catch((e) => console.warn('[prefs] set_ui_pref failed:', key, e));
+			else pendingWrites.set(key, v);
+			scheduleWrite(key, v);
 		},
 	};
 }

--- a/desktop/src/lib/run-recorder.ts
+++ b/desktop/src/lib/run-recorder.ts
@@ -32,7 +32,6 @@ interface RoomLogEntry {
 
 let navState: NavState = createNavState();
 let lockedDifficulty: string | null = null;
-let layoutLoaded = false;
 let pendingLayoutReset = false;
 
 let roomLog: RoomLogEntry[] = [];
@@ -59,10 +58,15 @@ function resetRun() {
 
 function applyLayoutReset() {
 	navState = createNavState();
-	layoutLoaded = false;
 	lockedDifficulty = null;
 	pendingLayoutReset = false;
 	logToApp('[recorder] layout reset applied (midnight UTC)');
+	// Refetch immediately: in the overlays a `layoutLoaded` guard effect does
+	// this, but a module has no effects, so without this call the recorder
+	// stays layout-less until the next layout upload — and if the new day's
+	// layout was uploaded before midnight, that event never comes. Runs
+	// submitted with an empty navState all read has_golden_door=false.
+	void fetchLayoutFromServer();
 }
 
 async function fetchLayoutFromServer(preferredDiff?: string) {
@@ -75,7 +79,6 @@ async function fetchLayoutFromServer(preferredDiff?: string) {
 	if (!layout) return;
 	navState = loadLayout(navState, layout);
 	if (!lockedDifficulty) lockedDifficulty = layout.difficulty;
-	layoutLoaded = true;
 	logToApp(`[recorder] layout loaded: ${layout.difficulty} (${layout.rooms.length} rooms)`);
 }
 

--- a/desktop/src/lib/run-recorder.ts
+++ b/desktop/src/lib/run-recorder.ts
@@ -1,0 +1,219 @@
+/**
+ * Headless lab-run recorder — measures every run and submits it to the server.
+ *
+ * Lives in the main window, which is open for the whole session. Measurement
+ * used to run inside the timer overlay's webview, so runs were only recorded
+ * while that overlay was enabled — with it toggled off, the Runs tab silently
+ * collected nothing. The overlay is display-only now; this module is the one
+ * place a run is measured and submitted.
+ *
+ * Elapsed time is computed from timestamps at event time, not from a ticking
+ * interval: the main window can be minimized mid-run, and WebView2 throttles
+ * background timers, but the timestamps are taken when the Tauri events arrive.
+ */
+
+import { listen } from '@tauri-apps/api/event';
+import { invoke } from '@tauri-apps/api/core';
+import {
+	createNavState,
+	loadLayout,
+	handleNavEvent,
+	setStrategy,
+	type NavEvent,
+	type NavState,
+} from '$lib/compass/navigation';
+import { fetchLabLayout } from '$lib/compass/layout-loader';
+
+interface RoomLogEntry {
+	room_name: string;
+	entered_at: string;
+	room_number: number;
+}
+
+let navState: NavState = createNavState();
+let lockedDifficulty: string | null = null;
+let layoutLoaded = false;
+let pendingLayoutReset = false;
+
+let roomLog: RoomLogEntry[] = [];
+let roomCounter = 0;
+let runStartTimestamp: number | null = null;
+let killSeconds = 0; // Izaro death time — snapshotted on LabFinished
+
+let started = false;
+
+function logToApp(msg: string) {
+	invoke('app_log_from_frontend', { msg }).catch((e) => console.warn('[recorder] logToApp IPC failed:', msg, e));
+}
+
+function elapsedSeconds(): number {
+	return runStartTimestamp === null ? 0 : Math.floor((Date.now() - runStartTimestamp) / 1000);
+}
+
+function resetRun() {
+	roomLog = [];
+	roomCounter = 0;
+	runStartTimestamp = null;
+	killSeconds = 0;
+}
+
+function applyLayoutReset() {
+	navState = createNavState();
+	layoutLoaded = false;
+	lockedDifficulty = null;
+	pendingLayoutReset = false;
+	logToApp('[recorder] layout reset applied (midnight UTC)');
+}
+
+async function fetchLayoutFromServer(preferredDiff?: string) {
+	if (preferredDiff) lockedDifficulty = preferredDiff;
+	const layout = await fetchLabLayout({
+		preferredDifficulty: preferredDiff,
+		lockedDifficulty,
+		log: (msg) => logToApp(`[recorder] ${msg}`),
+	});
+	if (!layout) return;
+	navState = loadLayout(navState, layout);
+	if (!lockedDifficulty) lockedDifficulty = layout.difficulty;
+	layoutLoaded = true;
+	logToApp(`[recorder] layout loaded: ${layout.difficulty} (${layout.rooms.length} rooms)`);
+}
+
+// Called on LabExited with the run complete. Kill time was snapshotted on
+// LabFinished; total elapsed runs from the first room to lab exit.
+async function submitRun() {
+	const totalElapsed = elapsedSeconds();
+	const snapshotRooms = [...roomLog];
+	const snapshotKillTime = killSeconds;
+	const snapshotStartedAt = runStartTimestamp;
+	if (snapshotKillTime <= 0 || snapshotRooms.length === 0) return;
+	try {
+		const status = await invoke<any>('get_status');
+		const serverUrl = status?.server_url;
+		if (!serverUrl) { logToApp('[recorder] no server_url, cannot submit run'); return; }
+
+		const settings = await invoke<any>('get_compass_settings').catch(() => null);
+		const visitedRoomNames = new Set(snapshotRooms.map(r => r.room_name.toLowerCase()));
+		const hasGoldenDoor = navState.lockedDoors.length > 0 ||
+			Array.from(navState.roomById.values())
+				.filter(r => visitedRoomNames.has(r.name.toLowerCase()))
+				.some(r => r.contents.some(c => c.toLowerCase().includes('golden-door')));
+
+		const body = {
+			difficulty: settings?.difficulty ?? lockedDifficulty ?? 'Uber',
+			strategy: settings?.strategy ?? navState.strategy,
+			elapsed_seconds: totalElapsed,
+			kill_seconds: snapshotKillTime,
+			room_count: snapshotRooms.length,
+			has_golden_door: hasGoldenDoor,
+			started_at: snapshotStartedAt ? new Date(snapshotStartedAt).toISOString() : new Date().toISOString(),
+			rooms: snapshotRooms,
+		};
+
+		const res = await fetch(`${serverUrl}/api/lab/runs`, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-Device-ID': status?.device_id ?? '',
+				'X-App-Version': status?.app_version ?? '',
+			},
+			body: JSON.stringify(body),
+		});
+
+		if (res.ok) {
+			const data = await res.json();
+			logToApp(`[recorder] run submitted: id=${data.run_id}, kill=${snapshotKillTime}s, total=${totalElapsed}s`);
+		} else {
+			const errBody = await res.text().catch(() => '');
+			logToApp(`[recorder] submit failed: ${res.status} ${errBody}`);
+		}
+	} catch (e) {
+		logToApp(`[recorder] submit error: ${e}`);
+	}
+}
+
+function onNavEvent(event: any) {
+	if (event.type === 'LayoutChanged') {
+		fetchLayoutFromServer(event.difficulty);
+		return;
+	}
+	if (event.type === 'StrategyChanged') {
+		navState = setStrategy(navState, event.strategy);
+		return;
+	}
+	navState = handleNavEvent(navState, event as NavEvent);
+
+	switch (event.type) {
+		case 'PlazaEntered':
+			resetRun();
+			break;
+		case 'RoomChanged':
+			if (navState.inLab && runStartTimestamp === null) {
+				runStartTimestamp = Date.now();
+			}
+			roomCounter++;
+			roomLog = [...roomLog, {
+				room_name: event.name,
+				entered_at: new Date().toISOString(),
+				room_number: roomCounter,
+			}];
+			break;
+		case 'LabFinished':
+			killSeconds = elapsedSeconds();
+			break;
+		case 'LabExited':
+			submitRun();
+			resetRun();
+			if (pendingLayoutReset) {
+				applyLayoutReset();
+			}
+			break;
+	}
+}
+
+/**
+ * Start the recorder: init from settings, replay catchup, subscribe to events.
+ * Call once from the main-window layout — it never unmounts, so no cleanup.
+ */
+export function startRunRecorder(): void {
+	if (started) return;
+	started = true;
+
+	(async () => {
+		const settings = await invoke<any>('get_compass_settings').catch((e: any) => {
+			logToApp(`[recorder] init settings failed: ${e}`);
+			return null;
+		});
+		if (settings?.difficulty) lockedDifficulty = settings.difficulty;
+		if (settings?.strategy) navState = setStrategy(navState, settings.strategy);
+		await fetchLayoutFromServer();
+		// Catch up to current lab state (app may start mid-run)
+		const catchup = await invoke<any>('get_lab_catchup').catch((e: any) => {
+			logToApp(`[recorder] catchup failed: ${e}`);
+			return null;
+		});
+		if (catchup?.events?.length) {
+			logToApp(`[recorder] replaying ${catchup.events.length} catchup events`);
+			for (const event of catchup.events) {
+				onNavEvent(event);
+			}
+		}
+	})();
+
+	listen<NavEvent>('lab-nav', (event) => {
+		onNavEvent(event.payload);
+	});
+	listen<any>('lab-layout-updated', (event) => {
+		if (event.payload?.action === 'reset') {
+			if (navState.inLab) {
+				// Mid-run at midnight — defer reset until lab exit
+				pendingLayoutReset = true;
+				logToApp('[recorder] layout reset deferred (in lab)');
+			} else {
+				applyLayoutReset();
+			}
+			return;
+		}
+		fetchLayoutFromServer(event.payload?.difficulty);
+	});
+}

--- a/desktop/src/lib/stores/ssot.svelte.test.ts
+++ b/desktop/src/lib/stores/ssot.svelte.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ssot, applySnapshot } from './ssot.svelte';
+
+// The store reaches Rust through `invoke` only; the real core module cannot load
+// outside a webview. Same shape as desktop/src/lib/compass/layout-loader.test.ts:13.
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+// The `ssot-changed` listener is an optional eager nudge; stub it so the poll
+// lifecycle tests are not at the mercy of a rejected real `listen`.
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(async () => vi.fn()) }));
 
 describe('applySnapshot', () => {
 	it('maps league.name to the flat league field', () => {
@@ -50,5 +57,286 @@ describe('applySnapshot', () => {
 		// Malformed snapshot (e.g. an older/empty payload) must not leak undefined.
 		applySnapshot({} as unknown as Parameters<typeof applySnapshot>[0]);
 		expect(ssot.league).toBeNull();
+	});
+});
+
+/**
+ * The farming-market half of the store (POE-163) carries module-level mutable
+ * state — the write counter and the per-field in-flight counters — so each test
+ * re-imports the module to get its own instance. The `applySnapshot` block above
+ * keeps using the statically imported instance and is unaffected.
+ */
+describe('farming market fields', () => {
+	let mod: typeof import('./ssot.svelte');
+	let invokeMock: ReturnType<typeof vi.mocked<typeof import('@tauri-apps/api/core').invoke>>;
+
+	/** A snapshot carrying only league state, for the fields we are not exercising. */
+	const league = { name: 'Mirage' };
+
+	/** Calls of one Tauri command, in order, with their argument objects. */
+	function callsOf(command: string): unknown[] {
+		return invokeMock.mock.calls.filter((c) => c[0] === command).map((c) => c[1]);
+	}
+
+	beforeEach(async () => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		const core = await import('@tauri-apps/api/core');
+		invokeMock = vi.mocked(core.invoke);
+		// Default: `get_ssot` answers with a league-only snapshot, every setter succeeds.
+		invokeMock.mockImplementation(async (command: string) =>
+			command === 'get_ssot' ? { league } : undefined,
+		);
+		mod = await import('./ssot.svelte');
+	});
+
+	/** Seed all three market fields to known-good values that differ from the ones
+	 *  each test then writes, so a passing assertion proves the write happened
+	 *  rather than that the value was already there. */
+	function seedKnownGood(): void {
+		mod.applySnapshot({
+			league,
+			normalVariant: '1/20',
+			dedicationVariant: '21/23',
+			dedicationPool: 'skill',
+		});
+	}
+
+	describe('applySnapshot', () => {
+		it('maps the three market fields from the snapshot', () => {
+			seedKnownGood();
+			mod.applySnapshot({
+				league,
+				normalVariant: '20/0',
+				dedicationVariant: '21/20',
+				dedicationPool: 'transfigured',
+			});
+			expect(mod.ssot.normalVariant).toBe('20/0');
+			expect(mod.ssot.dedicationVariant).toBe('21/20');
+			expect(mod.ssot.dedicationPool).toBe('transfigured');
+		});
+
+		it('keeps the last known good value when the field is absent', () => {
+			seedKnownGood();
+			mod.applySnapshot({ league });
+			expect(mod.ssot.normalVariant).toBe('1/20');
+		});
+
+		it('keeps the last known good value when the field is out of domain', () => {
+			seedKnownGood();
+			mod.applySnapshot({ league, normalVariant: '99/99' });
+			expect(mod.ssot.normalVariant).toBe('1/20');
+		});
+
+		it('keeps the last known good value when the field is an empty string', () => {
+			seedKnownGood();
+			mod.applySnapshot({ league, normalVariant: '' });
+			expect(mod.ssot.normalVariant).toBe('1/20');
+		});
+
+		it('does not write back when the field is an empty string', () => {
+			seedKnownGood();
+			invokeMock.mockClear();
+			// Empty means Rust has nothing set yet — nothing to heal, unlike a
+			// non-empty value Rust would keep stamping onto uploaded sessions.
+			mod.applySnapshot({ league, normalVariant: '' });
+			expect(callsOf('set_normal_variant')).toEqual([]);
+		});
+
+		it('heals Rust with the displayed value when the field is out of domain', () => {
+			seedKnownGood();
+			invokeMock.mockClear();
+			mod.applySnapshot({ league, normalVariant: '99/99' });
+			// Exactly one write-back, carrying what the UI shows — not the rejected
+			// value and not a hardcoded default.
+			expect(callsOf('set_normal_variant')).toEqual([{ variant: '1/20' }]);
+		});
+
+		it('does not throw on a malformed snapshot', () => {
+			seedKnownGood();
+			expect(() =>
+				mod.applySnapshot({} as unknown as Parameters<typeof mod.applySnapshot>[0]),
+			).not.toThrow();
+		});
+
+		it('keeps all three market fields at their last known good values on a malformed snapshot', () => {
+			seedKnownGood();
+			mod.applySnapshot({} as unknown as Parameters<typeof mod.applySnapshot>[0]);
+			expect(mod.ssot.normalVariant).toBe('1/20');
+			expect(mod.ssot.dedicationVariant).toBe('21/23');
+			expect(mod.ssot.dedicationPool).toBe('skill');
+		});
+	});
+
+	describe('setNormalVariant', () => {
+		it('mutates the rune before the invoke round-trip resolves', () => {
+			// Never settles: anything observable now happened synchronously.
+			invokeMock.mockImplementation(() => new Promise<void>(() => {}));
+			seedKnownGood();
+			void mod.setNormalVariant('20/20');
+			expect(mod.ssot.normalVariant).toBe('20/20');
+		});
+
+		it('writes through to the set_normal_variant command', async () => {
+			seedKnownGood();
+			await mod.setNormalVariant('20/20');
+			expect(callsOf('set_normal_variant')).toEqual([{ variant: '20/20' }]);
+		});
+
+		it('leaves the optimistic value in place when the invoke rejects', async () => {
+			invokeMock.mockRejectedValue(new Error('command failed'));
+			seedKnownGood();
+			// Never throws — same catch-and-warn contract as fetchSsot.
+			await expect(mod.setNormalVariant('20/20')).resolves.toBeUndefined();
+			expect(mod.ssot.normalVariant).toBe('20/20');
+		});
+
+		it('yields to Rust truth on the next snapshot after a rejected invoke', async () => {
+			invokeMock.mockRejectedValue(new Error('command failed'));
+			seedKnownGood();
+			await mod.setNormalVariant('20/20');
+			// The failed write must not keep the field pinned to the optimistic value.
+			mod.applySnapshot({ league, normalVariant: '1/0' });
+			expect(mod.ssot.normalVariant).toBe('1/0');
+		});
+	});
+
+	describe('setDedicationVariant / setDedicationPool', () => {
+		it('writes through to the set_dedication_variant command', async () => {
+			seedKnownGood();
+			await mod.setDedicationVariant('21/20');
+			expect(mod.ssot.dedicationVariant).toBe('21/20');
+			expect(callsOf('set_dedication_variant')).toEqual([{ variant: '21/20' }]);
+		});
+
+		it('writes through to the set_dedication_pool command', async () => {
+			seedKnownGood();
+			await mod.setDedicationPool('transfigured');
+			expect(mod.ssot.dedicationPool).toBe('transfigured');
+			expect(callsOf('set_dedication_pool')).toEqual([{ pool: 'transfigured' }]);
+		});
+	});
+
+	describe('setDedicationSelection', () => {
+		it('mutates variant and pool in one synchronous step', () => {
+			invokeMock.mockImplementation(() => new Promise<void>(() => {}));
+			seedKnownGood();
+			void mod.setDedicationSelection('21/20', 'transfigured');
+			expect(mod.ssot.dedicationVariant).toBe('21/20');
+			expect(mod.ssot.dedicationPool).toBe('transfigured');
+		});
+
+		it('writes through to both dedication commands', async () => {
+			seedKnownGood();
+			await mod.setDedicationSelection('21/20', 'transfigured');
+			expect(callsOf('set_dedication_variant')).toEqual([{ variant: '21/20' }]);
+			expect(callsOf('set_dedication_pool')).toEqual([{ pool: 'transfigured' }]);
+		});
+
+		it('cannot be observed half-applied by a snapshot landing between the two invokes', async () => {
+			let releaseVariantWrite: () => void = () => {};
+			invokeMock.mockImplementation((command: string) => {
+				if (command === 'set_dedication_variant') {
+					return new Promise<void>((resolve) => {
+						releaseVariantWrite = () => resolve();
+					});
+				}
+				return Promise.resolve(undefined);
+			});
+			seedKnownGood();
+
+			const selection = mod.setDedicationSelection('21/20', 'transfigured');
+			// Rust has taken the variant but not yet the pool — the torn pair nobody picked.
+			mod.applySnapshot({ league, dedicationVariant: '21/20', dedicationPool: 'skill' });
+			expect(mod.ssot.dedicationPool).toBe('transfigured');
+			expect(mod.ssot.dedicationVariant).toBe('21/20');
+
+			releaseVariantWrite();
+			await selection;
+		});
+	});
+
+	describe('poll-vs-write ordering guard', () => {
+		it('does not overwrite a field whose write round-trip is still outstanding', async () => {
+			let releaseWrite: () => void = () => {};
+			invokeMock.mockImplementation((command: string) => {
+				if (command === 'set_normal_variant') {
+					return new Promise<void>((resolve) => {
+						releaseWrite = () => resolve();
+					});
+				}
+				return Promise.resolve(undefined);
+			});
+			seedKnownGood();
+
+			const write = mod.setNormalVariant('20/20');
+			// A poll dispatched before the write lands mid-flight, still carrying the old value.
+			mod.applySnapshot({ league, normalVariant: '1/20' });
+			expect(mod.ssot.normalVariant).toBe('20/20');
+
+			releaseWrite();
+			await write;
+		});
+
+		/**
+		 * Drive the ordering the in-flight guard alone misses: a `get_ssot` is
+		 * dispatched, a write is issued *and settles*, and only then does the stale
+		 * response arrive. Returns once the stale snapshot has been applied.
+		 */
+		async function applyStaleSnapshotAfterCompletedWrite(): Promise<void> {
+			let deliverSnapshot: (snap: unknown) => void = () => {};
+			invokeMock.mockImplementation((command: string) => {
+				if (command === 'get_ssot') {
+					return new Promise((resolve) => {
+						deliverSnapshot = resolve;
+					});
+				}
+				return Promise.resolve(undefined);
+			});
+			seedKnownGood();
+
+			const poll = mod.fetchSsot();
+			await mod.setNormalVariant('20/20');
+			deliverSnapshot({ league: { name: 'Settlers' }, normalVariant: '1/20' });
+			await poll;
+		}
+
+		it('does not overwrite a field with a snapshot dispatched before the write', async () => {
+			await applyStaleSnapshotAfterCompletedWrite();
+			expect(mod.ssot.normalVariant).toBe('20/20');
+		});
+
+		it('still applies the rest of that same stale snapshot', async () => {
+			// The guard is per-field: league was never written, so it takes the update.
+			await applyStaleSnapshotAfterCompletedWrite();
+			expect(mod.ssot.league).toBe('Settlers');
+		});
+	});
+
+	describe('poll lifecycle', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('re-fetches get_ssot once per lazy poll interval', async () => {
+			const stop = mod.startSsotStore();
+			await vi.advanceTimersByTimeAsync(0);
+			expect(callsOf('get_ssot')).toHaveLength(1);
+			await vi.advanceTimersByTimeAsync(3000);
+			expect(callsOf('get_ssot')).toHaveLength(2);
+			stop();
+		});
+
+		it('stops re-fetching once the store is stopped', async () => {
+			const stop = mod.startSsotStore();
+			await vi.advanceTimersByTimeAsync(0);
+			stop();
+			await vi.advanceTimersByTimeAsync(9000);
+			expect(callsOf('get_ssot')).toHaveLength(1);
+		});
 	});
 });

--- a/desktop/src/lib/stores/ssot.svelte.ts
+++ b/desktop/src/lib/stores/ssot.svelte.ts
@@ -33,7 +33,7 @@ import { DEDICATION_VARIANTS, VARIANTS } from '$lib/api';
  * `api.ts` has no pool constant — the JSON API uses the plural `skills` for the
  * same pool, and translating between the two is the consumer's job.
  */
-const POOLS = ['skill', 'transfigured'];
+const POOLS = ['skill', 'transfigured'] as const;
 
 /** Serialized Rust `AppSsotSnapshot` — `league.name` is `string | null`. */
 export interface SsotSnapshot {
@@ -138,7 +138,7 @@ function applyMarketField(field: MarketField, incoming: string | undefined, disp
 		return;
 	}
 	console.warn(`[ssot] ignoring unknown persisted ${field}:`, incoming, '— healing Rust to', ssot[field]);
-	void writeField(field, ssot[field], MARKET_COMMANDS[field].command, MARKET_COMMANDS[field].arg);
+	void writeField(field, ssot[field]);
 }
 
 /** Map the Rust snapshot shape (`snap.league.name`, `snap.resolving`,
@@ -179,6 +179,25 @@ const MARKET_COMMANDS: Record<MarketField, { command: string; arg: string }> = {
 };
 
 /**
+ * Open the poll-vs-write guard on every field a single user action writes.
+ *
+ * One `writeSeq` bump for the whole action, so a multi-field action is ordered
+ * against polls as one unit rather than as N independent writes.
+ */
+function beginWrite(fields: readonly MarketField[]): void {
+	writeSeq += 1;
+	for (const field of fields) {
+		lastWriteSeq[field] = writeSeq;
+		inFlight[field] += 1;
+	}
+}
+
+/** Close the guard opened by `beginWrite`. Always call from a `finally`. */
+function endWrite(fields: readonly MarketField[]): void {
+	for (const field of fields) inFlight[field] -= 1;
+}
+
+/**
  * Write-through one market field: guard, mutate the rune synchronously, then
  * invoke. The synchronous mutation is what makes same-window surfaces update in
  * the same frame instead of waiting a poll interval.
@@ -187,37 +206,42 @@ const MARKET_COMMANDS: Record<MarketField, { command: string; arg: string }> = {
  * optimistic value stays: the next poll restores Rust truth once the guard
  * clears, and reverting here would flash a value the user did not pick.
  */
-async function writeField(field: MarketField, value: string, command: string, arg: string): Promise<void> {
-	writeSeq += 1;
-	lastWriteSeq[field] = writeSeq;
-	inFlight[field] += 1;
+async function writeField(field: MarketField, value: string): Promise<void> {
+	const { command, arg } = MARKET_COMMANDS[field];
+	beginWrite([field]);
 	ssot[field] = value;
 	try {
 		await invoke(command, { [arg]: value });
 	} catch (e) {
 		console.warn(`[ssot] ${command} failed:`, e);
 	} finally {
-		inFlight[field] -= 1;
+		endWrite([field]);
 	}
 }
 
 /** Set the normal-mode farming market. */
 export function setNormalVariant(variant: string): Promise<void> {
-	const { command, arg } = MARKET_COMMANDS.normalVariant;
-	return writeField('normalVariant', variant, command, arg);
+	return writeField('normalVariant', variant);
 }
 
-/** Set the dedication-mode farming market. */
+/** Set the dedication-mode farming market on its own.
+ *
+ *  Dedication surfaces that pick a market and a pool together must use
+ *  `setDedicationSelection` instead — this setter guards only its own field. */
 export function setDedicationVariant(variant: string): Promise<void> {
-	const { command, arg } = MARKET_COMMANDS.dedicationVariant;
-	return writeField('dedicationVariant', variant, command, arg);
+	return writeField('dedicationVariant', variant);
 }
 
-/** Set the dedication pool (canon spelling: "skill" | "transfigured"). */
+/** Set the dedication pool on its own (canon spelling: "skill" | "transfigured").
+ *
+ *  Same caveat as `setDedicationVariant`: use `setDedicationSelection` when the
+ *  user action changes both fields. */
 export function setDedicationPool(pool: string): Promise<void> {
-	const { command, arg } = MARKET_COMMANDS.dedicationPool;
-	return writeField('dedicationPool', pool, command, arg);
+	return writeField('dedicationPool', pool);
 }
+
+/** The fields `setDedicationSelection` guards and mutates as one unit. */
+const DEDICATION_FIELDS: readonly MarketField[] = ['dedicationVariant', 'dedicationPool'];
 
 /**
  * Set the dedication market and pool as one user action.
@@ -229,21 +253,16 @@ export function setDedicationPool(pool: string): Promise<void> {
  * single-field setters.
  */
 export async function setDedicationSelection(variant: string, pool: string): Promise<void> {
-	writeSeq += 1;
-	lastWriteSeq.dedicationVariant = writeSeq;
-	lastWriteSeq.dedicationPool = writeSeq;
-	inFlight.dedicationVariant += 1;
-	inFlight.dedicationPool += 1;
+	beginWrite(DEDICATION_FIELDS);
 	ssot.dedicationVariant = variant;
 	ssot.dedicationPool = pool;
 	try {
-		await invoke('set_dedication_variant', { variant });
-		await invoke('set_dedication_pool', { pool });
+		await invoke(MARKET_COMMANDS.dedicationVariant.command, { variant });
+		await invoke(MARKET_COMMANDS.dedicationPool.command, { pool });
 	} catch (e) {
 		console.warn('[ssot] set dedication selection failed:', e);
 	} finally {
-		inFlight.dedicationVariant -= 1;
-		inFlight.dedicationPool -= 1;
+		endWrite(DEDICATION_FIELDS);
 	}
 }
 

--- a/desktop/src/lib/stores/ssot.svelte.ts
+++ b/desktop/src/lib/stores/ssot.svelte.ts
@@ -247,10 +247,17 @@ const DEDICATION_FIELDS: readonly MarketField[] = ['dedicationVariant', 'dedicat
  * Set the dedication market and pool as one user action.
  *
  * Both fields are guarded and mutated together, then the two Tauri commands are
- * sequenced, and both guards are held until both settle — so no poll tick can
- * observe the half-applied pair (new variant, stale pool) that nobody selected.
- * Every Dedication surface writes through this, never through the two
- * single-field setters.
+ * sequenced, and both guards are held until both settle — so no poll tick lands
+ * between them and reverts one half. Every Dedication surface writes through
+ * this, never through the two single-field setters.
+ *
+ * What that does NOT buy is atomicity in Rust: the pair is two commands, so a
+ * rejected second invoke (IPC failure, command error) leaves Rust holding the
+ * new variant with the old pool, `persist_settings` writes that pair to disk,
+ * and once the guards clear the next poll settles the UI onto it. Accepted:
+ * making the pair atomic means a combined Rust command, and a failure between
+ * two local IPC calls has not been observed. The catch below only warns, per
+ * `writeField`'s never-throw contract.
  */
 export async function setDedicationSelection(variant: string, pool: string): Promise<void> {
 	beginWrite(DEDICATION_FIELDS);

--- a/desktop/src/lib/stores/ssot.svelte.ts
+++ b/desktop/src/lib/stores/ssot.svelte.ts
@@ -11,15 +11,29 @@
  * League is low-churn, so the poll interval is lazy (seconds), not the
  * comparator overlay's 500 ms.
  *
+ * The farming market (normal variant, dedication variant, dedication pool) is
+ * owned here too (POE-163): every surface reads the same rune and writes through
+ * the exported setters, so there is no per-component mirror to drift.
+ *
  * Usage:
  *   import { ssot, startSsotStore } from '$lib/stores/ssot.svelte';
  *   // Read: ssot.league  (string | null; null until first successful get_ssot)
+ *   // Read: ssot.normalVariant / ssot.dedicationVariant / ssot.dedicationPool
+ *   // Write: setNormalVariant(v) / setDedicationSelection(variant, pool)
  *   // Main window: call startSsotStore() top-level (like initStatusStore()).
  *   // Overlay windows: call startSsotStore() from an $effect and return its
  *   //   cleanup (onMount is unreliable in overlay windows).
  */
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { DEDICATION_VARIANTS, VARIANTS } from '$lib/api';
+
+/**
+ * The dedication pools, in Rust/settings/DB canon spelling (singular `skill`).
+ * `api.ts` has no pool constant — the JSON API uses the plural `skills` for the
+ * same pool, and translating between the two is the consumer's job.
+ */
+const POOLS = ['skill', 'transfigured'];
 
 /** Serialized Rust `AppSsotSnapshot` — `league.name` is `string | null`. */
 export interface SsotSnapshot {
@@ -29,6 +43,12 @@ export interface SsotSnapshot {
 	/** The resolver has failed enough times to treat the server as unreachable
 	 *  (still retrying). Only meaningful while `resolving` is true. */
 	unreachable?: boolean;
+	/** Normal-mode farming market, e.g. "20/20". */
+	normalVariant?: string;
+	/** Dedication-mode farming market, e.g. "21/23". */
+	dedicationVariant?: string;
+	/** Dedication pool, canon spelling: "skill" | "transfigured". */
+	dedicationPool?: string;
 }
 
 /**
@@ -51,26 +71,179 @@ export const ssot = $state({
 	 *  retrying — drives the "Server unreachable" state with an actionable
 	 *  Refresh. Defaults false. */
 	unreachable: false,
+	/** Normal-mode farming market. Every surface that shows or picks the normal
+	 *  market reads this field — it is what Rust stamps onto uploaded sessions.
+	 *  The initial value matches Rust's default; the first poll corrects it. */
+	normalVariant: '20/20',
+	/** Dedication-mode farming market. Same ownership as `normalVariant`. */
+	dedicationVariant: '21/23',
+	/** Dedication pool in canon spelling ("skill" | "transfigured"). */
+	dedicationPool: 'skill',
 });
+
+/** The three market fields, which share the write-through + poll-guard machinery. */
+type MarketField = 'normalVariant' | 'dedicationVariant' | 'dedicationPool';
+
+/**
+ * Poll-vs-write ordering guard.
+ *
+ * Every write bumps `writeSeq` and stamps it into `lastWriteSeq[field]`;
+ * `fetchSsot` captures the counter *before* awaiting `get_ssot` and hands it to
+ * `applySnapshot`. A snapshot is then ignored for a field when either:
+ *
+ *  - `inFlight[field] > 0` — the write round-trip has not settled yet, so the
+ *    snapshot cannot contain it; or
+ *  - `lastWriteSeq[field] > dispatchedAtSeq` — the snapshot was dispatched
+ *    before the write and merely arrived after it. The in-flight clause alone
+ *    misses this ordering, because the write can settle first.
+ *
+ * `inFlight` counts rather than flags: two rapid clicks overlap, and the first
+ * response must not unguard the second write.
+ */
+let writeSeq = 0;
+const lastWriteSeq: Record<MarketField, number> = {
+	normalVariant: 0,
+	dedicationVariant: 0,
+	dedicationPool: 0,
+};
+const inFlight: Record<MarketField, number> = {
+	normalVariant: 0,
+	dedicationVariant: 0,
+	dedicationPool: 0,
+};
+
+const MARKET_DOMAINS: Record<MarketField, readonly string[]> = {
+	normalVariant: VARIANTS,
+	dedicationVariant: DEDICATION_VARIANTS,
+	dedicationPool: POOLS,
+};
+
+/**
+ * Apply one market field from a snapshot, fail-closed.
+ *
+ * An absent, empty or out-of-domain value keeps the last known good value —
+ * never a hardcoded fallback, which would silently move the farming market to
+ * one nobody picked. An out-of-domain *non-empty* value additionally heals the
+ * Rust side: the UI refuses to display it, but Rust keeps stamping it onto
+ * uploaded font sessions, so it is written back with the value we do show. The
+ * write makes the next poll return the healed value, so this branch stops
+ * matching by itself — no repeat-suppression flag needed.
+ */
+function applyMarketField(field: MarketField, incoming: string | undefined, dispatchedAtSeq: number): void {
+	if (inFlight[field] > 0) return;
+	if (lastWriteSeq[field] > dispatchedAtSeq) return;
+	if (!incoming) return;
+	if (MARKET_DOMAINS[field].includes(incoming)) {
+		ssot[field] = incoming;
+		return;
+	}
+	console.warn(`[ssot] ignoring unknown persisted ${field}:`, incoming, '— healing Rust to', ssot[field]);
+	void writeField(field, ssot[field], MARKET_COMMANDS[field].command, MARKET_COMMANDS[field].arg);
+}
 
 /** Map the Rust snapshot shape (`snap.league.name`, `snap.resolving`,
  *  `snap.unreachable`) into the flat store fields. Missing/malformed fields fail
- *  closed (null / false). */
-export function applySnapshot(snap: SsotSnapshot): void {
+ *  closed (null / false for league state, last known good for markets).
+ *
+ *  `dispatchedAtSeq` is the write counter as of the moment this snapshot was
+ *  requested; it defaults to "now" so direct callers get no guard suppression. */
+export function applySnapshot(snap: SsotSnapshot, dispatchedAtSeq: number = writeSeq): void {
 	ssot.league = snap.league?.name ?? null;
 	ssot.resolving = snap.resolving ?? false;
 	ssot.unreachable = snap.unreachable ?? false;
+	applyMarketField('normalVariant', snap.normalVariant, dispatchedAtSeq);
+	applyMarketField('dedicationVariant', snap.dedicationVariant, dispatchedAtSeq);
+	applyMarketField('dedicationPool', snap.dedicationPool, dispatchedAtSeq);
 }
 
 let pollInterval: ReturnType<typeof setInterval> | null = null;
 let unlistenSsot: UnlistenFn | null = null;
 
 /** Fetch the snapshot via the poll-target command and apply it. */
-async function fetchSsot(): Promise<void> {
+export async function fetchSsot(): Promise<void> {
+	// Capture the write counter before awaiting: anything written after this
+	// point is newer than whatever the response carries.
+	const dispatchedAtSeq = writeSeq;
 	try {
-		applySnapshot(await invoke<SsotSnapshot>('get_ssot'));
+		applySnapshot(await invoke<SsotSnapshot>('get_ssot'), dispatchedAtSeq);
 	} catch (e) {
 		console.warn('[ssot] get_ssot failed:', e);
+	}
+}
+
+/** Command + argument name backing each market field's write path. */
+const MARKET_COMMANDS: Record<MarketField, { command: string; arg: string }> = {
+	normalVariant: { command: 'set_normal_variant', arg: 'variant' },
+	dedicationVariant: { command: 'set_dedication_variant', arg: 'variant' },
+	dedicationPool: { command: 'set_dedication_pool', arg: 'pool' },
+};
+
+/**
+ * Write-through one market field: guard, mutate the rune synchronously, then
+ * invoke. The synchronous mutation is what makes same-window surfaces update in
+ * the same frame instead of waiting a poll interval.
+ *
+ * Never throws — matches `fetchSsot`'s catch-and-warn contract. On failure the
+ * optimistic value stays: the next poll restores Rust truth once the guard
+ * clears, and reverting here would flash a value the user did not pick.
+ */
+async function writeField(field: MarketField, value: string, command: string, arg: string): Promise<void> {
+	writeSeq += 1;
+	lastWriteSeq[field] = writeSeq;
+	inFlight[field] += 1;
+	ssot[field] = value;
+	try {
+		await invoke(command, { [arg]: value });
+	} catch (e) {
+		console.warn(`[ssot] ${command} failed:`, e);
+	} finally {
+		inFlight[field] -= 1;
+	}
+}
+
+/** Set the normal-mode farming market. */
+export function setNormalVariant(variant: string): Promise<void> {
+	const { command, arg } = MARKET_COMMANDS.normalVariant;
+	return writeField('normalVariant', variant, command, arg);
+}
+
+/** Set the dedication-mode farming market. */
+export function setDedicationVariant(variant: string): Promise<void> {
+	const { command, arg } = MARKET_COMMANDS.dedicationVariant;
+	return writeField('dedicationVariant', variant, command, arg);
+}
+
+/** Set the dedication pool (canon spelling: "skill" | "transfigured"). */
+export function setDedicationPool(pool: string): Promise<void> {
+	const { command, arg } = MARKET_COMMANDS.dedicationPool;
+	return writeField('dedicationPool', pool, command, arg);
+}
+
+/**
+ * Set the dedication market and pool as one user action.
+ *
+ * Both fields are guarded and mutated together, then the two Tauri commands are
+ * sequenced, and both guards are held until both settle — so no poll tick can
+ * observe the half-applied pair (new variant, stale pool) that nobody selected.
+ * Every Dedication surface writes through this, never through the two
+ * single-field setters.
+ */
+export async function setDedicationSelection(variant: string, pool: string): Promise<void> {
+	writeSeq += 1;
+	lastWriteSeq.dedicationVariant = writeSeq;
+	lastWriteSeq.dedicationPool = writeSeq;
+	inFlight.dedicationVariant += 1;
+	inFlight.dedicationPool += 1;
+	ssot.dedicationVariant = variant;
+	ssot.dedicationPool = pool;
+	try {
+		await invoke('set_dedication_variant', { variant });
+		await invoke('set_dedication_pool', { pool });
+	} catch (e) {
+		console.warn('[ssot] set dedication selection failed:', e);
+	} finally {
+		inFlight.dedicationVariant -= 1;
+		inFlight.dedicationPool -= 1;
 	}
 }
 

--- a/desktop/src/lib/stores/status.svelte.ts
+++ b/desktop/src/lib/stores/status.svelte.ts
@@ -31,6 +31,10 @@ export interface AppStatus {
 	auto_trade_enabled: boolean;
 	/** Hardware device fingerprint — hex SHA-256 (64 chars) for hardware, UUID for fallback. */
 	device_id: string;
+	/** Rounds accumulated in the pending font session — 0 when nothing is captured.
+	 *  The session is stamped with the selected market at send time, so a non-zero
+	 *  count is what makes a discardable pending run visible. */
+	font_session_rounds: number;
 }
 
 /** Reactive store — mutate properties, never reassign the export. */

--- a/desktop/src/routes/(app)/+layout.svelte
+++ b/desktop/src/routes/(app)/+layout.svelte
@@ -7,6 +7,7 @@
 	import Sidebar from '$lib/components/Sidebar.svelte';
 	import { store, initStatusStore } from '$lib/stores/status.svelte';
 	import { startSsotStore } from '$lib/stores/ssot.svelte';
+	import { startRunRecorder } from '$lib/run-recorder';
 	import { nav } from '$lib/stores/navigation.svelte';
 	import { destroyOverlay, isOverlayActive, readOverlayRegion } from '$lib/overlay/manager';
 	import LabPage from '$lib/pages/LabPage.svelte';
@@ -451,6 +452,11 @@
 	// ssot-changed nudge, but polling get_ssot is consistent with the overlays
 	// and cheap for a low-churn slice. No cleanup — this layout never unmounts.
 	startSsotStore();
+
+	// Record every lab run, whether or not the timer overlay is enabled. The
+	// recorder used to live in the overlay's webview, so a disabled overlay
+	// meant the Runs tab silently collected nothing.
+	startRunRecorder();
 
 	// Reposition comparator overlay when settings page closes a config overlay.
 	// The config overlay destroy can leave Win32 mouse capture stuck; this move resets focus.

--- a/desktop/src/routes/(app)/+layout.svelte
+++ b/desktop/src/routes/(app)/+layout.svelte
@@ -423,14 +423,14 @@
 			if (e.ctrlKey && e.shiftKey && e.key === 'F12') {
 				e.preventDefault();
 				debugMode = !debugMode;
-				const win = getCurrentWebviewWindow();
+				// Devtools has no JS API in Tauri 2 — `openDevtools()` on the window
+				// object is not a function and threw before the .catch could apply.
+				invoke('set_devtools', { open: debugMode }).catch((e: any) => console.warn('[debug] set_devtools failed:', e));
 				if (debugMode) {
-					(win as any).openDevtools().catch((e: any) => console.warn('[debug] openDevtools failed:', e));
 					// Force-show overlays regardless of game focus
 					invoke('force_show_overlays').catch((e: any) => console.warn('[debug] force_show_overlays failed:', e));
 					console.log('[debug] Debug mode ON — overlays force-shown');
 				} else {
-					(win as any).closeDevtools().catch((e: any) => console.warn('[debug] closeDevtools failed:', e));
 					console.log('[debug] Debug mode OFF');
 				}
 			}

--- a/desktop/src/routes/(app)/components/BestPlays.svelte
+++ b/desktop/src/routes/(app)/components/BestPlays.svelte
@@ -27,16 +27,21 @@
 	// `searchActive` is the one thing a scoped table still needs to know about
 	// the search: a search names a gem explicitly, so its result is shown even
 	// when that gem is low-confidence and the toggle is off.
+	// `rowCap` is applied AFTER the sort: the owner passes the full filtered
+	// pool, and "top N" must mean top N under the sort the user picked. Capping
+	// upstream handed this table the top N by fetch order, reordered.
 	let {
 		plays,
 		title = 'Best Plays Now (ALL variants)',
 		showVariantColumn = true,
 		searchActive = false,
+		rowCap = Infinity,
 	}: {
 		plays: GemPlay[];
 		title?: string;
 		showVariantColumn?: boolean;
 		searchActive?: boolean;
+		rowCap?: number;
 	} = $props();
 
 	let sortBy = $state<'price' | 'riskAdjusted' | 'roi' | 'roiPercent'>('price');
@@ -59,14 +64,16 @@
 			filtered = filtered.filter((p) => !p.lowConfidence);
 		}
 		if (sortBy === 'price') {
-			return filtered.sort((a, b) => b.transPrice - a.transPrice);
+			filtered.sort((a, b) => b.transPrice - a.transPrice);
+		} else if (sortBy === 'riskAdjusted') {
+			filtered.sort((a, b) => b.weightedRoi - a.weightedRoi);
+		} else {
+			filtered.sort((a, b) =>
+				sortBy === 'roi' ? b.roi - a.roi : b.roiPercent - a.roiPercent
+			);
 		}
-		if (sortBy === 'riskAdjusted') {
-			return filtered.sort((a, b) => b.weightedRoi - a.weightedRoi);
-		}
-		return filtered.sort((a, b) =>
-			sortBy === 'roi' ? b.roi - a.roi : b.roiPercent - a.roiPercent
-		);
+		// A search names its gems explicitly — show them all, cap only browsing.
+		return searchActive ? filtered : filtered.slice(0, rowCap);
 	});
 
 	function velocityStr(v: number): string {

--- a/desktop/src/routes/(app)/components/BestPlays.svelte
+++ b/desktop/src/routes/(app)/components/BestPlays.svelte
@@ -4,6 +4,7 @@
 	import { baseGemName, baseGemTradeUrl } from '$lib/trade-utils';
 	import { formatPrice } from '$lib/price.svelte';
 	import { ssot } from '$lib/stores/ssot.svelte';
+	import { persisted } from '$lib/prefs.svelte';
 	import { METRIC_TOOLTIPS } from '$lib/tooltips';
 	import SignalBadge from './SignalBadge.svelte';
 	import Sparkline from './Sparkline.svelte';
@@ -44,7 +45,12 @@
 		rowCap?: number;
 	} = $props();
 
-	let sortBy = $state<'price' | 'riskAdjusted' | 'roi' | 'roiPercent'>('price');
+	// Persisted (ADR-013): the chosen sort survives restarts, and one key means
+	// every rankings table sorts the same way.
+	const sortPref = persisted('rankingsSort', 'price');
+	const sortBy = $derived(
+		(['price', 'riskAdjusted', 'roi', 'roiPercent'] as const).find(s => s === sortPref.value) ?? 'price'
+	);
 	// Default ON to match the Rust-side setting default; the stored value below
 	// overwrites it on mount. Starting false would flash a filtered list first.
 	let showLowConf = $state(true);
@@ -111,7 +117,7 @@
 	<div class="plays-controls">
 		<label class="control-label">
 			Sort:
-			<Select bind:value={sortBy} options={SORT_OPTIONS} />
+			<Select bind:value={sortPref.value} options={SORT_OPTIONS} />
 		</label>
 		<Tooltip text="Show gems with very few listings (unreliable prices)"><label class="low-conf-toggle">
 			<input type="checkbox" bind:checked={showLowConf} onchange={() => invoke('set_show_low_confidence', { show: showLowConf }).catch(() => {})} />

--- a/desktop/src/routes/(app)/components/BestPlays.svelte
+++ b/desktop/src/routes/(app)/components/BestPlays.svelte
@@ -40,7 +40,6 @@
 	} = $props();
 
 	let sortBy = $state<'price' | 'riskAdjusted' | 'roi' | 'roiPercent'>('price');
-	let budget = $state('');
 	// Default ON to match the Rust-side setting default; the stored value below
 	// overwrites it on mount. Starting false would flash a filtered list first.
 	let showLowConf = $state(true);
@@ -58,13 +57,6 @@
 		let filtered = [...plays];
 		if (!showLowConf && !searchActive) {
 			filtered = filtered.filter((p) => !p.lowConfidence);
-		}
-		const b = parseInt(budget);
-		if (b > 0) {
-			// NO_BASE gems have no known cost basis (basePrice 0 means unknown, not
-			// free), so they can't be shown to fit a budget — same rule as the server.
-			filtered = filtered.filter((p) => p.confidence !== 'NO_BASE' && p.basePrice <= b);
-			if (b <= 50) sortBy = 'roiPercent';
 		}
 		if (sortBy === 'price') {
 			return filtered.sort((a, b) => b.transPrice - a.transPrice);
@@ -110,15 +102,6 @@
 <div class="plays-header">
 	<h3 class="plays-title">{title}</h3>
 	<div class="plays-controls">
-		<label class="control-label">
-			Budget:
-			<input
-				type="text"
-				class="budget-input"
-				placeholder="unlimited"
-				bind:value={budget}
-			/>
-		</label>
 		<label class="control-label">
 			Sort:
 			<Select bind:value={sortBy} options={SORT_OPTIONS} />
@@ -293,18 +276,6 @@
 		display: flex;
 		align-items: center;
 		gap: 6px;
-	}
-	.budget-input {
-		width: 90px;
-		background: var(--color-lab-bg);
-		border: 1px solid var(--color-lab-border);
-		color: var(--color-lab-text);
-		padding: 5px 10px;
-		font-size: 0.875rem;
-		font-family: inherit;
-	}
-	.budget-input::placeholder {
-		color: var(--color-lab-text-secondary);
 	}
 	.table-scroll {
 		max-height: 590px;

--- a/desktop/src/routes/(app)/components/BestPlays.svelte
+++ b/desktop/src/routes/(app)/components/BestPlays.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { invoke } from '@tauri-apps/api/core';
-	import { fetchSignalHistory, fetchGemNames, fetchBestPlays, type GemPlay, type SignalTransition } from '$lib/api';
+	import { fetchSignalHistory, type GemPlay, type SignalTransition } from '$lib/api';
 	import { baseGemName, baseGemTradeUrl } from '$lib/trade-utils';
 	import { formatPrice } from '$lib/price.svelte';
 	import { ssot } from '$lib/stores/ssot.svelte';
@@ -18,78 +18,29 @@
 		{ value: 'roiPercent', label: 'ROI%' },
 	];
 
+	// `plays` arrives already scoped to this table's variant (and pool, in
+	// Dedication mode) by the owner. Search lives in the owner too, for the same
+	// reason: a search run per-table fetched across every variant and replaced
+	// the scoped rows wholesale, so a table headed "Best Plays (20/20)" listed
+	// all four variants of the matched gem with no column to tell them apart.
+	//
+	// `searchActive` is the one thing a scoped table still needs to know about
+	// the search: a search names a gem explicitly, so its result is shown even
+	// when that gem is low-confidence and the toggle is off.
 	let {
 		plays,
 		title = 'Best Plays Now (ALL variants)',
 		showVariantColumn = true,
+		searchActive = false,
 	}: {
 		plays: GemPlay[];
 		title?: string;
 		showVariantColumn?: boolean;
+		searchActive?: boolean;
 	} = $props();
 
 	let sortBy = $state<'price' | 'riskAdjusted' | 'roi' | 'roiPercent'>('price');
 	let budget = $state('');
-	let searchQuery = $state('');
-	let searchFilter = $state('');
-	let suggestions = $state<string[]>([]);
-	let showDropdown = $state(false);
-	let highlightedIndex = $state(-1);
-	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
-
-	function handleSearchInput(query: string) {
-		searchQuery = query;
-		if (searchDebounce) clearTimeout(searchDebounce);
-		if (!query.trim()) {
-			searchFilter = '';
-			searchResults = null;
-			suggestions = [];
-			showDropdown = false;
-			return;
-		}
-		if (query.length < 2) {
-			suggestions = [];
-			showDropdown = false;
-			return;
-		}
-		searchDebounce = setTimeout(async () => {
-			if (searchQuery !== query) return;
-			const names = await fetchGemNames(query);
-			if (searchQuery !== query) return;
-			suggestions = names;
-			showDropdown = suggestions.length > 0;
-			highlightedIndex = suggestions.length === 1 ? 0 : -1;
-		}, 100);
-	}
-
-	let searchResults = $state<GemPlay[] | null>(null);
-
-	async function selectGem(name: string) {
-		searchQuery = name;
-		searchFilter = name;
-		suggestions = [];
-		showDropdown = false;
-		const results = await fetchBestPlays(undefined, undefined, undefined, undefined, name);
-		searchResults = results;
-	}
-
-	function handleSearchKeydown(e: KeyboardEvent) {
-		if (e.key === 'ArrowDown' && showDropdown) {
-			e.preventDefault();
-			highlightedIndex = Math.min(highlightedIndex + 1, suggestions.length - 1);
-		} else if (e.key === 'ArrowUp' && showDropdown) {
-			e.preventDefault();
-			highlightedIndex = Math.max(highlightedIndex - 1, 0);
-		} else if (e.key === 'Enter' && highlightedIndex >= 0) {
-			e.preventDefault();
-			selectGem(suggestions[highlightedIndex]);
-		} else if (e.key === 'Escape') {
-			showDropdown = false;
-			searchQuery = '';
-			searchFilter = '';
-			searchResults = null;
-		}
-	}
 	// Default ON to match the Rust-side setting default; the stored value below
 	// overwrites it on mount. Starting false would flash a filtered list first.
 	let showLowConf = $state(true);
@@ -104,8 +55,8 @@
 	let historyLoading = $state(false);
 
 	let sorted = $derived.by(() => {
-		let filtered = searchResults ? [...searchResults] : [...plays];
-		if (!showLowConf && !searchResults) {
+		let filtered = [...plays];
+		if (!showLowConf && !searchActive) {
 			filtered = filtered.filter((p) => !p.lowConfidence);
 		}
 		const b = parseInt(budget);
@@ -158,29 +109,6 @@
 
 <div class="plays-header">
 	<h3 class="plays-title">{title}</h3>
-	<div class="search-wrapper">
-		<input
-			type="text"
-			class="search-input"
-			placeholder="Search gem..."
-			value={searchQuery}
-			oninput={(e) => handleSearchInput(e.currentTarget.value)}
-			onkeydown={handleSearchKeydown}
-			onfocus={() => { if (suggestions.length) showDropdown = true; }}
-			onblur={() => setTimeout(() => { showDropdown = false; }, 200)}
-		/>
-		{#if showDropdown && suggestions.length > 0}
-			<div class="dropdown">
-				{#each suggestions as gem, i}
-					<button
-						class="dropdown-item"
-						class:highlighted={i === highlightedIndex}
-						onmousedown={() => selectGem(gem)}
-					>{gem}</button>
-				{/each}
-			</div>
-		{/if}
-	</div>
 	<div class="plays-controls">
 		<label class="control-label">
 			Budget:
@@ -353,51 +281,6 @@
 		font-weight: 700;
 		color: var(--color-lab-text);
 		margin: 0;
-	}
-	.search-wrapper {
-		position: relative;
-		flex: 1;
-		max-width: 300px;
-	}
-	.search-input {
-		width: 100%;
-		background: var(--color-lab-bg);
-		border: 1px solid var(--color-lab-border);
-		color: var(--color-lab-text);
-		padding: 6px 12px;
-		font-size: 0.8125rem;
-		font-family: inherit;
-		box-sizing: border-box;
-		outline: none;
-	}
-	.search-input::placeholder {
-		color: var(--color-lab-text-secondary);
-	}
-	.dropdown {
-		position: absolute;
-		top: 100%;
-		left: 0;
-		right: 0;
-		background: var(--color-lab-surface);
-		border: 1px solid var(--color-lab-border);
-		border-top: none;
-		max-height: 200px;
-		overflow-y: auto;
-		z-index: 100;
-	}
-	.dropdown-item {
-		display: block;
-		width: 100%;
-		padding: 6px 12px;
-		text-align: left;
-		background: none;
-		border: none;
-		color: var(--color-lab-text);
-		font-size: 0.8125rem;
-		cursor: pointer;
-	}
-	.dropdown-item:hover, .dropdown-item.highlighted {
-		background: rgba(255, 255, 255, 0.08);
 	}
 	.plays-controls {
 		display: flex;

--- a/desktop/src/routes/(app)/components/ByVariant.svelte
+++ b/desktop/src/routes/(app)/components/ByVariant.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { untrack } from 'svelte';
 	import { VARIANTS, DEDICATION_VARIANTS, type GemPlay } from '$lib/api';
 	import { ssot, setNormalVariant, setDedicationSelection } from '$lib/stores/ssot.svelte';
 	import BestPlays from './BestPlays.svelte';
@@ -41,7 +40,7 @@
 		const variant = ssot.normalVariant;
 		if (variant === seenNormalVariant) return;
 		seenNormalVariant = variant;
-		untrack(() => { activeTab = variant; });
+		activeTab = variant;
 	});
 
 	// Both halves are the shared selection now: picking a dedication tab moves

--- a/desktop/src/routes/(app)/components/ByVariant.svelte
+++ b/desktop/src/routes/(app)/components/ByVariant.svelte
@@ -80,6 +80,7 @@
 	// that level/quality.
 	let searchQuery = $state('');
 	let searchResults = $state<GemPlay[] | null>(null);
+	let searchError = $state('');
 	let suggestions = $state<string[]>([]);
 	let showDropdown = $state(false);
 	let highlightedIndex = $state(-1);
@@ -88,6 +89,7 @@
 	function clearSearch() {
 		searchQuery = '';
 		searchResults = null;
+		searchError = '';
 		suggestions = [];
 		showDropdown = false;
 		highlightedIndex = -1;
@@ -107,7 +109,14 @@
 		}
 		searchDebounce = setTimeout(async () => {
 			if (searchQuery !== query) return;
-			const names = await fetchGemNames(query);
+			let names: string[];
+			try {
+				names = await fetchGemNames(query, isDedication ? 'dedication' : undefined);
+			} catch (err) {
+				// A swallowed rejection here presented as "typing does nothing".
+				console.warn('[ByVariant] gem name lookup failed:', err);
+				return;
+			}
 			if (searchQuery !== query) return;
 			suggestions = names;
 			showDropdown = suggestions.length > 0;
@@ -119,14 +128,25 @@
 		searchQuery = name;
 		suggestions = [];
 		showDropdown = false;
-		// Fetch across every market — the per-market filter below splits the
-		// result back out. The mode has to be passed: without it the server
-		// answers with normal-mode rows, which carry no `baseName`, so in
-		// Dedication mode every table matched nothing and search looked broken.
-		searchResults = await fetchBestPlays(
-			undefined, undefined, undefined, undefined, name,
-			isDedication ? 'dedication' : undefined,
-		);
+		searchError = '';
+		try {
+			// The dedication endpoint answers for ONE market per request: omitting
+			// `variant` does not mean "all", it silently defaults to 21/23, so a
+			// 21/20 tab found nothing. Fan out and merge, the way the ranked rows
+			// are loaded. Normal mode does return every variant in one response.
+			searchResults = isDedication
+				? (await Promise.all(
+						DEDICATION_VARIANTS.map((v) =>
+							fetchBestPlays(v, undefined, undefined, undefined, name, 'dedication'),
+						),
+					)).flat()
+				: await fetchBestPlays(undefined, undefined, undefined, undefined, name);
+		} catch (err) {
+			// Without this the rejection was silent and the UI simply never changed.
+			console.warn('[ByVariant] gem search failed:', err);
+			searchResults = null;
+			searchError = `Search for "${name}" failed \u2014 check the connection and try again.`;
+		}
 	}
 
 	function handleSearchKeydown(e: KeyboardEvent) {
@@ -228,7 +248,11 @@
 			{/each}
 		</div>
 		<div class="tabs">
-			{#if isDedication}
+			{#if searchError}
+		<div class="search-error">{searchError}</div>
+	{/if}
+
+	{#if isDedication}
 				{#each DEDICATION_TABS as tab}
 					<button
 						class="tab"
@@ -298,7 +322,14 @@
 		justify-content: space-between;
 		align-items: center;
 		margin-bottom: 16px;
-	}
+	/* Wrap, and give every child a gap. The row holds five items — title,
+	   search, Show, colour tabs, variant tabs — and measured wider than the
+	   1024px default window, so a no-wrap row left the search box at 26-82px:
+	   two visible characters, with the absolutely-positioned clear button
+	   covering all of it. */
+	flex-wrap: wrap;
+	gap: 8px;
+}
 	.section-title {
 		font-size: 1.125rem;
 		font-weight: 700;
@@ -307,7 +338,11 @@
 	}
 	.search-wrapper {
 		position: relative;
-		flex: 1;
+		/* NOT `flex: 1` — that is flex-basis 0, and this row has no free space to
+		   distribute, so the box collapsed to its automatic minimum. A real basis
+		   keeps it usable and still lets it shrink. */
+		flex: 0 1 240px;
+		min-width: 180px;
 		max-width: 300px;
 	}
 	.search-input {
@@ -326,6 +361,7 @@
 	}
 	.dropdown {
 		position: absolute;
+		min-width: 240px;
 		top: 100%;
 		left: 0;
 		right: 0;
@@ -339,6 +375,9 @@
 	.dropdown-item {
 		display: block;
 		width: 100%;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 		padding: 6px 12px;
 		text-align: left;
 		background: none;
@@ -365,6 +404,11 @@
 	}
 	.search-clear:hover {
 		color: var(--color-lab-text);
+	}
+	.search-error {
+		color: #f87171;
+		font-size: 0.8125rem;
+		margin-bottom: 12px;
 	}
 	.limit-select {
 		display: flex;

--- a/desktop/src/routes/(app)/components/ByVariant.svelte
+++ b/desktop/src/routes/(app)/components/ByVariant.svelte
@@ -5,6 +5,7 @@
 		DEDICATION_VARIANTS,
 		DEDICATION_POOLS,
 		DEDICATION_POOL_LABELS,
+		type DedicationPool,
 		fetchGemNames,
 		fetchBestPlays,
 		type GemPlay,
@@ -173,12 +174,53 @@
 	// across would be from the wrong one.
 	$effect(() => {
 		isDedication;
-		untrack(() => { if (searchResults) clearSearch(); });
+		// Unconditional: a query typed but not yet picked leaves `suggestions`
+		// full of names from the other mode's pool, and picking one then searches a
+		// gem that cannot exist in this mode.
+		untrack(() => { if (searchQuery || searchResults) clearSearch(); });
 	});
+
+	/**
+	 * Why a searched gem is missing from the table in front of you.
+	 *
+	 * The Dedication picker offers names the rankings can never contain: Vaal gems
+	 * are a legal feed and deliberately stay in the autocomplete for the compare
+	 * surface (internal/lab/repository.go, CorruptedGemNamesAutocomplete), but
+	 * isDedicationOutcome excludes them from every ranking. The picker also spans
+	 * both pools, so a non-transfigured name is offerable while the Transfigured
+	 * tab is active. Measured 2026-08-08 over 77 suggestions from 8 queries: 36 of
+	 * them yield nothing on the 21/23 Transfigured tab — 19 Vaal, 17 wrong-pool.
+	 *
+	 * "No <gem> in this pool" was a wrong answer for all 36: it reads as "this gem
+	 * does not sell here", when the truth is either "it is in the other pool" or
+	 * "it is never a craft outcome". Say which.
+	 */
+	function searchMissReason(): string {
+		if (!searchResults) return '';
+		if (searchResults.length === 0) {
+			return `${searchQuery} is not in the rankings \u2014 Vaal gems are a legal feed but never a craft outcome, so they are never ranked.`;
+		}
+		const pools = [...new Set(searchResults.map((g) => g.baseName).filter(Boolean))];
+		const markets = [...new Set(searchResults.map((g) => g.variant).filter(Boolean))].sort();
+		const wherePool = pools
+			.map((pool) => DEDICATION_POOL_LABELS[pool as DedicationPool] ?? pool)
+			.join(' / ');
+		if (isDedication && wherePool) {
+			return `${searchQuery} is in ${wherePool}${markets.length ? ` at ${markets.join(', ')}` : ''} \u2014 not this tab.`;
+		}
+		return markets.length
+			? `${searchQuery} is ranked at ${markets.join(', ')} \u2014 not this one.`
+			: `${searchQuery} is not in the rankings.`;
+	}
 
 	// Filter from already-loaded data — zero API calls.
 	function playsForVariant(variant: string): GemPlay[] {
 		let filtered = playSource.filter(g => g.variant === variant);
+		// A search names one gem, so the colour tab and the row cap do not apply to
+		// it — they are for browsing a ranked list. Filtering a searched gem out by
+		// colour and then rendering "not at this variant" answers a question the
+		// player did not ask, with the wrong reason.
+		if (searchResults) return filtered;
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
@@ -192,6 +234,7 @@
 		// table rather than the previous market's numbers — the rows themselves
 		// are the only thing here that knows which market they describe.
 		let filtered = playSource.filter(g => g.baseName === poolType && g.variant === variant);
+		if (searchResults) return filtered;
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
@@ -248,11 +291,7 @@
 			{/each}
 		</div>
 		<div class="tabs">
-			{#if searchError}
-		<div class="search-error">{searchError}</div>
-	{/if}
-
-	{#if isDedication}
+			{#if isDedication}
 				{#each DEDICATION_TABS as tab}
 					<button
 						class="tab"
@@ -286,13 +325,17 @@
 		</div>
 	</div>
 
+	{#if searchError}
+		<div class="search-error">{searchError}</div>
+	{/if}
+
 	{#if isDedication}
 		{@const tab = activeDedTabInfo}
 		{@const vd = playsForPool(tab.pool, tab.variant)}
 		{#if vd.length > 0}
 			<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool] || tab.pool}) — {tab.variant}" showVariantColumn={false} searchActive={searchResults !== null} />
 		{:else if searchResults}
-			<div class="loading">No {searchQuery} in this pool</div>
+			<div class="loading">{searchMissReason()}</div>
 		{:else}
 			<div class="loading">No data for this pool</div>
 		{/if}
@@ -302,7 +345,7 @@
 			{#if vd.length > 0}
 				<BestPlays plays={vd} title="Best Plays ({variant})" showVariantColumn={false} searchActive={searchResults !== null} />
 			{:else if searchResults}
-				<div class="loading">No {searchQuery} at {variant}</div>
+				<div class="loading">{searchMissReason()}</div>
 			{:else}
 				<div class="loading">No data for this variant</div>
 			{/if}

--- a/desktop/src/routes/(app)/components/ByVariant.svelte
+++ b/desktop/src/routes/(app)/components/ByVariant.svelte
@@ -50,6 +50,14 @@
 		if (variant === seenNormalVariant) return;
 		seenNormalVariant = variant;
 		activeTab = variant;
+		// A market change made anywhere (top-bar selector included) also ends
+		// the remembered ALL view — otherwise a later remount re-seeds ALL from
+		// the pref and silently discards the market the user just picked.
+		// Narrow accepted race: if this component mounts before the store's
+		// first poll lands AND the stored market differs from the default seed,
+		// this clears a remembered ALL view — degrading to the market tab, not
+		// corrupting anything.
+		tabViewPref.value = '';
 	});
 
 	// Both halves are the shared selection now: picking a dedication tab moves
@@ -87,13 +95,43 @@
 	// that level/quality.
 	// --- Budget (one box for every table below it, like the search) ---
 	//
-	// The filter must run BEFORE the per-table row cap. It used to live in
-	// BestPlays, downstream of the cap, so it could only thin out the 20 rows
-	// already chosen by price — and the visible top-20's base prices sit well
-	// under any realistic budget, so typing one changed nothing. Filtering here
-	// re-fills the table with the best gems that actually fit.
+	// A budget is answered by the SERVER, not by filtering the loaded rows: the
+	// ranked pool on hand is the top-100 per market by absolute ROI, so a small
+	// budget filtered client-side keeps only the affordable stragglers of an
+	// expensive-base list. The server's budget param filters the full corpus
+	// before its limit (internal/lab/collective.go). The client-side filter in
+	// browseFilter stays as the fallback while the fetch is in flight or failed.
 	const budgetPref = persisted('rankingsBudget', '');
 	const budgetChaos = $derived(parseInt(budgetPref.value) > 0 ? parseInt(budgetPref.value) : 0);
+	let budgetResults = $state<GemPlay[] | null>(null);
+	let budgetGeneration = 0;
+	$effect(() => {
+		const b = budgetChaos;
+		const dedication = isDedication;
+		const generation = ++budgetGeneration;
+		if (b <= 0) {
+			budgetResults = null;
+			return;
+		}
+		// Debounced: the box is a text input, and each fetch fans out per market.
+		const timer = setTimeout(async () => {
+			try {
+				const rows = dedication
+					? (await Promise.all(
+							DEDICATION_VARIANTS.map((v) => fetchBestPlays(v, b, undefined, 100, undefined, 'dedication')),
+						)).flat()
+					: (await Promise.all(
+							VARIANTS.map((v) => fetchBestPlays(v, b, undefined, 100)),
+						)).flat();
+				if (generation === budgetGeneration) budgetResults = rows;
+			} catch (err) {
+				// Fall back to filtering the rows on hand — fewer results, never wrong ones.
+				console.warn('[ByVariant] budget fetch failed:', err);
+				if (generation === budgetGeneration) budgetResults = null;
+			}
+		}, 300);
+		return () => clearTimeout(timer);
+	});
 
 	let searchQuery = $state('');
 	let searchResults = $state<GemPlay[] | null>(null);
@@ -183,8 +221,9 @@
 
 	// A search replaces the ranked rows as the source, but never the scoping: the
 	// per-market and per-color filters below apply to it exactly as they do to
-	// the ranked rows.
-	const playSource = $derived(searchResults ?? allPlays);
+	// the ranked rows. A budget-scoped fetch replaces them the same way, one
+	// rung lower — search wins over budget.
+	const playSource = $derived(searchResults ?? budgetResults ?? allPlays);
 
 	// Switching lab mode re-fetches under a different mode, so a result carried
 	// across would be from the wrong one.

--- a/desktop/src/routes/(app)/components/ByVariant.svelte
+++ b/desktop/src/routes/(app)/components/ByVariant.svelte
@@ -57,10 +57,6 @@
 	let activeColor = $state('ALL');
 	let itemLimit = $state('20');
 
-	let visibleVariants = $derived(
-		activeTab === 'ALL' ? VARIANTS : [activeTab]
-	);
-
 	let activeDedTabInfo = $derived(
 		DEDICATION_TABS.find(t => t.key === activeDedTab) ?? DEDICATION_TABS[0]
 	);
@@ -246,6 +242,20 @@
 		return browseFilter(filtered);
 	}
 
+	// The ALL tab is ONE merged table, not four stacked ones: a budget or colour
+	// filter there is a cross-market question, and four tables answer it four
+	// separate times. The merged pool arrives variant-grouped (per-variant
+	// fetches, concatenated), so it must be ranked by price before the row cap —
+	// a positional slice would fill the whole table from the first variant
+	// fetched. Ranking by price matches how the per-variant tables choose their
+	// rows; the Sort dropdown then reorders within the chosen set, as it does
+	// everywhere else.
+	function playsForAll(): GemPlay[] {
+		if (searchResults) return playSource;
+		const ranked = [...playSource].sort((a, b) => b.transPrice - a.transPrice);
+		return browseFilter(ranked);
+	}
+
 	function playsForPool(poolType: string, variant: string): GemPlay[] {
 		// baseName holds "skill" or "transfigured" for Dedication gems, and the
 		// server stamps each row with the market it was ranked in. Filtering on
@@ -364,17 +374,24 @@
 		{:else}
 			<div class="loading">No data for this pool</div>
 		{/if}
+	{:else if activeTab === 'ALL'}
+		{@const vd = playsForAll()}
+		{#if vd.length > 0}
+			<BestPlays plays={vd} title="Best Plays (all markets)" showVariantColumn={true} searchActive={searchResults !== null} />
+		{:else if searchResults}
+			<div class="loading">{searchMissReason()}</div>
+		{:else}
+			<div class="loading">No data available</div>
+		{/if}
 	{:else}
-		{#each visibleVariants as variant}
-			{@const vd = playsForVariant(variant)}
-			{#if vd.length > 0}
-				<BestPlays plays={vd} title="Best Plays ({variant})" showVariantColumn={false} searchActive={searchResults !== null} />
-			{:else if searchResults}
-				<div class="loading">{searchMissReason()}</div>
-			{:else}
-				<div class="loading">No data for this variant</div>
-			{/if}
-		{/each}
+		{@const vd = playsForVariant(activeTab)}
+		{#if vd.length > 0}
+			<BestPlays plays={vd} title="Best Plays ({activeTab})" showVariantColumn={false} searchActive={searchResults !== null} />
+		{:else if searchResults}
+			<div class="loading">{searchMissReason()}</div>
+		{:else}
+			<div class="loading">No data for this variant</div>
+		{/if}
 	{/if}
 </section>
 

--- a/desktop/src/routes/(app)/components/ByVariant.svelte
+++ b/desktop/src/routes/(app)/components/ByVariant.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
-	import { invoke } from '@tauri-apps/api/core';
+	import { untrack } from 'svelte';
 	import { VARIANTS, DEDICATION_VARIANTS, type GemPlay } from '$lib/api';
+	import { ssot, setNormalVariant, setDedicationSelection } from '$lib/stores/ssot.svelte';
 	import BestPlays from './BestPlays.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import Select from '$lib/components/Select.svelte';
@@ -29,17 +30,23 @@
 		{ value: '50', label: '50' },
 	];
 
-	let activeTab = $state('20/20');
-	let activeDedTab = $state(DEDICATION_TABS[0].key);
-	// Only the pool half is persisted in Rust (it also drives the overlay); the
-	// market shown here is a local view choice, unlike the farmed market in the
-	// top bar which is stamped onto recorded runs.
+	// The tab strip follows the shared market, but it also offers ALL — a fifth
+	// value the store's four-value domain has no room for. So the tab stays local
+	// state seeded from the store, and follows a *change* of the store value
+	// rather than the value itself: a plain effect would snap ALL back to the
+	// market on every run.
+	let activeTab = $state(ssot.normalVariant);
+	let seenNormalVariant = ssot.normalVariant;
 	$effect(() => {
-		invoke<string>('get_dedication_pool').then(p => {
-			const match = DEDICATION_TABS.find(t => t.pool === p);
-			if (match) activeDedTab = match.key;
-		}).catch(() => {});
+		const variant = ssot.normalVariant;
+		if (variant === seenNormalVariant) return;
+		seenNormalVariant = variant;
+		untrack(() => { activeTab = variant; });
 	});
+
+	// Both halves are the shared selection now: picking a dedication tab moves
+	// the market that Rust stamps onto recorded runs, not just this view.
+	const activeDedTab = $derived(`${ssot.dedicationVariant}:${ssot.dedicationPool}`);
 	let activeColor = $state('ALL');
 	let itemLimit = $state('20');
 
@@ -102,7 +109,7 @@
 					<button
 						class="tab"
 						class:active={activeDedTab === tab.key}
-						onclick={() => { activeDedTab = tab.key; invoke('set_dedication_pool', { pool: tab.pool }).catch(() => {}); }}
+						onclick={() => { setDedicationSelection(tab.variant, tab.pool); }}
 					>
 						{#if activeDedTab === tab.key}<span class="tab-dot">●</span>{/if}
 						{tab.label}
@@ -113,7 +120,15 @@
 					<button
 						class="tab"
 						class:active={activeTab === tab}
-						onclick={() => { activeTab = tab; }}
+						onclick={() => {
+							activeTab = tab;
+							// ALL is a view-only tab: it names no market, so it never
+							// writes to the shared selection.
+							if (tab !== 'ALL') {
+								seenNormalVariant = tab;
+								setNormalVariant(tab);
+							}
+						}}
 					>
 						{#if activeTab === tab}<span class="tab-dot">●</span>{/if}
 						{tab}

--- a/desktop/src/routes/(app)/components/ByVariant.svelte
+++ b/desktop/src/routes/(app)/components/ByVariant.svelte
@@ -79,6 +79,16 @@
 	// the unsearched rows go through. A market with no match renders its usual
 	// empty state, which is the useful answer — it says the gem does not sell at
 	// that level/quality.
+	// --- Budget (one box for every table below it, like the search) ---
+	//
+	// The filter must run BEFORE the per-table row cap. It used to live in
+	// BestPlays, downstream of the cap, so it could only thin out the 20 rows
+	// already chosen by price — and the visible top-20's base prices sit well
+	// under any realistic budget, so typing one changed nothing. Filtering here
+	// re-fills the table with the best gems that actually fit.
+	let budgetInput = $state('');
+	const budgetChaos = $derived(parseInt(budgetInput) > 0 ? parseInt(budgetInput) : 0);
+
 	let searchQuery = $state('');
 	let searchResults = $state<GemPlay[] | null>(null);
 	let searchError = $state('');
@@ -213,18 +223,27 @@
 			: `${searchQuery} is not in the rankings.`;
 	}
 
-	// Filter from already-loaded data — zero API calls.
-	function playsForVariant(variant: string): GemPlay[] {
-		let filtered = playSource.filter(g => g.variant === variant);
-		// A search names one gem, so the colour tab and the row cap do not apply to
-		// it — they are for browsing a ranked list. Filtering a searched gem out by
-		// colour and then rendering "not at this variant" answers a question the
-		// player did not ask, with the wrong reason.
-		if (searchResults) return filtered;
+	// Browse-mode filters shared by both table shapes: budget, then colour, then
+	// the row cap. A search bypasses all three — it names one gem explicitly, so
+	// hiding it by budget or colour and then blaming the market answers a
+	// question the player did not ask, with the wrong reason.
+	function browseFilter(filtered: GemPlay[]): GemPlay[] {
+		if (budgetChaos > 0) {
+			// NO_BASE gems have no known cost basis (basePrice 0 means unknown, not
+			// free), so they can't be shown to fit a budget — same rule as the server.
+			filtered = filtered.filter(g => g.confidence !== 'NO_BASE' && g.basePrice <= budgetChaos);
+		}
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
 		return filtered.slice(0, parseInt(itemLimit));
+	}
+
+	// Filter from already-loaded data — zero API calls.
+	function playsForVariant(variant: string): GemPlay[] {
+		const filtered = playSource.filter(g => g.variant === variant);
+		if (searchResults) return filtered;
+		return browseFilter(filtered);
 	}
 
 	function playsForPool(poolType: string, variant: string): GemPlay[] {
@@ -233,12 +252,9 @@
 		// both means a heading that has moved ahead of its rows shows an empty
 		// table rather than the previous market's numbers — the rows themselves
 		// are the only thing here that knows which market they describe.
-		let filtered = playSource.filter(g => g.baseName === poolType && g.variant === variant);
+		const filtered = playSource.filter(g => g.baseName === poolType && g.variant === variant);
 		if (searchResults) return filtered;
-		if (activeColor !== 'ALL') {
-			filtered = filtered.filter(g => g.color === activeColor);
-		}
-		return filtered.slice(0, parseInt(itemLimit));
+		return browseFilter(filtered);
 	}
 </script>
 
@@ -271,6 +287,15 @@
 				</div>
 			{/if}
 		</div>
+		<label class="budget-label">
+			Budget:
+			<input
+				type="text"
+				class="budget-input"
+				placeholder="unlimited"
+				bind:value={budgetInput}
+			/>
+		</label>
 		<div class="limit-select">
 			<span class="select-label">Show:</span>
 			<Select bind:value={itemLimit} options={LIMIT_OPTIONS} />
@@ -400,6 +425,25 @@
 		outline: none;
 	}
 	.search-input::placeholder {
+		color: var(--color-lab-text-secondary);
+	}
+	.budget-label {
+		color: var(--color-lab-text-secondary);
+		font-size: 0.875rem;
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+	.budget-input {
+		width: 90px;
+		background: var(--color-lab-bg);
+		border: 1px solid var(--color-lab-border);
+		color: var(--color-lab-text);
+		padding: 5px 10px;
+		font-size: 0.875rem;
+		font-family: inherit;
+	}
+	.budget-input::placeholder {
 		color: var(--color-lab-text-secondary);
 	}
 	.dropdown {

--- a/desktop/src/routes/(app)/components/ByVariant.svelte
+++ b/desktop/src/routes/(app)/components/ByVariant.svelte
@@ -11,6 +11,7 @@
 		type GemPlay,
 	} from '$lib/api';
 	import { ssot, setNormalVariant, setDedicationSelection } from '$lib/stores/ssot.svelte';
+	import { persisted } from '$lib/prefs.svelte';
 	import BestPlays from './BestPlays.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import Select from '$lib/components/Select.svelte';
@@ -54,8 +55,17 @@
 	// Both halves are the shared selection now: picking a dedication tab moves
 	// the market that Rust stamps onto recorded runs, not just this view.
 	const activeDedTab = $derived(`${ssot.dedicationVariant}:${ssot.dedicationPool}`);
-	let activeColor = $state('ALL');
-	let itemLimit = $state('20');
+
+	// Persisted picks (ADR-013): every select on this surface is remembered
+	// across launches. The market tabs are already remembered through the SSOT
+	// store; the ALL view is the one tab value the store's domain has no room
+	// for, so it gets its own pref, applied on top of the market seed.
+	const colorPref = persisted('rankingsColor', 'ALL');
+	const limitPref = persisted('rankingsLimit', '20');
+	const tabViewPref = persisted('rankingsTabView', '');
+	$effect(() => {
+		if (tabViewPref.value === 'ALL') activeTab = 'ALL';
+	});
 
 	let activeDedTabInfo = $derived(
 		DEDICATION_TABS.find(t => t.key === activeDedTab) ?? DEDICATION_TABS[0]
@@ -82,8 +92,8 @@
 	// already chosen by price — and the visible top-20's base prices sit well
 	// under any realistic budget, so typing one changed nothing. Filtering here
 	// re-fills the table with the best gems that actually fit.
-	let budgetInput = $state('');
-	const budgetChaos = $derived(parseInt(budgetInput) > 0 ? parseInt(budgetInput) : 0);
+	const budgetPref = persisted('rankingsBudget', '');
+	const budgetChaos = $derived(parseInt(budgetPref.value) > 0 ? parseInt(budgetPref.value) : 0);
 
 	let searchQuery = $state('');
 	let searchResults = $state<GemPlay[] | null>(null);
@@ -233,8 +243,8 @@
 			// free), so they can't be shown to fit a budget — same rule as the server.
 			filtered = filtered.filter(g => g.confidence !== 'NO_BASE' && g.basePrice <= budgetChaos);
 		}
-		if (activeColor !== 'ALL') {
-			filtered = filtered.filter(g => g.color === activeColor);
+		if (colorPref.value !== 'ALL') {
+			filtered = filtered.filter(g => g.color === colorPref.value);
 		}
 		return filtered;
 	}
@@ -303,22 +313,22 @@
 				type="text"
 				class="budget-input"
 				placeholder="unlimited"
-				bind:value={budgetInput}
+				bind:value={budgetPref.value}
 			/>
 		</label>
 		<div class="limit-select">
 			<span class="select-label">Show:</span>
-			<Select bind:value={itemLimit} options={LIMIT_OPTIONS} />
+			<Select bind:value={limitPref.value} options={LIMIT_OPTIONS} />
 		</div>
 		<div class="color-tabs">
 			{#each COLORS as color}
 				<button
 					class="tab color-tab"
-					class:active={activeColor === color}
+					class:active={colorPref.value === color}
 					class:c-red={color === 'RED'}
 					class:c-green={color === 'GREEN'}
 					class:c-blue={color === 'BLUE'}
-					onclick={() => { activeColor = color; }}
+					onclick={() => { colorPref.value = color; }}
 				>
 					{#if color !== 'ALL'}<span class="color-dot">●</span>{/if}
 					{color}
@@ -345,7 +355,9 @@
 						onclick={() => {
 							activeTab = tab;
 							// ALL is a view-only tab: it names no market, so it never
-							// writes to the shared selection.
+							// writes to the shared selection — it is remembered through
+							// its own pref instead.
+							tabViewPref.value = tab === 'ALL' ? 'ALL' : '';
 							if (tab !== 'ALL') {
 								seenNormalVariant = tab;
 								setNormalVariant(tab);
@@ -368,7 +380,7 @@
 		{@const tab = activeDedTabInfo}
 		{@const vd = playsForPool(tab.pool, tab.variant)}
 		{#if vd.length > 0}
-			<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool] || tab.pool}) — {tab.variant}" showVariantColumn={false} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
+			<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool] || tab.pool}) — {tab.variant}" showVariantColumn={false} rowCap={parseInt(limitPref.value)} searchActive={searchResults !== null} />
 		{:else if searchResults}
 			<div class="loading">{searchMissReason()}</div>
 		{:else}
@@ -377,7 +389,7 @@
 	{:else if activeTab === 'ALL'}
 		{@const vd = playsForAll()}
 		{#if vd.length > 0}
-			<BestPlays plays={vd} title="Best Plays (all markets)" showVariantColumn={true} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
+			<BestPlays plays={vd} title="Best Plays (all markets)" showVariantColumn={true} rowCap={parseInt(limitPref.value)} searchActive={searchResults !== null} />
 		{:else if searchResults}
 			<div class="loading">{searchMissReason()}</div>
 		{:else}
@@ -386,7 +398,7 @@
 	{:else}
 		{@const vd = playsForVariant(activeTab)}
 		{#if vd.length > 0}
-			<BestPlays plays={vd} title="Best Plays ({activeTab})" showVariantColumn={false} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
+			<BestPlays plays={vd} title="Best Plays ({activeTab})" showVariantColumn={false} rowCap={parseInt(limitPref.value)} searchActive={searchResults !== null} />
 		{:else if searchResults}
 			<div class="loading">{searchMissReason()}</div>
 		{:else}

--- a/desktop/src/routes/(app)/components/ByVariant.svelte
+++ b/desktop/src/routes/(app)/components/ByVariant.svelte
@@ -219,10 +219,14 @@
 			: `${searchQuery} is not in the rankings.`;
 	}
 
-	// Browse-mode filters shared by both table shapes: budget, then colour, then
-	// the row cap. A search bypasses all three — it names one gem explicitly, so
-	// hiding it by budget or colour and then blaming the market answers a
-	// question the player did not ask, with the wrong reason.
+	// Browse-mode filters shared by both table shapes: budget, then colour. A
+	// search bypasses both — it names one gem explicitly, so hiding it by budget
+	// or colour and then blaming the market answers a question the player did
+	// not ask, with the wrong reason.
+	//
+	// No row cap here: the cap belongs downstream in BestPlays, AFTER its sort.
+	// Capping before the sort handed the table "the top rows by fetch order,
+	// reordered" — under a ROI sort that is not the top rows by ROI at all.
 	function browseFilter(filtered: GemPlay[]): GemPlay[] {
 		if (budgetChaos > 0) {
 			// NO_BASE gems have no known cost basis (basePrice 0 means unknown, not
@@ -232,7 +236,7 @@
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
-		return filtered.slice(0, parseInt(itemLimit));
+		return filtered;
 	}
 
 	// Filter from already-loaded data — zero API calls.
@@ -245,15 +249,11 @@
 	// The ALL tab is ONE merged table, not four stacked ones: a budget or colour
 	// filter there is a cross-market question, and four tables answer it four
 	// separate times. The merged pool arrives variant-grouped (per-variant
-	// fetches, concatenated), so it must be ranked by price before the row cap —
-	// a positional slice would fill the whole table from the first variant
-	// fetched. Ranking by price matches how the per-variant tables choose their
-	// rows; the Sort dropdown then reorders within the chosen set, as it does
-	// everywhere else.
+	// fetches, concatenated) — safe to pass on unordered, because BestPlays
+	// sorts before it caps.
 	function playsForAll(): GemPlay[] {
 		if (searchResults) return playSource;
-		const ranked = [...playSource].sort((a, b) => b.transPrice - a.transPrice);
-		return browseFilter(ranked);
+		return browseFilter(playSource);
 	}
 
 	function playsForPool(poolType: string, variant: string): GemPlay[] {
@@ -368,7 +368,7 @@
 		{@const tab = activeDedTabInfo}
 		{@const vd = playsForPool(tab.pool, tab.variant)}
 		{#if vd.length > 0}
-			<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool] || tab.pool}) — {tab.variant}" showVariantColumn={false} searchActive={searchResults !== null} />
+			<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool] || tab.pool}) — {tab.variant}" showVariantColumn={false} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
 		{:else if searchResults}
 			<div class="loading">{searchMissReason()}</div>
 		{:else}
@@ -377,7 +377,7 @@
 	{:else if activeTab === 'ALL'}
 		{@const vd = playsForAll()}
 		{#if vd.length > 0}
-			<BestPlays plays={vd} title="Best Plays (all markets)" showVariantColumn={true} searchActive={searchResults !== null} />
+			<BestPlays plays={vd} title="Best Plays (all markets)" showVariantColumn={true} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
 		{:else if searchResults}
 			<div class="loading">{searchMissReason()}</div>
 		{:else}
@@ -386,7 +386,7 @@
 	{:else}
 		{@const vd = playsForVariant(activeTab)}
 		{#if vd.length > 0}
-			<BestPlays plays={vd} title="Best Plays ({activeTab})" showVariantColumn={false} searchActive={searchResults !== null} />
+			<BestPlays plays={vd} title="Best Plays ({activeTab})" showVariantColumn={false} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
 		{:else if searchResults}
 			<div class="loading">{searchMissReason()}</div>
 		{:else}

--- a/desktop/src/routes/(app)/components/ByVariant.svelte
+++ b/desktop/src/routes/(app)/components/ByVariant.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
-	import { VARIANTS, DEDICATION_VARIANTS, type GemPlay } from '$lib/api';
+	import { untrack } from 'svelte';
+	import {
+		VARIANTS,
+		DEDICATION_VARIANTS,
+		DEDICATION_POOLS,
+		DEDICATION_POOL_LABELS,
+		fetchGemNames,
+		fetchBestPlays,
+		type GemPlay,
+	} from '$lib/api';
 	import { ssot, setNormalVariant, setDedicationSelection } from '$lib/stores/ssot.svelte';
 	import BestPlays from './BestPlays.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
@@ -10,8 +19,6 @@
 	const isDedication = $derived(labMode === 'dedication');
 
 	const NORMAL_TABS = ['ALL', ...VARIANTS];
-	const DEDICATION_POOLS = ['skill', 'transfigured'];
-	const DEDICATION_POOL_LABELS: Record<string, string> = { skill: 'Skills', transfigured: 'Transfigured' };
 	// One tab per (market, pool): the four rows of the Dedication EV table, in
 	// the same order.
 	const DEDICATION_TABS = DEDICATION_VARIANTS.flatMap((variant) =>
@@ -57,9 +64,101 @@
 		DEDICATION_TABS.find(t => t.key === activeDedTab) ?? DEDICATION_TABS[0]
 	);
 
+	// --- Gem search (one box for every table below it) ---
+	//
+	// Search lives here rather than in BestPlays because the tables below are
+	// each scoped to one market. A per-table search fetched across every variant
+	// and then replaced that table's rows wholesale, so a table headed "Best
+	// Plays (20/20)" listed all four variants of the matched gem — with the Var
+	// column hidden, as four rows that read as identical. On the ALL tab it was
+	// worse: four tables, four independent boxes, so typing in one left the
+	// other three showing unrelated gems.
+	//
+	// One query, held here, feeds every table through the same per-market filter
+	// the unsearched rows go through. A market with no match renders its usual
+	// empty state, which is the useful answer — it says the gem does not sell at
+	// that level/quality.
+	let searchQuery = $state('');
+	let searchResults = $state<GemPlay[] | null>(null);
+	let suggestions = $state<string[]>([]);
+	let showDropdown = $state(false);
+	let highlightedIndex = $state(-1);
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function clearSearch() {
+		searchQuery = '';
+		searchResults = null;
+		suggestions = [];
+		showDropdown = false;
+		highlightedIndex = -1;
+	}
+
+	function handleSearchInput(query: string) {
+		searchQuery = query;
+		if (searchDebounce) clearTimeout(searchDebounce);
+		if (!query.trim()) {
+			clearSearch();
+			return;
+		}
+		if (query.length < 2) {
+			suggestions = [];
+			showDropdown = false;
+			return;
+		}
+		searchDebounce = setTimeout(async () => {
+			if (searchQuery !== query) return;
+			const names = await fetchGemNames(query);
+			if (searchQuery !== query) return;
+			suggestions = names;
+			showDropdown = suggestions.length > 0;
+			highlightedIndex = suggestions.length === 1 ? 0 : -1;
+		}, 100);
+	}
+
+	async function selectGem(name: string) {
+		searchQuery = name;
+		suggestions = [];
+		showDropdown = false;
+		// Fetch across every market — the per-market filter below splits the
+		// result back out. The mode has to be passed: without it the server
+		// answers with normal-mode rows, which carry no `baseName`, so in
+		// Dedication mode every table matched nothing and search looked broken.
+		searchResults = await fetchBestPlays(
+			undefined, undefined, undefined, undefined, name,
+			isDedication ? 'dedication' : undefined,
+		);
+	}
+
+	function handleSearchKeydown(e: KeyboardEvent) {
+		if (e.key === 'ArrowDown' && showDropdown) {
+			e.preventDefault();
+			highlightedIndex = Math.min(highlightedIndex + 1, suggestions.length - 1);
+		} else if (e.key === 'ArrowUp' && showDropdown) {
+			e.preventDefault();
+			highlightedIndex = Math.max(highlightedIndex - 1, 0);
+		} else if (e.key === 'Enter' && highlightedIndex >= 0) {
+			e.preventDefault();
+			selectGem(suggestions[highlightedIndex]);
+		} else if (e.key === 'Escape') {
+			clearSearch();
+		}
+	}
+
+	// A search replaces the ranked rows as the source, but never the scoping: the
+	// per-market and per-color filters below apply to it exactly as they do to
+	// the ranked rows.
+	const playSource = $derived(searchResults ?? allPlays);
+
+	// Switching lab mode re-fetches under a different mode, so a result carried
+	// across would be from the wrong one.
+	$effect(() => {
+		isDedication;
+		untrack(() => { if (searchResults) clearSearch(); });
+	});
+
 	// Filter from already-loaded data — zero API calls.
 	function playsForVariant(variant: string): GemPlay[] {
-		let filtered = allPlays.filter(g => g.variant === variant);
+		let filtered = playSource.filter(g => g.variant === variant);
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
@@ -72,7 +171,7 @@
 		// both means a heading that has moved ahead of its rows shows an empty
 		// table rather than the previous market's numbers — the rows themselves
 		// are the only thing here that knows which market they describe.
-		let filtered = allPlays.filter(g => g.baseName === poolType && g.variant === variant);
+		let filtered = playSource.filter(g => g.baseName === poolType && g.variant === variant);
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
@@ -83,6 +182,32 @@
 <section class="section">
 	<div class="section-header">
 		<h2 class="section-title"><Tooltip text="<b>Gem Ranking by Variant</b><br><br>Gems sorted by price (default), ROI, or risk-adjusted ROI. Filter by color and toggle low-confidence gems.<br><br><b>Tiers</b> (computed per variant, dynamic boundaries):<br>&nbsp;&nbsp;<span style='color:#fbbf24'>TOP</span> = monopoly outliers (gap-detected from clean pool)<br>&nbsp;&nbsp;<span style='color:#fb923c'>HIGH</span> = premium cluster (within 30% of top gem)<br>&nbsp;&nbsp;<span style='color:#c084fc'>MID-HIGH</span> = worth farming (above 50% of HIGH boundary)<br>&nbsp;&nbsp;<span style='color:#94a3b8'>MID</span> = decent profit<br>&nbsp;&nbsp;<span style='color:#64748b'>LOW</span> = marginal ROI<br>&nbsp;&nbsp;<span style='color:#475569'>FLOOR</span> = below 8% of top-5 average (not worth farming)<br><br><b>Low confidence</b> toggle shows thin-market gems (listings &lt; 40% of median). These may be price manipulation or meta shifts — system can't tell which.<br><br><b>Sort modes</b>: Price (default), Raw ROI, Risk-Adj ROI, ROI%.">By Variant</Tooltip></h2>
+		<div class="search-wrapper">
+			<input
+				type="text"
+				class="search-input"
+				placeholder="Search gem..."
+				value={searchQuery}
+				oninput={(e) => handleSearchInput(e.currentTarget.value)}
+				onkeydown={handleSearchKeydown}
+				onfocus={() => { if (suggestions.length) showDropdown = true; }}
+				onblur={() => setTimeout(() => { showDropdown = false; }, 200)}
+			/>
+			{#if searchQuery}
+				<button class="search-clear" title="Clear search" onclick={clearSearch}>×</button>
+			{/if}
+			{#if showDropdown && suggestions.length > 0}
+				<div class="dropdown">
+					{#each suggestions as gem, i}
+						<button
+							class="dropdown-item"
+							class:highlighted={i === highlightedIndex}
+							onmousedown={() => selectGem(gem)}
+						>{gem}</button>
+					{/each}
+				</div>
+			{/if}
+		</div>
 		<div class="limit-select">
 			<span class="select-label">Show:</span>
 			<Select bind:value={itemLimit} options={LIMIT_OPTIONS} />
@@ -141,7 +266,9 @@
 		{@const tab = activeDedTabInfo}
 		{@const vd = playsForPool(tab.pool, tab.variant)}
 		{#if vd.length > 0}
-			<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool] || tab.pool}) — {tab.variant}" showVariantColumn={false} />
+			<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool] || tab.pool}) — {tab.variant}" showVariantColumn={false} searchActive={searchResults !== null} />
+		{:else if searchResults}
+			<div class="loading">No {searchQuery} in this pool</div>
 		{:else}
 			<div class="loading">No data for this pool</div>
 		{/if}
@@ -149,7 +276,9 @@
 		{#each visibleVariants as variant}
 			{@const vd = playsForVariant(variant)}
 			{#if vd.length > 0}
-				<BestPlays plays={vd} title="Best Plays ({variant})" showVariantColumn={false} />
+				<BestPlays plays={vd} title="Best Plays ({variant})" showVariantColumn={false} searchActive={searchResults !== null} />
+			{:else if searchResults}
+				<div class="loading">No {searchQuery} at {variant}</div>
 			{:else}
 				<div class="loading">No data for this variant</div>
 			{/if}
@@ -175,6 +304,67 @@
 		font-weight: 700;
 		color: var(--color-lab-text);
 		margin: 0;
+	}
+	.search-wrapper {
+		position: relative;
+		flex: 1;
+		max-width: 300px;
+	}
+	.search-input {
+		width: 100%;
+		background: var(--color-lab-bg);
+		border: 1px solid var(--color-lab-border);
+		color: var(--color-lab-text);
+		padding: 6px 12px;
+		font-size: 0.8125rem;
+		font-family: inherit;
+		box-sizing: border-box;
+		outline: none;
+	}
+	.search-input::placeholder {
+		color: var(--color-lab-text-secondary);
+	}
+	.dropdown {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+		background: var(--color-lab-surface);
+		border: 1px solid var(--color-lab-border);
+		border-top: none;
+		max-height: 200px;
+		overflow-y: auto;
+		z-index: 100;
+	}
+	.dropdown-item {
+		display: block;
+		width: 100%;
+		padding: 6px 12px;
+		text-align: left;
+		background: none;
+		border: none;
+		color: var(--color-lab-text);
+		font-size: 0.8125rem;
+		cursor: pointer;
+	}
+	.dropdown-item:hover, .dropdown-item.highlighted {
+		background: rgba(255, 255, 255, 0.08);
+	}
+	.search-clear {
+		position: absolute;
+		right: 6px;
+		top: 50%;
+		transform: translateY(-50%);
+		background: none;
+		border: none;
+		color: var(--color-lab-text-secondary);
+		font-size: 1rem;
+		line-height: 1;
+		padding: 0 4px;
+		cursor: pointer;
+	}
+	.search-clear:hover {
+		color: var(--color-lab-text);
 	}
 	.limit-select {
 		display: flex;

--- a/desktop/src/routes/(app)/components/Comparator.svelte
+++ b/desktop/src/routes/(app)/components/Comparator.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-	import { fetchGemNames, fetchCompare, DEDICATION_VARIANTS, type CompareGem } from '$lib/api';
+	import { fetchGemNames, fetchCompare, DEDICATION_VARIANTS, VARIANTS, type CompareGem } from '$lib/api';
 	import { baseGemName, baseGemTradeUrl } from '$lib/trade-utils';
 	import type { TradeLookupResult, TradeSignals, TradeQueueEvent, TradeQueueDisplay } from '$lib/tradeApi';
 	import { SIGNAL_TOOLTIPS } from '$lib/tooltips';
 	import { formatPrice, formatPriceSigned } from '$lib/price.svelte';
 	import { store } from '$lib/stores/status.svelte';
-	import { ssot } from '$lib/stores/ssot.svelte';
+	import { ssot, setNormalVariant, setDedicationSelection } from '$lib/stores/ssot.svelte';
 	import { listen } from '@tauri-apps/api/event';
 	import { invoke } from '@tauri-apps/api/core';
 	import SignalBadge from './SignalBadge.svelte';
 	import Sparkline from './Sparkline.svelte';
 	import GemIcon from './GemIcon.svelte';
-	import Select from '$lib/components/Select.svelte';
+	import SegmentedButtons from '$lib/components/SegmentedButtons.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 
 	const SIGNAL_COLORS: Record<string, string> = {
@@ -34,18 +34,10 @@
 		divineRate = 0,
 		onQueueGem,
 		labMode = 'normal',
-		dedicationVariant,
-		onDedicationVariantChange,
-		normalVariant,
-		onNormalVariantChange,
 	}: {
 		divineRate?: number;
 		onQueueGem?: (gem: string, variant: string, roi: number, tradeData: TradeLookupResult | null) => void;
 		labMode?: 'normal' | 'dedication';
-		dedicationVariant?: string;
-		onDedicationVariantChange?: (variant: string) => void;
-		normalVariant?: string;
-		onNormalVariantChange?: (variant: string) => void;
 	} = $props();
 
 	let isDedication = $derived(labMode === 'dedication');
@@ -110,30 +102,8 @@
 		}).catch(e => console.warn('[comparator] push to overlay failed:', e));
 	});
 
-	const NORMAL_VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
-	let activeVariants = $derived<readonly string[]>(isDedication ? DEDICATION_VARIANTS : NORMAL_VARIANTS);
+	let activeVariants = $derived<readonly string[]>(isDedication ? DEDICATION_VARIANTS : VARIANTS);
 	let VARIANT_OPTIONS = $derived(activeVariants.map((v) => ({ value: v, label: v })));
-
-	// The market is NOT the comparator's to own. It is what Rust stamps onto the
-	// uploaded font session and onto every OCR push to a paired web view, so a
-	// locally-held copy made the recorded run and the comparison disagree — a
-	// 21/23 session priced and trade-searched at 21/20. The owner supplies it per
-	// mode and receives changes back (handleVariantChange), so this picker, the
-	// header, the persisted setting and the web view cannot drift apart.
-	//
-	// Without the prop the comparator falls back to owning it, and then only
-	// corrects a market the current mode cannot show: snapping to a market no
-	// caller tracks would rubber-band the picker on every click.
-	let ownerVariant = $derived.by(() => {
-		const supplied = isDedication ? dedicationVariant : normalVariant;
-		if (supplied === undefined) return null; // no owner — see below
-		if (activeVariants.includes(supplied)) return supplied;
-		// Supplied but unusable. Self-owning silently would leave this picker
-		// working while Rust and the paired web view keep using the bad market,
-		// which is the drift this arrangement exists to remove.
-		console.warn('[comparator] owner supplied a market this mode cannot show:', supplied);
-		return null;
-	});
 
 	// Rows are fetched per market AND per mode (loadResults sends the mode), so
 	// the mode has to trigger a refetch in its own right. Keying only on the
@@ -141,11 +111,15 @@
 	// disjoint — one shared string and a mode flip would leave the previous
 	// mode's rows on screen, priced and unrefetched.
 	let loadedForMode: string | null = null;
+	let loadedForVariant: string | null = null;
 
+	// The market is NOT the comparator's to own — it is the ssot store's, and it
+	// is what Rust stamps onto the uploaded font session and onto every OCR push
+	// to a paired web view. This effect only reacts to the store's value; it
+	// never assigns it.
 	$effect(() => {
-		const target = ownerVariant ?? (activeVariants.includes(variant) ? variant : (isDedication ? DEDICATION_VARIANTS[0] : '20/20'));
-		if (variant === target && loadedForMode === labMode) return;
-		variant = target;
+		if (variant === loadedForVariant && labMode === loadedForMode) return;
+		loadedForVariant = variant;
 		loadedForMode = labMode;
 		dropTradeData();
 		loadResults();
@@ -260,7 +234,7 @@
 		};
 	});
 
-	let variant = $state('20/20');
+	const variant = $derived(isDedication ? ssot.dedicationVariant : ssot.normalVariant);
 	let searchQuery = $state('');
 	let suggestions = $state<string[]>([]);
 	let selectedGems = $state<string[]>([]);
@@ -474,15 +448,6 @@
 		tradeExpanded = {};
 	}
 
-	function handleVariantChange() {
-		// Push the pick up to the owner: the header, the persisted setting, the
-		// run upload and the paired web view all read it from there.
-		if (isDedication) onDedicationVariantChange?.(variant);
-		else onNormalVariantChange?.(variant);
-		dropTradeData();
-		loadResults();
-	}
-
 	function handleKeydown(e: KeyboardEvent) {
 		if (e.key === 'Escape') {
 			showDropdown = false;
@@ -623,7 +588,11 @@
 			</label></Tooltip>
 			<div class="variant-select">
 				<span class="select-label">Variant:</span>
-				<Select bind:value={variant} options={VARIANT_OPTIONS} onchange={() => handleVariantChange()} />
+				<SegmentedButtons
+					value={variant}
+					options={VARIANT_OPTIONS}
+					onselect={(v) => isDedication ? setDedicationSelection(v, ssot.dedicationPool) : setNormalVariant(v)}
+				/>
 			</div>
 		</div>
 	</div>

--- a/desktop/src/routes/(app)/components/FontEVCompare.svelte
+++ b/desktop/src/routes/(app)/components/FontEVCompare.svelte
@@ -35,7 +35,7 @@
 	const isDedication = $derived(labMode === 'dedication');
 
 	const DEDICATION_ROWS = DEDICATION_VARIANTS.flatMap((variant) => [
-		{ variant, poolKey: 'skills' as const, label: `${variant} Skill Gems` },
+		{ variant, poolKey: 'skills' as const, label: `${variant} Non-Transfigured` },
 		{ variant, poolKey: 'transfigured' as const, label: `${variant} Transfigured` },
 	]);
 
@@ -320,7 +320,7 @@
 		<table class="ft ded">
 			<thead>
 				<tr>
-					<th class="var-header">Dedication EV<InfoTooltip text="<b>Dedication Lab — Corrupted Gem Exchange EV</b><br><br>Two font options per run, each at either corrupted variant:<br>• <b>Skill Gems</b>: Non-transfigured corrupted skill gems<br>• <b>Transfigured</b>: Transfigured corrupted skill gems<br><br><b>Nc/font</b>: Expected income per font usage. Based on best-of-3 random draws from the corrupted pool of that color.<br><br><b>Input cost</b>: Average price of the 10 cheapest corrupted gems of that variant in that color pool — this is what you feed into the font.<br><br><b>Profit</b>: EV minus input cost. Entry fee (Dedication offering) is NOT included.<br><br>21/23 and 21/20 are separate markets: pool, tiers and input cost are computed per variant, and the highlighted cell is the best <b>profit</b> across both.<br><br>Thin liquidity is expected for corrupted gems — fewer listings than normal font pools." /></th>
+					<th class="var-header">Dedication EV<InfoTooltip text="<b>Dedication Lab — Corrupted Gem Exchange EV</b><br><br>Two font options per run, each at either corrupted variant:<br>• <b>Non-Transfigured</b>: Corrupted skill gems that are not transfigured<br>• <b>Transfigured</b>: Transfigured corrupted skill gems<br><br><b>Nc/font</b>: Expected income per font usage. Based on best-of-3 random draws from the corrupted pool of that color.<br><br><b>Input cost</b>: Average price of the 10 cheapest corrupted gems of that variant in that color pool — this is what you feed into the font.<br><br><b>Profit</b>: EV minus input cost. Entry fee (Dedication offering) is NOT included.<br><br>21/23 and 21/20 are separate markets: pool, tiers and input cost are computed per variant, and the highlighted cell is the best <b>profit</b> across both.<br><br>Thin liquidity is expected for corrupted gems — fewer listings than normal font pools." /></th>
 					{#each COLORS as color}
 						<th><span class="c-{color.toLowerCase()}">{'\u25CF'} {color}</span></th>
 					{/each}

--- a/desktop/src/routes/(app)/components/FontEVCompare.svelte
+++ b/desktop/src/routes/(app)/components/FontEVCompare.svelte
@@ -1,16 +1,25 @@
 <script lang="ts">
-	import { fetchFontEV, fetchDedicationEV, DEDICATION_VARIANTS, type FontEVResponse, type FontColor, type DedicationEVResponse, type DedicationColor } from '$lib/api';
+	import { fetchFontEV, fetchDedicationEV, DEDICATION_VARIANTS, VARIANTS, type FontEVResponse, type FontColor, type DedicationEVResponse, type DedicationColor } from '$lib/api';
 	import { baseGemTradeUrl, cheapestCorruptedTradeUrl } from '$lib/trade-utils';
 	import { formatPrice, formatPriceSigned, type PriceUnit } from '$lib/price.svelte';
-	import { ssot } from '$lib/stores/ssot.svelte';
-	import Select from '$lib/components/Select.svelte';
+	import { ssot, setNormalVariant, setDedicationSelection } from '$lib/stores/ssot.svelte';
+	import SegmentedButtons from '$lib/components/SegmentedButtons.svelte';
 	import Tooltip from '$lib/components/Tooltip.svelte';
 	import InfoTooltip from './InfoTooltip.svelte';
 
 	let { refreshKey = 0, labMode = 'normal' }: { refreshKey?: number; labMode?: 'normal' | 'dedication' } = $props();
 
-	const VARIANTS = ['1/0', '1/20', '20/0', '20/20'];
 	const COLORS = ['RED', 'GREEN', 'BLUE'] as const;
+
+	// Rust, settings and the database spell the dedication pool `skill`; the JSON
+	// API — and therefore this component's data maps — spell it `skills`.
+	// Renaming the wire key is out of scope: the web frontend shares it.
+	function toWirePool(pool: string): 'skills' | 'transfigured' {
+		return pool === 'transfigured' ? 'transfigured' : 'skills';
+	}
+	function toStorePool(wire: string): string {
+		return wire === 'transfigured' ? 'transfigured' : 'skill';
+	}
 
 	// --- Normal (Font) mode state ---
 	let data = $state<Record<string, FontEVResponse>>({});
@@ -270,12 +279,12 @@
 	}
 
 	let showPool = $state(true);
-	let poolVariant = $state('20/20');
-	// One selector over the four (market, pool) combinations — "21/23:skills".
-	let dedPoolSel = $state(`${DEDICATION_ROWS[0].variant}:${DEDICATION_ROWS[0].poolKey}`);
-	const dedPool = $derived.by(() => {
-		const [variant, poolKey] = dedPoolSel.split(':');
-		return { variant, poolKey: poolKey as 'skills' | 'transfigured' };
+	// Both Pool Overviews show the shared farming selection — the market Rust
+	// stamps onto recorded runs — not a local pick.
+	const poolVariant = $derived(ssot.normalVariant);
+	const dedPool = $derived({
+		variant: ssot.dedicationVariant,
+		poolKey: toWirePool(ssot.dedicationPool),
 	});
 
 	function getPoolBreakdown(variant: string, color: string): { tier: string; count: number; minPrice: number; maxPrice: number }[] {
@@ -399,7 +408,14 @@
 			<div class="pool-section">
 				<div class="pool-variant-select">
 					<span class="pool-select-label">Pool:</span>
-					<Select bind:value={dedPoolSel} options={DEDICATION_ROWS.map(r => ({ value: `${r.variant}:${r.poolKey}`, label: r.label }))} />
+					<SegmentedButtons
+						value={`${ssot.dedicationVariant}:${toWirePool(ssot.dedicationPool)}`}
+						options={DEDICATION_ROWS.map(r => ({ value: `${r.variant}:${r.poolKey}`, label: r.label }))}
+						onselect={(key) => {
+							const [variant, poolKey] = key.split(':');
+							setDedicationSelection(variant, toStorePool(poolKey));
+						}}
+					/>
 				</div>
 				<div class="pool-grid">
 					{#each COLORS as color}
@@ -548,7 +564,11 @@
 			<div class="pool-section">
 				<div class="pool-variant-select">
 					<span class="pool-select-label">Variant:</span>
-					<Select bind:value={poolVariant} options={VARIANTS.map(v => ({ value: v, label: v }))} />
+					<SegmentedButtons
+						value={poolVariant}
+						options={VARIANTS.map(v => ({ value: v, label: v }))}
+						onselect={(variant) => setNormalVariant(variant)}
+					/>
 				</div>
 				<div class="pool-grid">
 					{#each COLORS as color}

--- a/desktop/src/routes/(app)/components/FontEVCompare.svelte
+++ b/desktop/src/routes/(app)/components/FontEVCompare.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fetchFontEV, fetchDedicationEV, DEDICATION_VARIANTS, VARIANTS, type FontEVResponse, type FontColor, type DedicationEVResponse, type DedicationColor } from '$lib/api';
+	import { fetchFontEV, fetchDedicationEV, DEDICATION_VARIANTS, DEDICATION_POOL_LABELS, type DedicationPool, VARIANTS, type FontEVResponse, type FontColor, type DedicationEVResponse, type DedicationColor } from '$lib/api';
 	import { baseGemTradeUrl, cheapestCorruptedTradeUrl } from '$lib/trade-utils';
 	import { formatPrice, formatPriceSigned, type PriceUnit } from '$lib/price.svelte';
 	import { ssot, setNormalVariant, setDedicationSelection } from '$lib/stores/ssot.svelte';
@@ -17,7 +17,7 @@
 	function toWirePool(pool: string): 'skills' | 'transfigured' {
 		return pool === 'transfigured' ? 'transfigured' : 'skills';
 	}
-	function toStorePool(wire: string): string {
+	function toStorePool(wire: string): DedicationPool {
 		return wire === 'transfigured' ? 'transfigured' : 'skill';
 	}
 
@@ -35,8 +35,10 @@
 	const isDedication = $derived(labMode === 'dedication');
 
 	const DEDICATION_ROWS = DEDICATION_VARIANTS.flatMap((variant) => [
-		{ variant, poolKey: 'skills' as const, label: `${variant} Non-Transfigured` },
-		{ variant, poolKey: 'transfigured' as const, label: `${variant} Transfigured` },
+		// Labels come from DEDICATION_POOL_LABELS via toStorePool, so a rename lands
+		// here too instead of leaving this file behind as a third home for them.
+		{ variant, poolKey: 'skills' as const, label: `${variant} ${DEDICATION_POOL_LABELS[toStorePool('skills')]}` },
+		{ variant, poolKey: 'transfigured' as const, label: `${variant} ${DEDICATION_POOL_LABELS[toStorePool('transfigured')]}` },
 	]);
 
 	// Entry fee is a property of the Dedication offering, not of a gem market —

--- a/desktop/src/routes/(app)/components/FontEVCompare.svelte
+++ b/desktop/src/routes/(app)/components/FontEVCompare.svelte
@@ -409,7 +409,7 @@
 				<div class="pool-variant-select">
 					<span class="pool-select-label">Pool:</span>
 					<SegmentedButtons
-						value={`${ssot.dedicationVariant}:${toWirePool(ssot.dedicationPool)}`}
+						value={`${dedPool.variant}:${dedPool.poolKey}`}
 						options={DEDICATION_ROWS.map(r => ({ value: `${r.variant}:${r.poolKey}`, label: r.label }))}
 						onselect={(key) => {
 							const [variant, poolKey] = key.split(':');

--- a/desktop/src/routes/overlay/timer/+page.svelte
+++ b/desktop/src/routes/overlay/timer/+page.svelte
@@ -17,7 +17,9 @@
 		resetTimer as timerReset_fn,
 	} from '$lib/compass/timer';
 
-	// --- Navigation state (needed for room tracking, golden door detection, and route info) ---
+	// --- Navigation state (needed to know when we're in the lab and which room) ---
+	// Display only: run measurement and submission live in $lib/run-recorder.ts,
+	// which runs in the main window regardless of this overlay's toggle.
 	let navState = $state(createNavState());
 	let lockedDifficulty = $state<string | null>(null);
 	let layoutLoaded = $state(false);
@@ -42,71 +44,12 @@
 	let textStroke = $state(true);
 	let bgStyle = $derived(`rgba(13, 13, 21, ${bgOpacity})`);
 
-	// --- Room tracking for run submission ---
-	let roomLog = $state<{ room_name: string; entered_at: string; room_number: number }[]>([]);
-	let roomCounter = 0;
-	let killTime = $state(0); // Izaro death time — snapshotted on LabFinished
-
 	function startTimer() { timer = timerStart_fn(timer, (e) => { elapsed = e; }); }
 	function stopTimer() { timer = timerStop_fn(timer); }
-	function resetTimer() { timer = timerReset_fn(timer); elapsed = 0; roomLog = []; roomCounter = 0; killTime = 0; }
+	function resetTimer() { timer = timerReset_fn(timer); elapsed = 0; }
 
 	function logToApp(msg: string) {
 		invoke('app_log_from_frontend', { msg }).catch((e) => console.warn('[timer] logToApp IPC failed:', msg, e));
-	}
-
-	// --- Submit completed run to server ---
-	// Called on LabExited with the full run data. Kill time was snapshotted
-	// on LabFinished; total elapsed is the time from first room to lab exit.
-	async function submitRun() {
-		const totalElapsed = elapsed;
-		const snapshotRooms = [...roomLog];
-		const snapshotKillTime = killTime;
-		const snapshotStartedAt = timer.startTimestamp;
-		if (snapshotKillTime <= 0 || snapshotRooms.length === 0) return;
-		try {
-			const status = await invoke<any>('get_status');
-			const serverUrl = status?.server_url;
-			if (!serverUrl) { logToApp('[timer] no server_url, cannot submit run'); return; }
-
-			const settings = await invoke<any>('get_compass_settings').catch(() => null);
-			const visitedRoomNames = new Set(snapshotRooms.map(r => r.room_name.toLowerCase()));
-			const hasGoldenDoor = navState.lockedDoors.length > 0 ||
-				Array.from(navState.roomById.values())
-					.filter(r => visitedRoomNames.has(r.name.toLowerCase()))
-					.some(r => r.contents.some(c => c.toLowerCase().includes('golden-door')));
-
-			const body = {
-				difficulty: settings?.difficulty ?? lockedDifficulty ?? 'Uber',
-				strategy: settings?.strategy ?? navState.strategy,
-				elapsed_seconds: totalElapsed,
-				kill_seconds: snapshotKillTime,
-				room_count: snapshotRooms.length,
-				has_golden_door: hasGoldenDoor,
-				started_at: snapshotStartedAt ? new Date(snapshotStartedAt).toISOString() : new Date().toISOString(),
-				rooms: snapshotRooms,
-			};
-
-			const res = await fetch(`${serverUrl}/api/lab/runs`, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					'X-Device-ID': status?.device_id ?? '',
-					'X-App-Version': status?.app_version ?? '',
-				},
-				body: JSON.stringify(body),
-			});
-
-			if (res.ok) {
-				const data = await res.json();
-				logToApp(`[timer] run submitted: id=${data.run_id}, kill=${snapshotKillTime}s, total=${totalElapsed}s`);
-			} else {
-				const errBody = await res.text().catch(() => '');
-				logToApp(`[timer] submit failed: ${res.status} ${errBody}`);
-			}
-		} catch (e) {
-			logToApp(`[timer] submit error: ${e}`);
-		}
 	}
 
 	// --- Event handling ---
@@ -130,26 +73,17 @@
 				if (navState.inLab && timer.startTimestamp === null) {
 					startTimer();
 				}
-				// Log room for submission
-				roomCounter++;
-				roomLog = [...roomLog, {
-					room_name: event.name,
-					entered_at: new Date().toISOString(),
-					room_number: roomCounter,
-				}];
 				// Hide during Izaro fights
 				const room = navState.currentRoom ? navState.roomById.get(navState.currentRoom) : null;
 				hidden = room?.name.toLowerCase() === "aspirant's trial";
 				break;
 			}
 			case 'LabFinished':
-				// Snapshot Izaro death time — timer keeps running through looting
-				killTime = elapsed;
+				// Timer keeps running through looting
 				hidden = false;
 				break;
 			case 'LabExited':
 				stopTimer();
-				submitRun();
 				resetTimer();
 				hidden = true;
 				if (pendingLayoutReset) {

--- a/desktop/vite.config.ts
+++ b/desktop/vite.config.ts
@@ -19,7 +19,23 @@ export default defineConfig({
 				}
 			: undefined,
 		watch: {
-			ignored: ['**/src-tauri/**']
+			ignored: ['**/src-tauri/**'],
+			// The dev tree is written by `make desktop-watch`, which rsyncs from WSL
+			// into a Windows directory. Observed 2026-08-08: an edit landed in the
+			// Windows tree but Vite never rebuilt, so HMR kept serving a module
+			// compiled from the previous version — the running app threw
+			// `searchQuery is not defined` from code that no longer existed on disk,
+			// which reads as an application bug rather than a stale build.
+			//
+			// Native filesystem events do not cross the WSL→/mnt/c boundary
+			// reliably, and rsync's write-temp-then-rename makes it worse. Polling
+			// is the only watch mode that sees those writes.
+			//
+			// Accepted trade-off: a poll every 400ms costs idle CPU that native
+			// events would not. That is worth less than one debugging session spent
+			// on a file that was already correct.
+			usePolling: true,
+			interval: 400
 		}
 	}
 });

--- a/docs/adr/001-go-module-path-short-local-identifier.md
+++ b/docs/adr/001-go-module-path-short-local-identifier.md
@@ -1,3 +1,7 @@
+---
+uid: 2c9b0507-f2f3-4a0f-be2c-432d1ec74c4a
+---
+
 # ADR-001: Go Module Path: Short Local Identifier
 
 ## Status

--- a/docs/adr/002-internal-architecture-hexagonal-cqrs-vertical-slice.md
+++ b/docs/adr/002-internal-architecture-hexagonal-cqrs-vertical-slice.md
@@ -1,3 +1,7 @@
+---
+uid: c62e3757-3699-439d-ad95-36930c1b19fd
+---
+
 # ADR-002: Internal Architecture: Hexagonal + CQRS + Vertical Slice
 
 ## Status

--- a/docs/adr/003-no-orm-direct-pgx-queries.md
+++ b/docs/adr/003-no-orm-direct-pgx-queries.md
@@ -1,3 +1,7 @@
+---
+uid: 53495e24-6c45-41f9-84ed-40f065777ac8
+---
+
 # ADR-003: No ORM — Direct pgx Queries
 
 ## Status

--- a/docs/adr/004-database-migration-strategy-auto-migrate-on-start-with-golang-migrate.md
+++ b/docs/adr/004-database-migration-strategy-auto-migrate-on-start-with-golang-migrate.md
@@ -1,3 +1,7 @@
+---
+uid: 55dea7ab-ff6d-4869-964f-eeb0d123e206
+---
+
 # ADR-004: Database Migration Strategy — Auto-Migrate on Start with golang-migrate
 
 ## Status

--- a/docs/adr/006-gem-colors-database-backed-upsert-lookup-table-with-in-memory-resolver.md
+++ b/docs/adr/006-gem-colors-database-backed-upsert-lookup-table-with-in-memory-resolver.md
@@ -1,3 +1,7 @@
+---
+uid: cbd946d2-34a3-4258-a21d-1ec536493960
+---
+
 # ADR-006: gem_colors — Database-Backed UPSERT Lookup Table with In-Memory Resolver
 
 ## Status

--- a/docs/adr/007-v3-hybrid-analysis-unified-pipeline-with-trade-enriched-features.md
+++ b/docs/adr/007-v3-hybrid-analysis-unified-pipeline-with-trade-enriched-features.md
@@ -1,3 +1,7 @@
+---
+uid: 84f28ce3-dcf5-48c5-9efb-4f56a4f9df30
+---
+
 # ADR-007: v3 Hybrid Analysis — Unified Pipeline with Trade-Enriched Features
 
 ## Status

--- a/docs/adr/008-current-go-package-architecture.md
+++ b/docs/adr/008-current-go-package-architecture.md
@@ -1,3 +1,7 @@
+---
+uid: 723f68df-5208-4743-ae8f-e6de4013e7ff
+---
+
 # ADR-008: Current Go Package Architecture
 
 ## Status

--- a/docs/adr/009-league-scoped-repository-convention.md
+++ b/docs/adr/009-league-scoped-repository-convention.md
@@ -1,3 +1,7 @@
+---
+uid: 8e39f612-f8e4-4aeb-b33a-702359ebbcf3
+---
+
 # ADR-009: League-Scoped Repository Convention
 
 ## Status

--- a/docs/adr/010-archived-league-history-is-retained-indefinitely.md
+++ b/docs/adr/010-archived-league-history-is-retained-indefinitely.md
@@ -1,3 +1,7 @@
+---
+uid: 0e463a23-26d2-4052-bbe2-9fee9995d8d6
+---
+
 # ADR-010: Archived League History Is Retained Indefinitely
 
 ## Status

--- a/docs/adr/011-wipe-the-outgoing-league-at-rollover-preserve-it-as-a-dump.md
+++ b/docs/adr/011-wipe-the-outgoing-league-at-rollover-preserve-it-as-a-dump.md
@@ -1,3 +1,7 @@
+---
+uid: b6757498-fa1b-4213-939c-cd41c22fb626
+---
+
 # ADR-011: Wipe the Outgoing League at Rollover; Preserve It as a Dump
 
 ## Status

--- a/docs/adr/012-icons-are-pre-seeded-from-an-allowed-ip-and-cached-by-content-address.md
+++ b/docs/adr/012-icons-are-pre-seeded-from-an-allowed-ip-and-cached-by-content-address.md
@@ -1,3 +1,7 @@
+---
+uid: 5daeb06f-ad96-499d-a640-f66bac72b04c
+---
+
 # ADR-012: Icons Are Pre-Seeded from an Allowed IP and Cached by Content Address
 
 ## Status

--- a/docs/adr/013-ui-picks-persist-in-a-schema-less-prefs-map.md
+++ b/docs/adr/013-ui-picks-persist-in-a-schema-less-prefs-map.md
@@ -1,0 +1,60 @@
+# ADR-013: UI Picks Persist in a Schema-less Prefs Map
+
+## Status
+
+Accepted
+
+## Context
+
+Every select the user can set — rankings sort mode, colour filter, row limit,
+budget, the ALL-tab view, the Runs difficulty filter — should be set the same
+way on the next launch. Before this decision, each persisted pick grew its own
+plumbing: `show_low_confidence` has a typed Rust settings field, an AppState
+mutex, and a dedicated get/set command pair; the web app used an ad-hoc
+localStorage key for the same toggle. Most picks had no persistence at all,
+and adding it per-pick at that cost meant it kept not happening.
+
+Two kinds of persisted values were being conflated:
+
+1. **Values Rust itself reads** — the market stamped onto uploaded font
+   sessions, the lab mode, overlay geometry. These need typed fields: Rust
+   logic branches on them, so a typo must fail at compile time.
+2. **View preferences only the frontend reads** — sort mode, filters, limits.
+   Rust never branches on them; it is purely a persistence host.
+
+## Decision
+
+View preferences persist through a single schema-less map:
+
+- **Desktop**: `ui_prefs: HashMap<String, String>` inside the Rust settings
+  file, exposed by exactly two commands — `get_ui_prefs` (whole map, fetched
+  once) and `set_ui_pref` (write-through). Rust stores the map blindly; the
+  frontend owns the keys.
+- **Web**: the same interface backed by localStorage (`poe-pref-` prefix).
+- Both apps consume it through a `persisted(key, initial)` helper in
+  `$lib/prefs.svelte.ts` that returns a reactive `{ value }` usable directly
+  in `bind:value`.
+
+The boundary rule: **a typed `Settings` field is added only when Rust itself
+reads the value.** Everything else goes in the map. Transient inputs (the gem
+search query) persist nowhere.
+
+Key naming: camelCase, surface-prefixed — `rankingsSort`, `rankingsColor`,
+`rankingsLimit`, `rankingsBudget`, `rankingsTabView`, `runsDifficulty`.
+
+## Consequences
+
+- Adding a persisted pick is one `persisted()` call — no Rust change, no new
+  command, no settings-struct edit.
+- The map is schema-less by design: values are strings, and consumers must
+  validate on read (the sort pref narrows through a whitelist with a fallback
+  default). A stale or garbage value degrades to the default, never crashes.
+- Desktop and web do not share storage; the same key can hold different values
+  per app. Accepted — they are different installs with different habits.
+- `show_low_confidence` predates this decision and keeps its typed field; the
+  migration is not worth the settings-file churn. New view-only picks must not
+  follow its pattern.
+- The desktop map loads asynchronously after mount, so components start on
+  defaults and snap to the stored value when the load lands (the same
+  start-default-then-overwrite pattern the low-confidence toggle established).
+  A pick changed before the load resolves wins over the loaded value.

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -151,6 +151,28 @@ export interface DedicationEVResponse {
  * that is the cheaper input and the more common play.
  */
 export const DEDICATION_VARIANTS = ['21/20', '21/23'] as const;
+
+/**
+ * The two Dedication gem pools, in the canon spelling — the one the server,
+ * settings and the database use. The Font EV JSON wire format spells the first
+ * one `skills`; that boundary is translated at the component that reads it
+ * rather than renamed here.
+ */
+export const DEDICATION_POOLS = ['skill', 'transfigured'] as const;
+export type DedicationPool = typeof DEDICATION_POOLS[number];
+
+/**
+ * Display labels for the pools. Every surface that names a pool reads them from
+ * here — they were previously written out at each call site, so renaming one
+ * label meant finding six of them.
+ *
+ * "Non-Transfigured" rather than "Normal": the desktop top bar already labels
+ * the lab mode Normal, and the two would name different things.
+ */
+export const DEDICATION_POOL_LABELS: Record<DedicationPool, string> = {
+	skill: 'Non-Transfigured',
+	transfigured: 'Transfigured',
+};
 export type DedicationVariant = typeof DEDICATION_VARIANTS[number];
 
 export interface MarketOverviewData {

--- a/frontend/src/lib/prefs.svelte.ts
+++ b/frontend/src/lib/prefs.svelte.ts
@@ -1,0 +1,31 @@
+/**
+ * Persisted UI picks — sort mode, colour filter, row limit, and every other
+ * select the user can set and expects to find set on the next visit.
+ *
+ * Web counterpart of the desktop `ui_prefs` map (see docs/adr/013): same
+ * interface, backed by localStorage since there is no Rust side here. The
+ * frontend owns the keys. Search-style transient inputs stay out of this.
+ */
+
+const PREFIX = 'poe-pref-';
+
+export interface PersistedString {
+	value: string;
+}
+
+/**
+ * A string preference that survives page reloads. Bind it like state:
+ * `bind:value={pref.value}` — writes go through to localStorage, reads are
+ * reactive. localStorage is synchronous, so there is no load race.
+ */
+export function persisted(key: string, initial: string): PersistedString {
+	const stored = typeof localStorage === 'undefined' ? null : localStorage.getItem(PREFIX + key);
+	let value = $state(stored ?? initial);
+	return {
+		get value() { return value; },
+		set value(v: string) {
+			value = v;
+			try { localStorage.setItem(PREFIX + key, v); } catch { /* private mode */ }
+		},
+	};
+}

--- a/frontend/src/routes/lab/+page.svelte
+++ b/frontend/src/routes/lab/+page.svelte
@@ -20,7 +20,6 @@
 	import Comparator from './components/Comparator.svelte';
 	import SessionQueue from './components/SessionQueue.svelte';
 	import type { QueueItem } from './components/SessionQueue.svelte';
-	import BestPlays from './components/BestPlays.svelte';
 	import ByVariant from './components/ByVariant.svelte';
 	import MarketOverview from './components/MarketOverview.svelte';
 	import Legend from './components/Legend.svelte';

--- a/frontend/src/routes/lab/components/BestPlays.svelte
+++ b/frontend/src/routes/lab/components/BestPlays.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fetchSignalHistory, fetchGemNames, fetchBestPlays, type GemPlay, type SignalTransition } from '$lib/api';
+	import { fetchSignalHistory, type GemPlay, type SignalTransition } from '$lib/api';
 	import { baseGemName, baseGemTradeUrl } from '$lib/trade-utils';
 	import { formatPrice } from '$lib/price.svelte';
 	import { METRIC_TOOLTIPS } from '$lib/tooltips';
@@ -21,76 +21,17 @@
 		title = 'Best Plays Now (ALL variants)',
 		showVariantColumn = true,
 		league = '',
+		searchActive = false,
 	}: {
 		plays: GemPlay[];
 		title?: string;
 		showVariantColumn?: boolean;
 		league?: string;
+		searchActive?: boolean;
 	} = $props();
 
 	let sortBy = $state<'price' | 'riskAdjusted' | 'roi' | 'roiPercent'>('price');
 	let budget = $state('');
-	let searchQuery = $state('');
-	let searchFilter = $state('');
-	let suggestions = $state<string[]>([]);
-	let showDropdown = $state(false);
-	let highlightedIndex = $state(-1);
-	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
-
-	function handleSearchInput(query: string) {
-		searchQuery = query;
-		if (searchDebounce) clearTimeout(searchDebounce);
-		if (!query.trim()) {
-			searchFilter = '';
-			searchResults = null;
-			suggestions = [];
-			showDropdown = false;
-			return;
-		}
-		if (query.length < 2) {
-			suggestions = [];
-			showDropdown = false;
-			return;
-		}
-		searchDebounce = setTimeout(async () => {
-			if (searchQuery !== query) return;
-			const names = await fetchGemNames(query);
-			if (searchQuery !== query) return;
-			suggestions = names;
-			showDropdown = suggestions.length > 0;
-			highlightedIndex = suggestions.length === 1 ? 0 : -1;
-		}, 100);
-	}
-
-	let searchResults = $state<GemPlay[] | null>(null);
-
-	async function selectGem(name: string) {
-		searchQuery = name;
-		searchFilter = name;
-		suggestions = [];
-		showDropdown = false;
-		// Fetch this gem's data from the server (it may not be in the top-N loaded list).
-		const results = await fetchBestPlays(undefined, undefined, undefined, undefined, name);
-		searchResults = results;
-	}
-
-	function handleSearchKeydown(e: KeyboardEvent) {
-		if (e.key === 'ArrowDown' && showDropdown) {
-			e.preventDefault();
-			highlightedIndex = Math.min(highlightedIndex + 1, suggestions.length - 1);
-		} else if (e.key === 'ArrowUp' && showDropdown) {
-			e.preventDefault();
-			highlightedIndex = Math.max(highlightedIndex - 1, 0);
-		} else if (e.key === 'Enter' && highlightedIndex >= 0) {
-			e.preventDefault();
-			selectGem(suggestions[highlightedIndex]);
-		} else if (e.key === 'Escape') {
-			showDropdown = false;
-			searchQuery = '';
-			searchFilter = '';
-			searchResults = null;
-		}
-	}
 	// Default ON. At 20-level variants a thin transfigured market is normal, not
 	// anomalous, so the flag covers most of the pool there — a default that hid it
 	// would reproduce the ranking gap this toggle exists to make visible (POE-131).
@@ -105,9 +46,8 @@
 	let historyLoading = $state(false);
 
 	let sorted = $derived.by(() => {
-		// When search is active, use server-fetched results instead of local data.
-		let filtered = searchResults ? [...searchResults] : [...plays];
-		if (!showLowConf && !searchResults) {
+		let filtered = [...plays];
+		if (!showLowConf && !searchActive) {
 			filtered = filtered.filter((p) => !p.lowConfidence);
 		}
 		const b = parseInt(budget);
@@ -160,29 +100,6 @@
 
 <div class="plays-header">
 	<h3 class="plays-title">{title}</h3>
-	<div class="search-wrapper">
-		<input
-			type="text"
-			class="search-input"
-			placeholder="Search gem..."
-			value={searchQuery}
-			oninput={(e) => handleSearchInput(e.currentTarget.value)}
-			onkeydown={handleSearchKeydown}
-			onfocus={() => { if (suggestions.length) showDropdown = true; }}
-			onblur={() => setTimeout(() => { showDropdown = false; }, 200)}
-		/>
-		{#if showDropdown && suggestions.length > 0}
-			<div class="dropdown">
-				{#each suggestions as gem, i}
-					<button
-						class="dropdown-item"
-						class:highlighted={i === highlightedIndex}
-						onmousedown={() => selectGem(gem)}
-					>{gem}</button>
-				{/each}
-			</div>
-		{/if}
-	</div>
 	<div class="plays-controls">
 		<label class="control-label">
 			Budget:
@@ -345,51 +262,6 @@
 		font-weight: 700;
 		color: var(--color-lab-text);
 		margin: 0;
-	}
-	.search-wrapper {
-		position: relative;
-		flex: 1;
-		max-width: 300px;
-	}
-	.search-input {
-		width: 100%;
-		background: var(--color-lab-bg);
-		border: 1px solid var(--color-lab-border);
-		color: var(--color-lab-text);
-		padding: 6px 12px;
-		font-size: 0.8125rem;
-		font-family: inherit;
-		box-sizing: border-box;
-		outline: none;
-	}
-	.search-input::placeholder {
-		color: var(--color-lab-text-secondary);
-	}
-	.dropdown {
-		position: absolute;
-		top: 100%;
-		left: 0;
-		right: 0;
-		background: var(--color-lab-surface);
-		border: 1px solid var(--color-lab-border);
-		border-top: none;
-		max-height: 200px;
-		overflow-y: auto;
-		z-index: 100;
-	}
-	.dropdown-item {
-		display: block;
-		width: 100%;
-		padding: 6px 12px;
-		text-align: left;
-		background: none;
-		border: none;
-		color: var(--color-lab-text);
-		font-size: 0.8125rem;
-		cursor: pointer;
-	}
-	.dropdown-item:hover, .dropdown-item.highlighted {
-		background: rgba(255, 255, 255, 0.08);
 	}
 	.plays-controls {
 		display: flex;

--- a/frontend/src/routes/lab/components/BestPlays.svelte
+++ b/frontend/src/routes/lab/components/BestPlays.svelte
@@ -31,7 +31,6 @@
 	} = $props();
 
 	let sortBy = $state<'price' | 'riskAdjusted' | 'roi' | 'roiPercent'>('price');
-	let budget = $state('');
 	// Default ON. At 20-level variants a thin transfigured market is normal, not
 	// anomalous, so the flag covers most of the pool there — a default that hid it
 	// would reproduce the ranking gap this toggle exists to make visible (POE-131).
@@ -49,13 +48,6 @@
 		let filtered = [...plays];
 		if (!showLowConf && !searchActive) {
 			filtered = filtered.filter((p) => !p.lowConfidence);
-		}
-		const b = parseInt(budget);
-		if (b > 0) {
-			// NO_BASE gems have no known cost basis (basePrice 0 means unknown, not
-			// free), so they can't be shown to fit a budget — same rule as the server.
-			filtered = filtered.filter((p) => p.confidence !== 'NO_BASE' && p.basePrice <= b);
-			if (b <= 50) sortBy = 'roiPercent';
 		}
 		if (sortBy === 'price') {
 			return filtered.sort((a, b) => b.transPrice - a.transPrice);
@@ -101,15 +93,6 @@
 <div class="plays-header">
 	<h3 class="plays-title">{title}</h3>
 	<div class="plays-controls">
-		<label class="control-label">
-			Budget:
-			<input
-				type="text"
-				class="budget-input"
-				placeholder="unlimited"
-				bind:value={budget}
-			/>
-		</label>
 		<label class="control-label">
 			Sort:
 			<Select bind:value={sortBy} options={SORT_OPTIONS} />
@@ -274,18 +257,6 @@
 		display: flex;
 		align-items: center;
 		gap: 6px;
-	}
-	.budget-input {
-		width: 90px;
-		background: var(--color-lab-bg);
-		border: 1px solid var(--color-lab-border);
-		color: var(--color-lab-text);
-		padding: 5px 10px;
-		font-size: 0.875rem;
-		font-family: inherit;
-	}
-	.budget-input::placeholder {
-		color: var(--color-lab-text-secondary);
 	}
 	.table-scroll {
 		max-height: 590px;

--- a/frontend/src/routes/lab/components/BestPlays.svelte
+++ b/frontend/src/routes/lab/components/BestPlays.svelte
@@ -8,6 +8,7 @@
 	import GemIcon from './GemIcon.svelte';
 	import InfoTooltip from './InfoTooltip.svelte';
 	import Select from '$lib/components/Select.svelte';
+	import { persisted } from '$lib/prefs.svelte';
 
 	const SORT_OPTIONS = [
 		{ value: 'price', label: 'Price' },
@@ -35,7 +36,12 @@
 		rowCap?: number;
 	} = $props();
 
-	let sortBy = $state<'price' | 'riskAdjusted' | 'roi' | 'roiPercent'>('price');
+	// Persisted (ADR-013): the chosen sort survives reloads, and one key means
+	// every rankings table sorts the same way.
+	const sortPref = persisted('rankingsSort', 'price');
+	const sortBy = $derived(
+		(['price', 'riskAdjusted', 'roi', 'roiPercent'] as const).find(s => s === sortPref.value) ?? 'price'
+	);
 	// Default ON. At 20-level variants a thin transfigured market is normal, not
 	// anomalous, so the flag covers most of the pool there — a default that hid it
 	// would reproduce the ranking gap this toggle exists to make visible (POE-131).
@@ -102,7 +108,7 @@
 	<div class="plays-controls">
 		<label class="control-label">
 			Sort:
-			<Select bind:value={sortBy} options={SORT_OPTIONS} />
+			<Select bind:value={sortPref.value} options={SORT_OPTIONS} />
 		</label>
 		<label class="low-conf-toggle" title="Show gems with very few listings (unreliable prices)">
 			<input type="checkbox" bind:checked={showLowConf} />

--- a/frontend/src/routes/lab/components/BestPlays.svelte
+++ b/frontend/src/routes/lab/components/BestPlays.svelte
@@ -16,18 +16,23 @@
 		{ value: 'roiPercent', label: 'ROI%' },
 	];
 
+	// `rowCap` is applied AFTER the sort: the owner passes the full filtered
+	// pool, and "top N" must mean top N under the sort the user picked. Capping
+	// upstream handed this table the top N by fetch order, reordered.
 	let {
 		plays,
 		title = 'Best Plays Now (ALL variants)',
 		showVariantColumn = true,
 		league = '',
 		searchActive = false,
+		rowCap = Infinity,
 	}: {
 		plays: GemPlay[];
 		title?: string;
 		showVariantColumn?: boolean;
 		league?: string;
 		searchActive?: boolean;
+		rowCap?: number;
 	} = $props();
 
 	let sortBy = $state<'price' | 'riskAdjusted' | 'roi' | 'roiPercent'>('price');
@@ -50,14 +55,16 @@
 			filtered = filtered.filter((p) => !p.lowConfidence);
 		}
 		if (sortBy === 'price') {
-			return filtered.sort((a, b) => b.transPrice - a.transPrice);
+			filtered.sort((a, b) => b.transPrice - a.transPrice);
+		} else if (sortBy === 'riskAdjusted') {
+			filtered.sort((a, b) => b.weightedRoi - a.weightedRoi);
+		} else {
+			filtered.sort((a, b) =>
+				sortBy === 'roi' ? b.roi - a.roi : b.roiPercent - a.roiPercent
+			);
 		}
-		if (sortBy === 'riskAdjusted') {
-			return filtered.sort((a, b) => b.weightedRoi - a.weightedRoi);
-		}
-		return filtered.sort((a, b) =>
-			sortBy === 'roi' ? b.roi - a.roi : b.roiPercent - a.roiPercent
-		);
+		// A search names its gems explicitly — show them all, cap only browsing.
+		return searchActive ? filtered : filtered.slice(0, rowCap);
 	});
 
 	function velocityStr(v: number): string {

--- a/frontend/src/routes/lab/components/ByVariant.svelte
+++ b/frontend/src/routes/lab/components/ByVariant.svelte
@@ -203,10 +203,14 @@
 			: `${searchQuery} is not in the rankings.`;
 	}
 
-	// Browse-mode filters shared by both table shapes: budget, then colour, then
-	// the row cap. A search bypasses all three — it names one gem explicitly, so
-	// hiding it by budget or colour and then blaming the market answers a
-	// question the player did not ask, with the wrong reason.
+	// Browse-mode filters shared by both table shapes: budget, then colour. A
+	// search bypasses both — it names one gem explicitly, so hiding it by budget
+	// or colour and then blaming the market answers a question the player did
+	// not ask, with the wrong reason.
+	//
+	// No row cap here: the cap belongs downstream in BestPlays, AFTER its sort.
+	// Capping before the sort handed the table "the top rows by fetch order,
+	// reordered" — under a ROI sort that is not the top rows by ROI at all.
 	function browseFilter(filtered: GemPlay[]): GemPlay[] {
 		if (budgetChaos > 0) {
 			// NO_BASE gems have no known cost basis (basePrice 0 means unknown, not
@@ -216,7 +220,7 @@
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
-		return filtered.slice(0, parseInt(itemLimit));
+		return filtered;
 	}
 
 	// Filter from already-loaded data — zero API calls.
@@ -229,15 +233,11 @@
 	// The ALL tab is ONE merged table, not four stacked ones: a budget or colour
 	// filter there is a cross-market question, and four tables answer it four
 	// separate times. The merged pool arrives variant-grouped (per-variant
-	// fetches, concatenated), so it must be ranked by price before the row cap —
-	// a positional slice would fill the whole table from the first variant
-	// fetched. Ranking by price matches how the per-variant tables choose their
-	// rows; the Sort dropdown then reorders within the chosen set, as it does
-	// everywhere else.
+	// fetches, concatenated) — safe to pass on unordered, because BestPlays
+	// sorts before it caps.
 	function playsForAll(): GemPlay[] {
 		if (searchResults) return playSource;
-		const ranked = [...playSource].sort((a, b) => b.transPrice - a.transPrice);
-		return browseFilter(ranked);
+		return browseFilter(playSource);
 	}
 
 	// baseName holds "skill" or "transfigured" for Dedication gems, and each row
@@ -343,7 +343,7 @@
 		<div class="variant-block">
 			<div class="variant-label">{tab.label}</div>
 			{#if vd.length > 0}
-				<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool]}) — {tab.variant}" showVariantColumn={false} {league} searchActive={searchResults !== null} />
+				<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool]}) — {tab.variant}" showVariantColumn={false} {league} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
 			{:else if searchResults}
 				<div class="loading">{searchMissReason()}</div>
 			{:else}
@@ -355,7 +355,7 @@
 		<div class="variant-block">
 			<div class="variant-label">All markets</div>
 			{#if vd.length > 0}
-				<BestPlays plays={vd} title="Best Plays (all markets)" showVariantColumn={true} {league} searchActive={searchResults !== null} />
+				<BestPlays plays={vd} title="Best Plays (all markets)" showVariantColumn={true} {league} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
 			{:else if searchResults}
 				<div class="loading">{searchMissReason()}</div>
 			{:else}
@@ -367,7 +367,7 @@
 		<div class="variant-block">
 			<div class="variant-label">{activeTab}</div>
 			{#if vd.length > 0}
-				<BestPlays plays={vd} title="Best Plays ({activeTab})" showVariantColumn={false} {league} searchActive={searchResults !== null} />
+				<BestPlays plays={vd} title="Best Plays ({activeTab})" showVariantColumn={false} {league} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
 			{:else if searchResults}
 				<div class="loading">{searchMissReason()}</div>
 			{:else}

--- a/frontend/src/routes/lab/components/ByVariant.svelte
+++ b/frontend/src/routes/lab/components/ByVariant.svelte
@@ -63,6 +63,16 @@
 	// the unsearched rows go through. A market with no match renders its usual
 	// empty state, which is the useful answer — it says the gem does not sell at
 	// that level/quality.
+	// --- Budget (one box for every table below it, like the search) ---
+	//
+	// The filter must run BEFORE the per-table row cap. It used to live in
+	// BestPlays, downstream of the cap, so it could only thin out the 20 rows
+	// already chosen by price — and the visible top-20's base prices sit well
+	// under any realistic budget, so typing one changed nothing. Filtering here
+	// re-fills the table with the best gems that actually fit.
+	let budgetInput = $state('');
+	const budgetChaos = $derived(parseInt(budgetInput) > 0 ? parseInt(budgetInput) : 0);
+
 	let searchQuery = $state('');
 	let searchResults = $state<GemPlay[] | null>(null);
 	let searchError = $state('');
@@ -197,29 +207,35 @@
 			: `${searchQuery} is not in the rankings.`;
 	}
 
-	// Filter from already-loaded data — zero API calls.
-	function playsForVariant(variant: string): GemPlay[] {
-		let filtered = playSource.filter(g => g.variant === variant);
-		// A search names one gem, so the colour tab and the row cap do not apply to
-		// it — they are for browsing a ranked list. Filtering a searched gem out by
-		// colour and then rendering "not at this variant" answers a question the
-		// player did not ask, with the wrong reason.
-		if (searchResults) return filtered;
+	// Browse-mode filters shared by both table shapes: budget, then colour, then
+	// the row cap. A search bypasses all three — it names one gem explicitly, so
+	// hiding it by budget or colour and then blaming the market answers a
+	// question the player did not ask, with the wrong reason.
+	function browseFilter(filtered: GemPlay[]): GemPlay[] {
+		if (budgetChaos > 0) {
+			// NO_BASE gems have no known cost basis (basePrice 0 means unknown, not
+			// free), so they can't be shown to fit a budget — same rule as the server.
+			filtered = filtered.filter(g => g.confidence !== 'NO_BASE' && g.basePrice <= budgetChaos);
+		}
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
 		return filtered.slice(0, parseInt(itemLimit));
 	}
 
+	// Filter from already-loaded data — zero API calls.
+	function playsForVariant(variant: string): GemPlay[] {
+		const filtered = playSource.filter(g => g.variant === variant);
+		if (searchResults) return filtered;
+		return browseFilter(filtered);
+	}
+
 	// baseName holds "skill" or "transfigured" for Dedication gems, and each row
 	// carries the market it was ranked in, so both halves of the tab filter.
 	function playsForPool(pool: string, variant: string): GemPlay[] {
-		let filtered = playSource.filter(g => g.baseName === pool && g.variant === variant);
+		const filtered = playSource.filter(g => g.baseName === pool && g.variant === variant);
 		if (searchResults) return filtered;
-		if (activeColor !== 'ALL') {
-			filtered = filtered.filter(g => g.color === activeColor);
-		}
-		return filtered.slice(0, parseInt(itemLimit));
+		return browseFilter(filtered);
 	}
 </script>
 
@@ -252,6 +268,15 @@
 				</div>
 			{/if}
 		</div>
+		<label class="budget-label">
+			Budget:
+			<input
+				type="text"
+				class="budget-input"
+				placeholder="unlimited"
+				bind:value={budgetInput}
+			/>
+		</label>
 		<div class="limit-select">
 			<span class="select-label">Show:</span>
 			<Select bind:value={itemLimit} options={LIMIT_OPTIONS} />
@@ -379,6 +404,25 @@
 		outline: none;
 	}
 	.search-input::placeholder {
+		color: var(--color-lab-text-secondary);
+	}
+	.budget-label {
+		color: var(--color-lab-text-secondary);
+		font-size: 0.875rem;
+		display: flex;
+		align-items: center;
+		gap: 6px;
+	}
+	.budget-input {
+		width: 90px;
+		background: var(--color-lab-bg);
+		border: 1px solid var(--color-lab-border);
+		color: var(--color-lab-text);
+		padding: 5px 10px;
+		font-size: 0.875rem;
+		font-family: inherit;
+	}
+	.budget-input::placeholder {
 		color: var(--color-lab-text-secondary);
 	}
 	.dropdown {

--- a/frontend/src/routes/lab/components/ByVariant.svelte
+++ b/frontend/src/routes/lab/components/ByVariant.svelte
@@ -5,6 +5,7 @@
 		DEDICATION_VARIANTS,
 		DEDICATION_POOLS,
 		DEDICATION_POOL_LABELS,
+		type DedicationPool,
 		fetchGemNames,
 		fetchBestPlays,
 		type GemPlay,
@@ -157,12 +158,53 @@
 	// across would be from the wrong one.
 	$effect(() => {
 		isDedication;
-		untrack(() => { if (searchResults) clearSearch(); });
+		// Unconditional: a query typed but not yet picked leaves `suggestions`
+		// full of names from the other mode's pool, and picking one then searches a
+		// gem that cannot exist in this mode.
+		untrack(() => { if (searchQuery || searchResults) clearSearch(); });
 	});
+
+	/**
+	 * Why a searched gem is missing from the table in front of you.
+	 *
+	 * The Dedication picker offers names the rankings can never contain: Vaal gems
+	 * are a legal feed and deliberately stay in the autocomplete for the compare
+	 * surface (internal/lab/repository.go, CorruptedGemNamesAutocomplete), but
+	 * isDedicationOutcome excludes them from every ranking. The picker also spans
+	 * both pools, so a non-transfigured name is offerable while the Transfigured
+	 * tab is active. Measured 2026-08-08 over 77 suggestions from 8 queries: 36 of
+	 * them yield nothing on the 21/23 Transfigured tab — 19 Vaal, 17 wrong-pool.
+	 *
+	 * "No <gem> in this pool" was a wrong answer for all 36: it reads as "this gem
+	 * does not sell here", when the truth is either "it is in the other pool" or
+	 * "it is never a craft outcome". Say which.
+	 */
+	function searchMissReason(): string {
+		if (!searchResults) return '';
+		if (searchResults.length === 0) {
+			return `${searchQuery} is not in the rankings \u2014 Vaal gems are a legal feed but never a craft outcome, so they are never ranked.`;
+		}
+		const pools = [...new Set(searchResults.map((g) => g.baseName).filter(Boolean))];
+		const markets = [...new Set(searchResults.map((g) => g.variant).filter(Boolean))].sort();
+		const wherePool = pools
+			.map((pool) => DEDICATION_POOL_LABELS[pool as DedicationPool] ?? pool)
+			.join(' / ');
+		if (isDedication && wherePool) {
+			return `${searchQuery} is in ${wherePool}${markets.length ? ` at ${markets.join(', ')}` : ''} \u2014 not this tab.`;
+		}
+		return markets.length
+			? `${searchQuery} is ranked at ${markets.join(', ')} \u2014 not this one.`
+			: `${searchQuery} is not in the rankings.`;
+	}
 
 	// Filter from already-loaded data — zero API calls.
 	function playsForVariant(variant: string): GemPlay[] {
 		let filtered = playSource.filter(g => g.variant === variant);
+		// A search names one gem, so the colour tab and the row cap do not apply to
+		// it — they are for browsing a ranked list. Filtering a searched gem out by
+		// colour and then rendering "not at this variant" answers a question the
+		// player did not ask, with the wrong reason.
+		if (searchResults) return filtered;
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
@@ -173,6 +215,7 @@
 	// carries the market it was ranked in, so both halves of the tab filter.
 	function playsForPool(pool: string, variant: string): GemPlay[] {
 		let filtered = playSource.filter(g => g.baseName === pool && g.variant === variant);
+		if (searchResults) return filtered;
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
@@ -229,11 +272,7 @@
 			{/each}
 		</div>
 		<div class="tabs">
-			{#if searchError}
-		<div class="search-error">{searchError}</div>
-	{/if}
-
-	{#if isDedication}
+			{#if isDedication}
 				{#each DEDICATION_TABS as tab}
 					<button
 						class="tab"
@@ -259,6 +298,10 @@
 		</div>
 	</div>
 
+	{#if searchError}
+		<div class="search-error">{searchError}</div>
+	{/if}
+
 	{#if isDedication}
 		{@const tab = activeDedTabInfo}
 		{@const vd = playsForPool(tab.pool, tab.variant)}
@@ -267,7 +310,7 @@
 			{#if vd.length > 0}
 				<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool]}) — {tab.variant}" showVariantColumn={false} {league} searchActive={searchResults !== null} />
 			{:else if searchResults}
-				<div class="loading">No {searchQuery} in this pool</div>
+				<div class="loading">{searchMissReason()}</div>
 			{:else}
 				<div class="loading">No data for this pool</div>
 			{/if}
@@ -280,7 +323,7 @@
 				{#if vd.length > 0}
 					<BestPlays plays={vd} title="Best Plays ({variant})" showVariantColumn={false} {league} searchActive={searchResults !== null} />
 				{:else if searchResults}
-					<div class="loading">No {searchQuery} at {variant}</div>
+					<div class="loading">{searchMissReason()}</div>
 				{:else}
 					<div class="loading">No data for this variant</div>
 				{/if}

--- a/frontend/src/routes/lab/components/ByVariant.svelte
+++ b/frontend/src/routes/lab/components/ByVariant.svelte
@@ -13,6 +13,7 @@
 	import BestPlays from './BestPlays.svelte';
 	import InfoTooltip from './InfoTooltip.svelte';
 	import Select from '$lib/components/Select.svelte';
+	import { persisted } from '$lib/prefs.svelte';
 
 	let { allPlays = [], league = '', labMode = 'normal' }: { allPlays?: GemPlay[]; league?: string; labMode?: 'normal' | 'dedication' } = $props();
 
@@ -36,13 +37,16 @@
 		{ value: '50', label: '50' },
 	];
 
-	let activeTab = $state('20/20');
-	let activeDedTab = $state(DEDICATION_TABS[0].key);
-	let activeColor = $state('ALL');
-	let itemLimit = $state('20');
+	// Persisted picks (ADR-013): every select on this surface is remembered
+	// across visits. Unlike the desktop app there is no SSOT store here, so the
+	// tabs persist wholesale.
+	const activeTab = persisted('rankingsTab', '20/20');
+	const activeDedTab = persisted('rankingsDedTab', DEDICATION_TABS[0].key);
+	const colorPref = persisted('rankingsColor', 'ALL');
+	const limitPref = persisted('rankingsLimit', '20');
 
 	let activeDedTabInfo = $derived(
-		DEDICATION_TABS.find(t => t.key === activeDedTab) ?? DEDICATION_TABS[0]
+		DEDICATION_TABS.find(t => t.key === activeDedTab.value) ?? DEDICATION_TABS[0]
 	);
 
 	// --- Gem search (one box for every table below it) ---
@@ -66,8 +70,8 @@
 	// already chosen by price — and the visible top-20's base prices sit well
 	// under any realistic budget, so typing one changed nothing. Filtering here
 	// re-fills the table with the best gems that actually fit.
-	let budgetInput = $state('');
-	const budgetChaos = $derived(parseInt(budgetInput) > 0 ? parseInt(budgetInput) : 0);
+	const budgetPref = persisted('rankingsBudget', '');
+	const budgetChaos = $derived(parseInt(budgetPref.value) > 0 ? parseInt(budgetPref.value) : 0);
 
 	let searchQuery = $state('');
 	let searchResults = $state<GemPlay[] | null>(null);
@@ -217,8 +221,8 @@
 			// free), so they can't be shown to fit a budget — same rule as the server.
 			filtered = filtered.filter(g => g.confidence !== 'NO_BASE' && g.basePrice <= budgetChaos);
 		}
-		if (activeColor !== 'ALL') {
-			filtered = filtered.filter(g => g.color === activeColor);
+		if (colorPref.value !== 'ALL') {
+			filtered = filtered.filter(g => g.color === colorPref.value);
 		}
 		return filtered;
 	}
@@ -284,22 +288,22 @@
 				type="text"
 				class="budget-input"
 				placeholder="unlimited"
-				bind:value={budgetInput}
+				bind:value={budgetPref.value}
 			/>
 		</label>
 		<div class="limit-select">
 			<span class="select-label">Show:</span>
-			<Select bind:value={itemLimit} options={LIMIT_OPTIONS} />
+			<Select bind:value={limitPref.value} options={LIMIT_OPTIONS} />
 		</div>
 		<div class="color-tabs">
 			{#each COLORS as color}
 				<button
 					class="tab color-tab"
-					class:active={activeColor === color}
+					class:active={colorPref.value === color}
 					class:c-red={color === 'RED'}
 					class:c-green={color === 'GREEN'}
 					class:c-blue={color === 'BLUE'}
-					onclick={() => { activeColor = color; }}
+					onclick={() => { colorPref.value = color; }}
 				>
 					{#if color !== 'ALL'}<span class="color-dot">●</span>{/if}
 					{color}
@@ -311,10 +315,10 @@
 				{#each DEDICATION_TABS as tab}
 					<button
 						class="tab"
-						class:active={activeDedTab === tab.key}
-						onclick={() => { activeDedTab = tab.key; }}
+						class:active={activeDedTab.value === tab.key}
+						onclick={() => { activeDedTab.value = tab.key; }}
 					>
-						{#if activeDedTab === tab.key}<span class="tab-dot">●</span>{/if}
+						{#if activeDedTab.value === tab.key}<span class="tab-dot">●</span>{/if}
 						{tab.label}
 					</button>
 				{/each}
@@ -322,10 +326,10 @@
 				{#each TABS as tab}
 					<button
 						class="tab"
-						class:active={activeTab === tab}
-						onclick={() => { activeTab = tab; }}
+						class:active={activeTab.value === tab}
+						onclick={() => { activeTab.value = tab; }}
 					>
-						{#if activeTab === tab}<span class="tab-dot">●</span>{/if}
+						{#if activeTab.value === tab}<span class="tab-dot">●</span>{/if}
 						{tab}
 					</button>
 				{/each}
@@ -343,19 +347,19 @@
 		<div class="variant-block">
 			<div class="variant-label">{tab.label}</div>
 			{#if vd.length > 0}
-				<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool]}) — {tab.variant}" showVariantColumn={false} {league} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
+				<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool]}) — {tab.variant}" showVariantColumn={false} {league} rowCap={parseInt(limitPref.value)} searchActive={searchResults !== null} />
 			{:else if searchResults}
 				<div class="loading">{searchMissReason()}</div>
 			{:else}
 				<div class="loading">No data for this pool</div>
 			{/if}
 		</div>
-	{:else if activeTab === 'ALL'}
+	{:else if activeTab.value === 'ALL'}
 		{@const vd = playsForAll()}
 		<div class="variant-block">
 			<div class="variant-label">All markets</div>
 			{#if vd.length > 0}
-				<BestPlays plays={vd} title="Best Plays (all markets)" showVariantColumn={true} {league} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
+				<BestPlays plays={vd} title="Best Plays (all markets)" showVariantColumn={true} {league} rowCap={parseInt(limitPref.value)} searchActive={searchResults !== null} />
 			{:else if searchResults}
 				<div class="loading">{searchMissReason()}</div>
 			{:else}
@@ -363,11 +367,11 @@
 			{/if}
 		</div>
 	{:else}
-		{@const vd = playsForVariant(activeTab)}
+		{@const vd = playsForVariant(activeTab.value)}
 		<div class="variant-block">
-			<div class="variant-label">{activeTab}</div>
+			<div class="variant-label">{activeTab.value}</div>
 			{#if vd.length > 0}
-				<BestPlays plays={vd} title="Best Plays ({activeTab})" showVariantColumn={false} {league} rowCap={parseInt(itemLimit)} searchActive={searchResults !== null} />
+				<BestPlays plays={vd} title="Best Plays ({activeTab.value})" showVariantColumn={false} {league} rowCap={parseInt(limitPref.value)} searchActive={searchResults !== null} />
 			{:else if searchResults}
 				<div class="loading">{searchMissReason()}</div>
 			{:else}

--- a/frontend/src/routes/lab/components/ByVariant.svelte
+++ b/frontend/src/routes/lab/components/ByVariant.svelte
@@ -65,13 +65,43 @@
 	// that level/quality.
 	// --- Budget (one box for every table below it, like the search) ---
 	//
-	// The filter must run BEFORE the per-table row cap. It used to live in
-	// BestPlays, downstream of the cap, so it could only thin out the 20 rows
-	// already chosen by price — and the visible top-20's base prices sit well
-	// under any realistic budget, so typing one changed nothing. Filtering here
-	// re-fills the table with the best gems that actually fit.
+	// A budget is answered by the SERVER, not by filtering the loaded rows: the
+	// ranked pool on hand is the top-100 per market by absolute ROI, so a small
+	// budget filtered client-side keeps only the affordable stragglers of an
+	// expensive-base list. The server's budget param filters the full corpus
+	// before its limit (internal/lab/collective.go). The client-side filter in
+	// browseFilter stays as the fallback while the fetch is in flight or failed.
 	const budgetPref = persisted('rankingsBudget', '');
 	const budgetChaos = $derived(parseInt(budgetPref.value) > 0 ? parseInt(budgetPref.value) : 0);
+	let budgetResults = $state<GemPlay[] | null>(null);
+	let budgetGeneration = 0;
+	$effect(() => {
+		const b = budgetChaos;
+		const dedication = isDedication;
+		const generation = ++budgetGeneration;
+		if (b <= 0) {
+			budgetResults = null;
+			return;
+		}
+		// Debounced: the box is a text input, and each fetch fans out per market.
+		const timer = setTimeout(async () => {
+			try {
+				const rows = dedication
+					? (await Promise.all(
+							DEDICATION_VARIANTS.map((v) => fetchBestPlays(v, b, undefined, 100, undefined, 'dedication')),
+						)).flat()
+					: (await Promise.all(
+							VARIANTS.map((v) => fetchBestPlays(v, b, undefined, 100)),
+						)).flat();
+				if (generation === budgetGeneration) budgetResults = rows;
+			} catch (err) {
+				// Fall back to filtering the rows on hand — fewer results, never wrong ones.
+				console.warn('[ByVariant] budget fetch failed:', err);
+				if (generation === budgetGeneration) budgetResults = null;
+			}
+		}, 300);
+		return () => clearTimeout(timer);
+	});
 
 	let searchQuery = $state('');
 	let searchResults = $state<GemPlay[] | null>(null);
@@ -161,8 +191,9 @@
 
 	// A search replaces the ranked rows as the source, but never the scoping: the
 	// per-market and per-color filters below apply to it exactly as they do to
-	// the ranked rows.
-	const playSource = $derived(searchResults ?? allPlays);
+	// the ranked rows. A budget-scoped fetch replaces them the same way, one
+	// rung lower — search wins over budget.
+	const playSource = $derived(searchResults ?? budgetResults ?? allPlays);
 
 	// Switching lab mode re-fetches under a different mode, so a result carried
 	// across would be from the wrong one.

--- a/frontend/src/routes/lab/components/ByVariant.svelte
+++ b/frontend/src/routes/lab/components/ByVariant.svelte
@@ -1,5 +1,14 @@
 <script lang="ts">
-	import { VARIANTS, DEDICATION_VARIANTS, type GemPlay } from '$lib/api';
+	import { untrack } from 'svelte';
+	import {
+		VARIANTS,
+		DEDICATION_VARIANTS,
+		DEDICATION_POOLS,
+		DEDICATION_POOL_LABELS,
+		fetchGemNames,
+		fetchBestPlays,
+		type GemPlay,
+	} from '$lib/api';
 	import BestPlays from './BestPlays.svelte';
 	import InfoTooltip from './InfoTooltip.svelte';
 	import Select from '$lib/components/Select.svelte';
@@ -9,11 +18,10 @@
 	const isDedication = $derived(labMode === 'dedication');
 
 	const TABS = ['ALL', ...VARIANTS];
-	const DEDICATION_POOL_LABELS: Record<string, string> = { skill: 'Skills', transfigured: 'Transfigured' };
 	// One tab per (market, pool): the four rows of the Dedication EV table, in
 	// the same order.
 	const DEDICATION_TABS = DEDICATION_VARIANTS.flatMap((variant) =>
-		['skill', 'transfigured'].map((pool) => ({
+		DEDICATION_POOLS.map((pool) => ({
 			key: `${variant}:${pool}`,
 			variant,
 			pool,
@@ -40,9 +48,101 @@
 		DEDICATION_TABS.find(t => t.key === activeDedTab) ?? DEDICATION_TABS[0]
 	);
 
+	// --- Gem search (one box for every table below it) ---
+	//
+	// Search lives here rather than in BestPlays because the tables below are
+	// each scoped to one market. A per-table search fetched across every variant
+	// and then replaced that table's rows wholesale, so a table headed "Best
+	// Plays (20/20)" listed all four variants of the matched gem — with the Var
+	// column hidden, as four rows that read as identical. On the ALL tab it was
+	// worse: four tables, four independent boxes, so typing in one left the
+	// other three showing unrelated gems.
+	//
+	// One query, held here, feeds every table through the same per-market filter
+	// the unsearched rows go through. A market with no match renders its usual
+	// empty state, which is the useful answer — it says the gem does not sell at
+	// that level/quality.
+	let searchQuery = $state('');
+	let searchResults = $state<GemPlay[] | null>(null);
+	let suggestions = $state<string[]>([]);
+	let showDropdown = $state(false);
+	let highlightedIndex = $state(-1);
+	let searchDebounce: ReturnType<typeof setTimeout> | null = null;
+
+	function clearSearch() {
+		searchQuery = '';
+		searchResults = null;
+		suggestions = [];
+		showDropdown = false;
+		highlightedIndex = -1;
+	}
+
+	function handleSearchInput(query: string) {
+		searchQuery = query;
+		if (searchDebounce) clearTimeout(searchDebounce);
+		if (!query.trim()) {
+			clearSearch();
+			return;
+		}
+		if (query.length < 2) {
+			suggestions = [];
+			showDropdown = false;
+			return;
+		}
+		searchDebounce = setTimeout(async () => {
+			if (searchQuery !== query) return;
+			const names = await fetchGemNames(query);
+			if (searchQuery !== query) return;
+			suggestions = names;
+			showDropdown = suggestions.length > 0;
+			highlightedIndex = suggestions.length === 1 ? 0 : -1;
+		}, 100);
+	}
+
+	async function selectGem(name: string) {
+		searchQuery = name;
+		suggestions = [];
+		showDropdown = false;
+		// Fetch across every market — the per-market filter below splits the
+		// result back out. The mode has to be passed: without it the server
+		// answers with normal-mode rows, which carry no `baseName`, so in
+		// Dedication mode every table matched nothing and search looked broken.
+		searchResults = await fetchBestPlays(
+			undefined, undefined, undefined, undefined, name,
+			isDedication ? 'dedication' : undefined,
+		);
+	}
+
+	function handleSearchKeydown(e: KeyboardEvent) {
+		if (e.key === 'ArrowDown' && showDropdown) {
+			e.preventDefault();
+			highlightedIndex = Math.min(highlightedIndex + 1, suggestions.length - 1);
+		} else if (e.key === 'ArrowUp' && showDropdown) {
+			e.preventDefault();
+			highlightedIndex = Math.max(highlightedIndex - 1, 0);
+		} else if (e.key === 'Enter' && highlightedIndex >= 0) {
+			e.preventDefault();
+			selectGem(suggestions[highlightedIndex]);
+		} else if (e.key === 'Escape') {
+			clearSearch();
+		}
+	}
+
+	// A search replaces the ranked rows as the source, but never the scoping: the
+	// per-market and per-color filters below apply to it exactly as they do to
+	// the ranked rows.
+	const playSource = $derived(searchResults ?? allPlays);
+
+	// Switching lab mode re-fetches under a different mode, so a result carried
+	// across would be from the wrong one.
+	$effect(() => {
+		isDedication;
+		untrack(() => { if (searchResults) clearSearch(); });
+	});
+
 	// Filter from already-loaded data — zero API calls.
 	function playsForVariant(variant: string): GemPlay[] {
-		let filtered = allPlays.filter(g => g.variant === variant);
+		let filtered = playSource.filter(g => g.variant === variant);
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
@@ -52,7 +152,7 @@
 	// baseName holds "skill" or "transfigured" for Dedication gems, and each row
 	// carries the market it was ranked in, so both halves of the tab filter.
 	function playsForPool(pool: string, variant: string): GemPlay[] {
-		let filtered = allPlays.filter(g => g.baseName === pool && g.variant === variant);
+		let filtered = playSource.filter(g => g.baseName === pool && g.variant === variant);
 		if (activeColor !== 'ALL') {
 			filtered = filtered.filter(g => g.color === activeColor);
 		}
@@ -63,6 +163,32 @@
 <section class="section">
 	<div class="section-header">
 		<h2 class="section-title">By Variant<InfoTooltip text="<b>Gem Ranking by Variant</b><br><br>Gems sorted by price (default), ROI, or risk-adjusted ROI. Filter by color and toggle low-confidence gems.<br><br><b>Tiers</b> (computed per variant, dynamic boundaries):<br>&nbsp;&nbsp;<span style='color:#fbbf24'>TOP</span> = monopoly outliers (gap-detected from clean pool)<br>&nbsp;&nbsp;<span style='color:#fb923c'>HIGH</span> = premium cluster (within 30% of top gem)<br>&nbsp;&nbsp;<span style='color:#c084fc'>MID-HIGH</span> = worth farming (above 50% of HIGH boundary)<br>&nbsp;&nbsp;<span style='color:#94a3b8'>MID</span> = decent profit<br>&nbsp;&nbsp;<span style='color:#64748b'>LOW</span> = marginal ROI<br>&nbsp;&nbsp;<span style='color:#475569'>FLOOR</span> = below 8% of top-5 average (not worth farming)<br><br><b>Low confidence</b> toggle shows thin-market gems (listings &lt; 40% of median). These may be price manipulation or meta shifts — system can't tell which.<br><br><b>Sort modes</b>: Price (default), Raw ROI, Risk-Adj ROI, ROI%." /></h2>
+		<div class="search-wrapper">
+			<input
+				type="text"
+				class="search-input"
+				placeholder="Search gem..."
+				value={searchQuery}
+				oninput={(e) => handleSearchInput(e.currentTarget.value)}
+				onkeydown={handleSearchKeydown}
+				onfocus={() => { if (suggestions.length) showDropdown = true; }}
+				onblur={() => setTimeout(() => { showDropdown = false; }, 200)}
+			/>
+			{#if searchQuery}
+				<button class="search-clear" title="Clear search" onclick={clearSearch}>×</button>
+			{/if}
+			{#if showDropdown && suggestions.length > 0}
+				<div class="dropdown">
+					{#each suggestions as gem, i}
+						<button
+							class="dropdown-item"
+							class:highlighted={i === highlightedIndex}
+							onmousedown={() => selectGem(gem)}
+						>{gem}</button>
+					{/each}
+				</div>
+			{/if}
+		</div>
 		<div class="limit-select">
 			<span class="select-label">Show:</span>
 			<Select bind:value={itemLimit} options={LIMIT_OPTIONS} />
@@ -115,7 +241,9 @@
 		<div class="variant-block">
 			<div class="variant-label">{tab.label}</div>
 			{#if vd.length > 0}
-				<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool]}) — {tab.variant}" showVariantColumn={false} {league} />
+				<BestPlays plays={vd} title="Dedication Pool ({DEDICATION_POOL_LABELS[tab.pool]}) — {tab.variant}" showVariantColumn={false} {league} searchActive={searchResults !== null} />
+			{:else if searchResults}
+				<div class="loading">No {searchQuery} in this pool</div>
 			{:else}
 				<div class="loading">No data for this pool</div>
 			{/if}
@@ -126,7 +254,9 @@
 			<div class="variant-block">
 				<div class="variant-label">{variant}</div>
 				{#if vd.length > 0}
-					<BestPlays plays={vd} title="Best Plays ({variant})" showVariantColumn={false} {league} />
+					<BestPlays plays={vd} title="Best Plays ({variant})" showVariantColumn={false} {league} searchActive={searchResults !== null} />
+				{:else if searchResults}
+					<div class="loading">No {searchQuery} at {variant}</div>
 				{:else}
 					<div class="loading">No data for this variant</div>
 				{/if}
@@ -153,6 +283,67 @@
 		font-weight: 700;
 		color: var(--color-lab-text);
 		margin: 0;
+	}
+	.search-wrapper {
+		position: relative;
+		flex: 1;
+		max-width: 300px;
+	}
+	.search-input {
+		width: 100%;
+		background: var(--color-lab-bg);
+		border: 1px solid var(--color-lab-border);
+		color: var(--color-lab-text);
+		padding: 6px 12px;
+		font-size: 0.8125rem;
+		font-family: inherit;
+		box-sizing: border-box;
+		outline: none;
+	}
+	.search-input::placeholder {
+		color: var(--color-lab-text-secondary);
+	}
+	.dropdown {
+		position: absolute;
+		top: 100%;
+		left: 0;
+		right: 0;
+		background: var(--color-lab-surface);
+		border: 1px solid var(--color-lab-border);
+		border-top: none;
+		max-height: 200px;
+		overflow-y: auto;
+		z-index: 100;
+	}
+	.dropdown-item {
+		display: block;
+		width: 100%;
+		padding: 6px 12px;
+		text-align: left;
+		background: none;
+		border: none;
+		color: var(--color-lab-text);
+		font-size: 0.8125rem;
+		cursor: pointer;
+	}
+	.dropdown-item:hover, .dropdown-item.highlighted {
+		background: rgba(255, 255, 255, 0.08);
+	}
+	.search-clear {
+		position: absolute;
+		right: 6px;
+		top: 50%;
+		transform: translateY(-50%);
+		background: none;
+		border: none;
+		color: var(--color-lab-text-secondary);
+		font-size: 1rem;
+		line-height: 1;
+		padding: 0 4px;
+		cursor: pointer;
+	}
+	.search-clear:hover {
+		color: var(--color-lab-text);
 	}
 	.limit-select {
 		display: flex;

--- a/frontend/src/routes/lab/components/ByVariant.svelte
+++ b/frontend/src/routes/lab/components/ByVariant.svelte
@@ -64,6 +64,7 @@
 	// that level/quality.
 	let searchQuery = $state('');
 	let searchResults = $state<GemPlay[] | null>(null);
+	let searchError = $state('');
 	let suggestions = $state<string[]>([]);
 	let showDropdown = $state(false);
 	let highlightedIndex = $state(-1);
@@ -72,6 +73,7 @@
 	function clearSearch() {
 		searchQuery = '';
 		searchResults = null;
+		searchError = '';
 		suggestions = [];
 		showDropdown = false;
 		highlightedIndex = -1;
@@ -91,7 +93,14 @@
 		}
 		searchDebounce = setTimeout(async () => {
 			if (searchQuery !== query) return;
-			const names = await fetchGemNames(query);
+			let names: string[];
+			try {
+				names = await fetchGemNames(query, isDedication ? 'dedication' : undefined);
+			} catch (err) {
+				// A swallowed rejection here presented as "typing does nothing".
+				console.warn('[ByVariant] gem name lookup failed:', err);
+				return;
+			}
 			if (searchQuery !== query) return;
 			suggestions = names;
 			showDropdown = suggestions.length > 0;
@@ -103,14 +112,25 @@
 		searchQuery = name;
 		suggestions = [];
 		showDropdown = false;
-		// Fetch across every market — the per-market filter below splits the
-		// result back out. The mode has to be passed: without it the server
-		// answers with normal-mode rows, which carry no `baseName`, so in
-		// Dedication mode every table matched nothing and search looked broken.
-		searchResults = await fetchBestPlays(
-			undefined, undefined, undefined, undefined, name,
-			isDedication ? 'dedication' : undefined,
-		);
+		searchError = '';
+		try {
+			// The dedication endpoint answers for ONE market per request: omitting
+			// `variant` does not mean "all", it silently defaults to 21/23, so a
+			// 21/20 tab found nothing. Fan out and merge, the way the ranked rows
+			// are loaded. Normal mode does return every variant in one response.
+			searchResults = isDedication
+				? (await Promise.all(
+						DEDICATION_VARIANTS.map((v) =>
+							fetchBestPlays(v, undefined, undefined, undefined, name, 'dedication'),
+						),
+					)).flat()
+				: await fetchBestPlays(undefined, undefined, undefined, undefined, name);
+		} catch (err) {
+			// Without this the rejection was silent and the UI simply never changed.
+			console.warn('[ByVariant] gem search failed:', err);
+			searchResults = null;
+			searchError = `Search for "${name}" failed \u2014 check the connection and try again.`;
+		}
 	}
 
 	function handleSearchKeydown(e: KeyboardEvent) {
@@ -209,7 +229,11 @@
 			{/each}
 		</div>
 		<div class="tabs">
-			{#if isDedication}
+			{#if searchError}
+		<div class="search-error">{searchError}</div>
+	{/if}
+
+	{#if isDedication}
 				{#each DEDICATION_TABS as tab}
 					<button
 						class="tab"
@@ -277,7 +301,14 @@
 		justify-content: space-between;
 		align-items: center;
 		margin-bottom: 16px;
-	}
+	/* Wrap, and give every child a gap. The row holds five items — title,
+	   search, Show, colour tabs, variant tabs — and measured wider than the
+	   1024px default window, so a no-wrap row left the search box at 26-82px:
+	   two visible characters, with the absolutely-positioned clear button
+	   covering all of it. */
+	flex-wrap: wrap;
+	gap: 8px;
+}
 	.section-title {
 		font-size: 1.125rem;
 		font-weight: 700;
@@ -286,7 +317,11 @@
 	}
 	.search-wrapper {
 		position: relative;
-		flex: 1;
+		/* NOT `flex: 1` — that is flex-basis 0, and this row has no free space to
+		   distribute, so the box collapsed to its automatic minimum. A real basis
+		   keeps it usable and still lets it shrink. */
+		flex: 0 1 240px;
+		min-width: 180px;
 		max-width: 300px;
 	}
 	.search-input {
@@ -305,6 +340,7 @@
 	}
 	.dropdown {
 		position: absolute;
+		min-width: 240px;
 		top: 100%;
 		left: 0;
 		right: 0;
@@ -318,6 +354,9 @@
 	.dropdown-item {
 		display: block;
 		width: 100%;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
 		padding: 6px 12px;
 		text-align: left;
 		background: none;
@@ -344,6 +383,11 @@
 	}
 	.search-clear:hover {
 		color: var(--color-lab-text);
+	}
+	.search-error {
+		color: #f87171;
+		font-size: 0.8125rem;
+		margin-bottom: 12px;
 	}
 	.limit-select {
 		display: flex;

--- a/frontend/src/routes/lab/components/ByVariant.svelte
+++ b/frontend/src/routes/lab/components/ByVariant.svelte
@@ -41,10 +41,6 @@
 	let activeColor = $state('ALL');
 	let itemLimit = $state('20');
 
-	let visibleVariants = $derived(
-		activeTab === 'ALL' ? VARIANTS : [activeTab]
-	);
-
 	let activeDedTabInfo = $derived(
 		DEDICATION_TABS.find(t => t.key === activeDedTab) ?? DEDICATION_TABS[0]
 	);
@@ -230,6 +226,20 @@
 		return browseFilter(filtered);
 	}
 
+	// The ALL tab is ONE merged table, not four stacked ones: a budget or colour
+	// filter there is a cross-market question, and four tables answer it four
+	// separate times. The merged pool arrives variant-grouped (per-variant
+	// fetches, concatenated), so it must be ranked by price before the row cap —
+	// a positional slice would fill the whole table from the first variant
+	// fetched. Ranking by price matches how the per-variant tables choose their
+	// rows; the Sort dropdown then reorders within the chosen set, as it does
+	// everywhere else.
+	function playsForAll(): GemPlay[] {
+		if (searchResults) return playSource;
+		const ranked = [...playSource].sort((a, b) => b.transPrice - a.transPrice);
+		return browseFilter(ranked);
+	}
+
 	// baseName holds "skill" or "transfigured" for Dedication gems, and each row
 	// carries the market it was ranked in, so both halves of the tab filter.
 	function playsForPool(pool: string, variant: string): GemPlay[] {
@@ -340,20 +350,30 @@
 				<div class="loading">No data for this pool</div>
 			{/if}
 		</div>
+	{:else if activeTab === 'ALL'}
+		{@const vd = playsForAll()}
+		<div class="variant-block">
+			<div class="variant-label">All markets</div>
+			{#if vd.length > 0}
+				<BestPlays plays={vd} title="Best Plays (all markets)" showVariantColumn={true} {league} searchActive={searchResults !== null} />
+			{:else if searchResults}
+				<div class="loading">{searchMissReason()}</div>
+			{:else}
+				<div class="loading">No data available</div>
+			{/if}
+		</div>
 	{:else}
-		{#each visibleVariants as variant}
-			{@const vd = playsForVariant(variant)}
-			<div class="variant-block">
-				<div class="variant-label">{variant}</div>
-				{#if vd.length > 0}
-					<BestPlays plays={vd} title="Best Plays ({variant})" showVariantColumn={false} {league} searchActive={searchResults !== null} />
-				{:else if searchResults}
-					<div class="loading">{searchMissReason()}</div>
-				{:else}
-					<div class="loading">No data for this variant</div>
-				{/if}
-			</div>
-		{/each}
+		{@const vd = playsForVariant(activeTab)}
+		<div class="variant-block">
+			<div class="variant-label">{activeTab}</div>
+			{#if vd.length > 0}
+				<BestPlays plays={vd} title="Best Plays ({activeTab})" showVariantColumn={false} {league} searchActive={searchResults !== null} />
+			{:else if searchResults}
+				<div class="loading">{searchMissReason()}</div>
+			{:else}
+				<div class="loading">No data for this variant</div>
+			{/if}
+		</div>
 	{/if}
 </section>
 

--- a/frontend/src/routes/lab/components/FontEVCompare.svelte
+++ b/frontend/src/routes/lab/components/FontEVCompare.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { fetchFontEV, fetchDedicationEV, DEDICATION_VARIANTS, type FontEVResponse, type FontColor, type DedicationEVResponse, type DedicationColor } from '$lib/api';
+	import { fetchFontEV, fetchDedicationEV, DEDICATION_VARIANTS, DEDICATION_POOL_LABELS, type DedicationPool, type FontEVResponse, type FontColor, type DedicationEVResponse, type DedicationColor } from '$lib/api';
 	import { baseGemTradeUrl, cheapestCorruptedTradeUrl } from '$lib/trade-utils';
 	import { formatPrice, formatPriceSigned, type PriceUnit } from '$lib/price.svelte';
 	import InfoTooltip from './InfoTooltip.svelte';
@@ -25,8 +25,10 @@
 
 	// --- Dedication row definitions ---
 	const DEDICATION_ROWS = DEDICATION_VARIANTS.flatMap((variant) => [
-		{ variant, poolKey: 'skills' as const, label: `${variant} Non-Transfigured` },
-		{ variant, poolKey: 'transfigured' as const, label: `${variant} Transfigured` },
+		// Labels come from DEDICATION_POOL_LABELS via toStorePool, so a rename lands
+		// here too instead of leaving this file behind as a third home for them.
+		{ variant, poolKey: 'skills' as const, label: `${variant} ${DEDICATION_POOL_LABELS[toStorePool('skills')]}` },
+		{ variant, poolKey: 'transfigured' as const, label: `${variant} ${DEDICATION_POOL_LABELS[toStorePool('transfigured')]}` },
 	]);
 
 	// Entry fee is a property of the Dedication offering, not of a gem market —

--- a/frontend/src/routes/lab/components/FontEVCompare.svelte
+++ b/frontend/src/routes/lab/components/FontEVCompare.svelte
@@ -25,7 +25,7 @@
 
 	// --- Dedication row definitions ---
 	const DEDICATION_ROWS = DEDICATION_VARIANTS.flatMap((variant) => [
-		{ variant, poolKey: 'skills' as const, label: `${variant} Skill Gems` },
+		{ variant, poolKey: 'skills' as const, label: `${variant} Non-Transfigured` },
 		{ variant, poolKey: 'transfigured' as const, label: `${variant} Transfigured` },
 	]);
 
@@ -298,7 +298,7 @@
 		<table class="ft ded">
 			<thead>
 				<tr>
-					<th class="var-header">Dedication EV<InfoTooltip text="<b>Dedication Lab — Corrupted Gem Exchange EV</b><br><br>Two font options per run, each at either corrupted variant:<br>• <b>Skill Gems</b>: Non-transfigured corrupted skill gems<br>• <b>Transfigured</b>: Transfigured corrupted skill gems<br><br><b>Nc/font</b>: Expected income per font usage. Based on best-of-3 random draws from the corrupted pool of that color.<br><br><b>Input cost</b>: Average price of the 10 cheapest corrupted gems of that variant in that color pool — this is what you feed into the font.<br><br><b>Profit</b>: EV minus input cost. Entry fee (Dedication offering) is NOT included.<br><br>21/23 and 21/20 are separate markets: pool, tiers and input cost are computed per variant, and the highlighted cell is the best <b>profit</b> across both.<br><br>Thin liquidity is expected for corrupted gems — fewer listings than normal font pools." /></th>
+					<th class="var-header">Dedication EV<InfoTooltip text="<b>Dedication Lab — Corrupted Gem Exchange EV</b><br><br>Two font options per run, each at either corrupted variant:<br>• <b>Non-Transfigured</b>: Corrupted skill gems that are not transfigured<br>• <b>Transfigured</b>: Transfigured corrupted skill gems<br><br><b>Nc/font</b>: Expected income per font usage. Based on best-of-3 random draws from the corrupted pool of that color.<br><br><b>Input cost</b>: Average price of the 10 cheapest corrupted gems of that variant in that color pool — this is what you feed into the font.<br><br><b>Profit</b>: EV minus input cost. Entry fee (Dedication offering) is NOT included.<br><br>21/23 and 21/20 are separate markets: pool, tiers and input cost are computed per variant, and the highlighted cell is the best <b>profit</b> across both.<br><br>Thin liquidity is expected for corrupted gems — fewer listings than normal font pools." /></th>
 					{#each COLORS as color}
 						<th><span class="c-{color.toLowerCase()}">{'\u25CF'} {color}</span></th>
 					{/each}

--- a/scripts/integration-test.sh
+++ b/scripts/integration-test.sh
@@ -32,8 +32,26 @@ psql_super() {
 	docker exec -i "$PG_CONTAINER" psql -U "$PG_SUPERUSER" -v ON_ERROR_STOP=1 "$@"
 }
 
+# -buildvcs=false, module-wide via GOFLAGS rather than per invocation, because a
+# per-invocation flag drifts: phase 1 does not need it (no main package under
+# internal/db/migrations) and would sit there untouched until the day one lands.
+#
+# Observed 2026-08-07 on the first CI run of this script: phase 2 died with eight
+# `error obtaining VCS status: exit status 128` — one per main package under
+# cmd/. `go test` stamps VCS metadata into a main package's test binary, which
+# shells out to git; in CI the checkout is owned by the runner and the container
+# runs as another user, so git refuses the repository and the build fails. It
+# passes locally only because the repository and the container user happen to
+# agree there.
+#
+# Accepted trade-off: test binaries lose their VCS stamp. They are built, run and
+# discarded inside this script — nothing reads the stamp — so the information has
+# no consumer to lose.
 in_app() {
-	docker compose run --rm -T -e DATABASE_URL="$DATABASE_URL" app "$@"
+	docker compose run --rm -T \
+		-e DATABASE_URL="$DATABASE_URL" \
+		-e GOFLAGS=-buildvcs=false \
+		app "$@"
 }
 
 # Fail on a green-but-vacuous run. Every integration helper in this repository


### PR DESCRIPTION
## Summary

Collapses four independent gem-market/pool selections in the desktop app into one Rust-owned SSOT. Picking a market anywhere — top bar, Rankings tab, Pool Overview — now moves all three together, and the choice survives tab switches and restarts.

- **Rust**: `AppSsotSnapshot` carries `normalVariant` / `dedicationVariant` / `dedicationPool`; the existing `set_*` commands stay the write path. No new settings keys — all three already persisted.
- **Store**: `ssot.svelte.ts` gains those fields plus write-through setters with a poll-vs-write ordering guard (in-flight counter + write-sequence comparison), so an in-flight `get_ssot` can't revert a just-made pick. A combined `setDedicationSelection` writes market and pool together instead of two racy invokes.
- **Propagation by reading**: every surface derives from the store rune. Removes the `onDedicationVariantChange` prop chain, the per-component mount `invoke`s, and the `pickedDedVariant`/`pickedNormalVariant` mirrors — that race is now handled once, in the store.
- **UI**: new shared `SegmentedButtons` component (alongside Button/Toggle/Select); Pool Overview's dropdown becomes a segmented group; the top bar gains a Normal-mode market picker it never had.
- **Discard font session**: new command + affordance. Previously `font_session` reset only at scan start and after a successful send, so a run captured against the wrong market could not be thrown away.

## Follow-up session on the same branch (2026-08-08)

**Root-cause fix — dead keystrokes in the rankings gem search.** vite-plugin-svelte 4 under Vite 6 (out of its peer range) made the dep optimizer bundle Svelte's *server* runtime, whose `untrack` is a no-op — so the search-clear effect re-ran per keystroke and wiped the box. Bumped the plugin to ^5 and added a `make deps-check` QA gate (`npm ls --all`) that fails on peer-range violations; it caught a second live instance (stale docker volume) immediately.

**Rankings UX rework** (both apps):
- Budget filter actually filters: answered by the server's `budget` param over the full corpus (debounced fan-out; client filter kept as in-flight/failure fallback). The old placement filtered downstream of the row cap and did nothing; budgets ≤ 50 had thrown `state_unsafe_mutation` since the Svelte 5 migration.
- The ALL tab renders one merged, Var-column table instead of four stacked per-variant tables.
- The row cap moved into BestPlays, applied *after* the sort — "top 20" now means top 20 under the chosen sort, not the top 20 by fetch order reordered.
- Every pick persists across launches (ADR-013): one schema-less `ui_prefs` map (Rust-persisted on desktop, localStorage on web) behind a `persisted()` helper. Sort, colour, limit, budget, ALL view, Runs difficulty.

**Run recording decoupled from the timer overlay**: measurement + submission moved to a headless `run-recorder.ts` the main window always runs — the Runs tab collects data with the overlay off. Timing computed from timestamps at event arrival (immune to WebView2 background-timer throttling).

**Devtools toggle fixed**: Ctrl+Shift+F12 routes through a new `set_devtools` Rust command — Tauri 2 has no JS devtools API, the old call threw synchronously.

**Opus review pass** on the session's commits surfaced and fixed 5 findings, including a critical one: the run recorder never refetched the lab layout after the midnight-UTC reset, so later runs uploaded `has_golden_door=false`. Also: atomic settings writes (temp+rename), debounced pref writes, a stale remembered-ALL override, and a pref load race.

### Also on this branch (deliberate, not scope creep)

- `scripts/integration-test.sh`: fixes red CI on main (`GOFLAGS=-buildvcs=false` for the VCS-stamping failure).
- `Makefile`: `make qa` runs the desktop Rust and vitest suites plus the new `deps-check` gate.
- `.gitignore`: pipeforge's per-run triage state.

## Notes

The farming stamp is read once at send time, so correcting the market at the font re-stamps the whole pending session — that is the intended recovery path, and the discard command is its escape hatch. The trade-off is that any market click before a send re-stamps the pending run; mitigated by making the market visible in the top bar in both modes.

## Tracker
https://youtrack.softsolution.pro/issue/POE-163

## Test Plan
- [x] All tests pass (`make qa` — Go, 119 Rust tests, 323 vitest across 8 files, deps-check, web build)
- [x] Manual testing: gem search regression verified fixed in the running dev app; budget/ALL-tab behavior confirmed on live data
- [x] Fixtures updated (if applicable) — no fixture impact detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
